### PR TITLE
Fix the API of credential creating/updating failed due to URI is too long

### DIFF
--- a/pkg/client/devops/jenkins/credential.go
+++ b/pkg/client/devops/jenkins/credential.go
@@ -226,7 +226,7 @@ func (j *Jenkins) CreateCredentialInProject(projectId string, credential *v1.Sec
 		return "", restful.NewError(http.StatusBadRequest, err.Error())
 	}
 
-	response, err := j.Requester.Post(
+	response, err := j.Requester.PostForm(
 		fmt.Sprintf("/job/%s/credentials/store/folder/domain/_/createCredentials", projectId),
 		nil, &responseString, map[string]string{
 			"json": makeJson(map[string]interface{}{
@@ -237,7 +237,7 @@ func (j *Jenkins) CreateCredentialInProject(projectId string, credential *v1.Sec
 		return "", err
 	}
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusFound {
 		return "", errors.New(strconv.Itoa(response.StatusCode))
 	}
 	return credential.Name, nil
@@ -264,7 +264,7 @@ func (j *Jenkins) UpdateCredentialInProject(projectId string, credential *v1.Sec
 		klog.Errorf("%+v", err)
 		return "", restful.NewError(http.StatusBadRequest, err.Error())
 	}
-	response, err := j.Requester.Post(
+	response, err := j.Requester.PostForm(
 		fmt.Sprintf("/job/%s/credentials/store/folder/domain/_/credential/%s/updateSubmit", projectId, credential.Name),
 		nil, nil, map[string]string{
 			"json": requestContent,
@@ -272,7 +272,7 @@ func (j *Jenkins) UpdateCredentialInProject(projectId string, credential *v1.Sec
 	if err != nil {
 		return "", err
 	}
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusFound {
 		return "", errors.New(strconv.Itoa(response.StatusCode))
 	}
 	return credential.Name, nil

--- a/pkg/client/devops/jenkins/credential.go
+++ b/pkg/client/devops/jenkins/credential.go
@@ -237,6 +237,10 @@ func (j *Jenkins) CreateCredentialInProject(projectId string, credential *v1.Sec
 		return "", err
 	}
 
+	// the jenkins api `/job/{projectId}/credentials/store/folder/domain/_/createCredentials`
+	// under a special version of jenkins, the response status code is `http.StatusFound`
+	// In order to be applicable to multiple versions of jenkins,
+	// here you need to verify `http.StatusOK` and `http.StatusFound`
 	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusFound {
 		return "", errors.New(strconv.Itoa(response.StatusCode))
 	}
@@ -272,6 +276,11 @@ func (j *Jenkins) UpdateCredentialInProject(projectId string, credential *v1.Sec
 	if err != nil {
 		return "", err
 	}
+
+	// the jenkins api `/job/{projectId}/credentials/store/folder/domain/_/credential/{credential.Name}/updateSubmit`
+	// under a special version of jenkins, the response status code is `http.StatusFound`
+	// In order to be applicable to multiple versions of jenkins,
+	// here you need to verify `http.StatusOK` and `http.StatusFound`
 	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusFound {
 		return "", errors.New(strconv.Itoa(response.StatusCode))
 	}

--- a/pkg/client/devops/jenkins/credential.go
+++ b/pkg/client/devops/jenkins/credential.go
@@ -237,9 +237,9 @@ func (j *Jenkins) CreateCredentialInProject(projectId string, credential *v1.Sec
 		return "", err
 	}
 
-	// the jenkins api `/job/{projectId}/credentials/store/folder/domain/_/createCredentials`
-	// under a special version of jenkins, the response status code is `http.StatusFound`
-	// In order to be applicable to multiple versions of jenkins,
+	// the Jenkins API `/job/{jobName}/credentials/store/folder/domain/_/createCredentials`
+	// under a special version of Jenkins, the response status code is `http.StatusFound`
+	// In order to be applicable to multiple versions of Jenkins,
 	// here you need to verify `http.StatusOK` and `http.StatusFound`
 	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusFound {
 		return "", errors.New(strconv.Itoa(response.StatusCode))
@@ -277,9 +277,9 @@ func (j *Jenkins) UpdateCredentialInProject(projectId string, credential *v1.Sec
 		return "", err
 	}
 
-	// the jenkins api `/job/{projectId}/credentials/store/folder/domain/_/credential/{credential.Name}/updateSubmit`
-	// under a special version of jenkins, the response status code is `http.StatusFound`
-	// In order to be applicable to multiple versions of jenkins,
+	// the Jenkins API `/job/{jobName}/credentials/store/folder/domain/_/credential/{credentialName}/updateSubmit`
+	// under a special version of Jenkins, the response status code is `http.StatusFound`
+	// In order to be applicable to multiple versions of Jenkins,
 	// here you need to verify `http.StatusOK` and `http.StatusFound`
 	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusFound {
 		return "", errors.New(strconv.Itoa(response.StatusCode))


### PR DESCRIPTION
Fix: #101 

1. Modify the request param to form-data
2. Adjustment request result verification 
