### PR TITLE
Add a root API path which without the group name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20210527164424-3c818078ee3d
 	kubesphere.io/api v0.0.0-20210511124541-08f2d682bd07
 	sigs.k8s.io/controller-runtime v0.6.3
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace (

--- a/pkg/apiserver/runtime/runtime.go
+++ b/pkg/apiserver/runtime/runtime.go
@@ -17,6 +17,7 @@ limitations under the License.
 package runtime
 
 import (
+	"fmt"
 	"github.com/emicklei/go-restful"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -44,6 +45,12 @@ func NewWebService(gv schema.GroupVersion) *restful.WebService {
 	webservice.Path(ApiRootPath + "/" + gv.String()).
 		Produces(restful.MIME_JSON)
 
+	return &webservice
+}
+
+func NewWebServiceWithoutGroup(gv schema.GroupVersion) *restful.WebService {
+	webservice := restful.WebService{}
+	webservice.Path(fmt.Sprintf("/%s", gv.Version)).Produces(restful.MIME_JSON)
 	return &webservice
 }
 

--- a/pkg/apiserver/runtime/runtime_test.go
+++ b/pkg/apiserver/runtime/runtime_test.go
@@ -1,0 +1,26 @@
+package runtime
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"testing"
+)
+
+func TestNewWebServiceWithoutGroup(t *testing.T) {
+	ws := NewWebServiceWithoutGroup(schema.GroupVersion{
+		Version: "v2",
+	})
+
+	assert.NotNil(t, ws)
+	assert.Equal(t, "/v2", ws.RootPath())
+}
+
+func TestNewWebService(t *testing.T) {
+	ws := NewWebService(schema.GroupVersion{
+		Group:   "devops",
+		Version: "v2",
+	})
+
+	assert.NotNil(t, ws)
+	assert.Equal(t, ApiRootPath + "/devops/v2", ws.RootPath())
+}

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -50,8 +50,24 @@ var GroupVersion = schema.GroupVersion{Group: api.GroupName, Version: "v1alpha2"
 func AddToContainer(container *restful.Container, ksInformers externalversions.SharedInformerFactory,
 	devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface,
 	s3Client s3.Interface, endpoint string, k8sClient k8s.Client) error {
-	ws := runtime.NewWebService(GroupVersion)
+	wsWithGroup := runtime.NewWebService(GroupVersion)
+	// the API endpoint with group version will be removed in the future release
+	if err := addToContainerWithWebService(container, ksInformers, devopsClient, sonarqubeClient, ksClient,
+		s3Client, endpoint, k8sClient, wsWithGroup); err != nil {
+		return err
+	}
 
+	ws := runtime.NewWebServiceWithoutGroup(GroupVersion)
+	if err := addToContainerWithWebService(container, ksInformers, devopsClient, sonarqubeClient, ksClient,
+		s3Client, endpoint, k8sClient, ws); err != nil {
+		return err
+	}
+	return nil
+}
+
+func addToContainerWithWebService(container *restful.Container, ksInformers externalversions.SharedInformerFactory,
+	devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface,
+	s3Client s3.Interface, endpoint string, k8sClient k8s.Client, ws *restful.WebService) error {
 	err := AddPipelineToWebService(ws, devopsClient, k8sClient)
 	if err != nil {
 		return err

--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -36,146 +36,152 @@ import (
 	"kubesphere.io/devops/pkg/server/params"
 )
 
-//GroupVersion describes CRD group and its version.
+// GroupVersion describes CRD group and its version.
 var GroupVersion = schema.GroupVersion{Group: api.GroupName, Version: "v1alpha3"}
 
-//AddToContainer adds web service into container.
-func AddToContainer(container *restful.Container, devopsClient devopsClient.Interface, k8sClient k8s.Client) error {
-	devopsEnable := devopsClient != nil
-	if devopsEnable {
-		ws := runtime.NewWebService(GroupVersion)
-		handler := newDevOpsHandler(devopsClient, k8sClient)
-		// credential
-		ws.Route(ws.GET("/devops/{devops}/credentials").
-			To(handler.ListCredential).
-			Param(ws.PathParameter("devops", "devops name")).
-			Param(ws.QueryParameter(query.ParameterName, "name used to do filtering").Required(false)).
-			Param(ws.QueryParameter(query.ParameterPage, "page").Required(false).DataFormat("page=%d").DefaultValue("page=1")).
-			Param(ws.QueryParameter(query.ParameterLimit, "limit").Required(false)).
-			Param(ws.QueryParameter(query.ParameterAscending, "sort parameters, e.g. ascending=false").Required(false).DefaultValue("ascending=false")).
-			Param(ws.QueryParameter(query.ParameterOrderBy, "sort parameters, e.g. orderBy=createTime")).
-			Doc("list the credentials of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, api.ListResult{Items: []interface{}{}}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.POST("/devops/{devops}/credentials").
-			To(handler.CreateCredential).
-			Param(ws.PathParameter("devops", "devops name")).
-			Doc("create the credential of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.GET("/devops/{devops}/credentials/{credential}").
-			To(handler.GetCredential).
-			Param(ws.PathParameter("devops", "project name")).
-			Param(ws.PathParameter("credential", "pipeline name")).
-			Doc("get the credential of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1.Secret{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.PUT("/devops/{devops}/credentials/{credential}").
-			To(handler.UpdateCredential).
-			Param(ws.PathParameter("devops", "project name")).
-			Param(ws.PathParameter("credential", "credential name")).
-			Doc("put the credential of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1.Secret{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.DELETE("/devops/{devops}/credentials/{credential}").
-			To(handler.DeleteCredential).
-			Param(ws.PathParameter("devops", "project name")).
-			Param(ws.PathParameter("credential", "credential name")).
-			Doc("delete the credential of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1.Secret{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
-
-		// pipeline
-		ws.Route(ws.GET("/devops/{devops}/pipelines").
-			To(handler.ListPipeline).
-			Param(ws.PathParameter("devops", "devops name")).
-			Param(ws.QueryParameter(params.PagingParam, "paging query, e.g. limit=100,page=1").
-				Required(false).
-				DataFormat("limit=%d,page=%d").
-				DefaultValue("limit=10,page=1")).
-			Doc("list the pipelines of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, api.ListResult{Items: []interface{}{}}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.POST("/devops/{devops}/pipelines").
-			To(handler.CreatePipeline).
-			Param(ws.PathParameter("devops", "devops name")).
-			Doc("create the pipeline of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.GET("/devops/{devops}/pipelines/{pipeline}").
-			To(handler.GetPipeline).
-			Operation("getPipelineByName").
-			Param(ws.PathParameter("devops", "project name")).
-			Param(ws.PathParameter("pipeline", "pipeline name")).
-			Doc("get the pipeline of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.PUT("/devops/{devops}/pipelines/{pipeline}").
-			To(handler.UpdatePipeline).
-			Param(ws.PathParameter("devops", "project name")).
-			Param(ws.PathParameter("pipeline", "pipeline name")).
-			Doc("put the pipeline of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.DELETE("/devops/{devops}/pipelines/{pipeline}").
-			To(handler.DeletePipeline).
-			Param(ws.PathParameter("devops", "project name")).
-			Param(ws.PathParameter("pipeline", "pipeline name")).
-			Doc("delete the pipeline of the specified devops for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
-
-		// devops
-		ws.Route(ws.GET("/workspaces/{workspace}/devops").
-			To(handler.ListDevOpsProject).
-			Param(ws.PathParameter("workspace", "workspace name")).
-			Param(ws.QueryParameter(params.PagingParam, "paging query, e.g. limit=100,page=1").
-				Required(false).
-				DataFormat("limit=%d,page=%d").
-				DefaultValue("limit=10,page=1")).Doc("List the devopsproject of the specified workspace for the current user").
-			Returns(http.StatusOK, api.StatusOK, api.ListResult{Items: []interface{}{}}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.POST("/workspaces/{workspace}/devops").
-			To(handler.CreateDevOpsProject).
-			Param(ws.PathParameter("workspace", "workspace name")).
-			Doc("Create the devopsproject of the specified workspace for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.GET("/workspaces/{workspace}/devops/{devops}").
-			To(handler.GetDevOpsProject).
-			Param(ws.PathParameter("workspace", "workspace name")).
-			Param(ws.PathParameter("devops", "project name")).
-			Doc("Get the devopsproject of the specified workspace for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.PUT("/workspaces/{workspace}/devops/{devops}").
-			To(handler.UpdateDevOpsProject).
-			Param(ws.PathParameter("workspace", "workspace name")).
-			Param(ws.PathParameter("devops", "project name")).
-			Doc("Put the devopsproject of the specified workspace for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		ws.Route(ws.DELETE("/workspaces/{workspace}/devops/{devops}").
-			To(handler.DeleteDevOpsProject).
-			Param(ws.PathParameter("workspace", "workspace name")).
-			Param(ws.PathParameter("devops", "project name")).
-			Doc("Get the devopsproject of the specified workspace for the current user").
-			Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
-
-		container.Add(ws)
+// AddToContainer adds web service into container.
+func AddToContainer(container *restful.Container, devopsClient devopsClient.Interface, k8sClient k8s.Client) (err error) {
+	wsWithGroup := runtime.NewWebService(GroupVersion)
+	if err = addToContainerWithWebService(container, devopsClient, k8sClient, wsWithGroup); err == nil {
+		ws := runtime.NewWebServiceWithoutGroup(GroupVersion)
+		err = addToContainerWithWebService(container, devopsClient, k8sClient, ws)
 	}
+	return
+}
+
+func addToContainerWithWebService(container *restful.Container, devopsClient devopsClient.Interface,
+	k8sClient k8s.Client, ws *restful.WebService) error {
+	handler := newDevOpsHandler(devopsClient, k8sClient)
+	// credential
+	ws.Route(ws.GET("/devops/{devops}/credentials").
+		To(handler.ListCredential).
+		Param(ws.PathParameter("devops", "devops name")).
+		Param(ws.QueryParameter(query.ParameterName, "name used to do filtering").Required(false)).
+		Param(ws.QueryParameter(query.ParameterPage, "page").Required(false).DataFormat("page=%d").DefaultValue("page=1")).
+		Param(ws.QueryParameter(query.ParameterLimit, "limit").Required(false)).
+		Param(ws.QueryParameter(query.ParameterAscending, "sort parameters, e.g. ascending=false").Required(false).DefaultValue("ascending=false")).
+		Param(ws.QueryParameter(query.ParameterOrderBy, "sort parameters, e.g. orderBy=createTime")).
+		Doc("list the credentials of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, api.ListResult{Items: []interface{}{}}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.POST("/devops/{devops}/credentials").
+		To(handler.CreateCredential).
+		Param(ws.PathParameter("devops", "devops name")).
+		Doc("create the credential of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.GET("/devops/{devops}/credentials/{credential}").
+		To(handler.GetCredential).
+		Param(ws.PathParameter("devops", "project name")).
+		Param(ws.PathParameter("credential", "pipeline name")).
+		Doc("get the credential of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1.Secret{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.PUT("/devops/{devops}/credentials/{credential}").
+		To(handler.UpdateCredential).
+		Param(ws.PathParameter("devops", "project name")).
+		Param(ws.PathParameter("credential", "credential name")).
+		Doc("put the credential of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1.Secret{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.DELETE("/devops/{devops}/credentials/{credential}").
+		To(handler.DeleteCredential).
+		Param(ws.PathParameter("devops", "project name")).
+		Param(ws.PathParameter("credential", "credential name")).
+		Doc("delete the credential of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1.Secret{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
+
+	// pipeline
+	ws.Route(ws.GET("/devops/{devops}/pipelines").
+		To(handler.ListPipeline).
+		Param(ws.PathParameter("devops", "devops name")).
+		Param(ws.QueryParameter(params.PagingParam, "paging query, e.g. limit=100,page=1").
+			Required(false).
+			DataFormat("limit=%d,page=%d").
+			DefaultValue("limit=10,page=1")).
+		Doc("list the pipelines of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, api.ListResult{Items: []interface{}{}}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.POST("/devops/{devops}/pipelines").
+		To(handler.CreatePipeline).
+		Param(ws.PathParameter("devops", "devops name")).
+		Doc("create the pipeline of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.GET("/devops/{devops}/pipelines/{pipeline}").
+		To(handler.GetPipeline).
+		Operation("getPipelineByName").
+		Param(ws.PathParameter("devops", "project name")).
+		Param(ws.PathParameter("pipeline", "pipeline name")).
+		Doc("get the pipeline of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.PUT("/devops/{devops}/pipelines/{pipeline}").
+		To(handler.UpdatePipeline).
+		Param(ws.PathParameter("devops", "project name")).
+		Param(ws.PathParameter("pipeline", "pipeline name")).
+		Doc("put the pipeline of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.DELETE("/devops/{devops}/pipelines/{pipeline}").
+		To(handler.DeletePipeline).
+		Param(ws.PathParameter("devops", "project name")).
+		Param(ws.PathParameter("pipeline", "pipeline name")).
+		Doc("delete the pipeline of the specified devops for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
+
+	// devops
+	ws.Route(ws.GET("/workspaces/{workspace}/devops").
+		To(handler.ListDevOpsProject).
+		Param(ws.PathParameter("workspace", "workspace name")).
+		Param(ws.QueryParameter(params.PagingParam, "paging query, e.g. limit=100,page=1").
+			Required(false).
+			DataFormat("limit=%d,page=%d").
+			DefaultValue("limit=10,page=1")).Doc("List the devopsproject of the specified workspace for the current user").
+		Returns(http.StatusOK, api.StatusOK, api.ListResult{Items: []interface{}{}}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.POST("/workspaces/{workspace}/devops").
+		To(handler.CreateDevOpsProject).
+		Param(ws.PathParameter("workspace", "workspace name")).
+		Doc("Create the devopsproject of the specified workspace for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.GET("/workspaces/{workspace}/devops/{devops}").
+		To(handler.GetDevOpsProject).
+		Param(ws.PathParameter("workspace", "workspace name")).
+		Param(ws.PathParameter("devops", "project name")).
+		Doc("Get the devopsproject of the specified workspace for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.PUT("/workspaces/{workspace}/devops/{devops}").
+		To(handler.UpdateDevOpsProject).
+		Param(ws.PathParameter("workspace", "workspace name")).
+		Param(ws.PathParameter("devops", "project name")).
+		Doc("Put the devopsproject of the specified workspace for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	ws.Route(ws.DELETE("/workspaces/{workspace}/devops/{devops}").
+		To(handler.DeleteDevOpsProject).
+		Param(ws.PathParameter("workspace", "workspace name")).
+		Param(ws.PathParameter("devops", "project name")).
+		Doc("Get the devopsproject of the specified workspace for the current user").
+		Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	container.Add(ws)
 	return nil
 }

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -341,7 +341,9 @@ func (d devopsOperator) ListCredentialObj(projectName string, query *query.Query
 		v1alpha3.SecretTypeSecretText,
 		v1alpha3.SecretTypeKubeConfig,
 	}
-	for _, credential := range credentialObjList.Items {
+	for i, _ := range credentialObjList.Items {
+		credential := credentialObjList.Items[i]
+
 		for _, credentialType := range credentialTypeList {
 			if credential.Type == credentialType {
 				result = append(result, &credential)


### PR DESCRIPTION
According to the https://github.com/kubesphere/kubesphere/pull/4129. The new DevOps proxy does not send the HTTP request with the group name of DevOps APIs. So in this PR, I let it support two styles that contain or not the group name.

## How to test it manually

You only need to update the image `surenpi/devops-apiserver:dev--71e1645`. Because this PR didn't change the controller part.

fix #116 