### PR TITLE
Align go version with version defined in go.mod

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -218,10 +218,10 @@ jobs:
     name: Test
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.13
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.13
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
### What this PR dose

Align go version in Test action with version defined in go.mod.

### Why we need it

Keep same go version all the time.