### PR TITLE
WIP: Make kubesphere authentication server configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ lint-chart:
 install-chart: lint-chart
 	helm install ks-devops charts/ks-devops -n kubesphere-devops-system --set serviceAccount.create=true --create-namespace \
 		--set image.pullPolicy=Always \
-		--set jenkins.ksAuth.enabled=true \
-		--set jenkins.ksAuth.server=http://ks-devops-apiserver.kubesphere-devops-system:9090
+		--set jenkins.ksAuth.enabled=true
+
 uninstall-chart:
 	make uninstall-jenkins-chart || true
 	helm uninstall ks-devops -n kubesphere-devops-system

--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,15 @@ lint-chart:
 	helm lint charts/ks-devops
 
 install-chart: lint-chart
-	helm install ks-ctl charts/ks-devops -n kubesphere-devops-system --set serviceAccount.create=true --create-namespace \
+	helm install ks-devops charts/ks-devops -n kubesphere-devops-system --set serviceAccount.create=true --create-namespace \
 		--set image.pullPolicy=Always \
-		--set jenkins.ksAuth.enabled=true
+		--set jenkins.ksAuth.enabled=true \
+		--set jenkins.ksAuth.server=http://ks-devops-apiserver.kubesphere-devops-system:9090
 uninstall-chart:
 	make uninstall-jenkins-chart || true
-	helm uninstall ks-ctl -n kubesphere-devops-system
+	helm uninstall ks-devops -n kubesphere-devops-system
 render-chart:
-	helm template ks-ctl charts/ks-devops  -n kubesphere-devops-system \
+	helm template ks-devops charts/ks-devops  -n kubesphere-devops-system \
 		--set serviceAccount.create=true --create-namespace \
 		--set image.pullPolicy=Always \
 		--set jenkins.ksAuth.enabled=true --debug

--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -201,7 +201,7 @@ data:
           size: 20
           ttl: 300
         enabled: {{ .Values.ksAuth.enabled }}
-        server: "http://{{ .Release.Name }}-ks-devops-apiserver.{{ .Release.Namespace }}:9090/"
+        server: {{ .Values.ksAuth.server }}
       gitLabServers:
         servers:
         - name: "https://gitlab.com"

--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -453,4 +453,4 @@ securityRealm:
 
 ksAuth:
   enabled: false
-#  server:
+  server: ""


### PR DESCRIPTION
### Why we need it

The out of dated ksAuth.server config item is configured in Jenkins charts due to apiserver full name changed of ks-devops. This behaviour will lead to out of contact between KubeSphere and Jenkins. 

### What this PR dose

- Change helm chart name of ks-devops from `ks-ctl` into `ks-devops`
- Make KubeSphere Authentication server configured in Jenkins chart as variable, which could be configured from outside

### What kind of this PR

/kind bug
