### PR TITLE
Make the branch tekton-support can run GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - tekton-support
       - test-* # make it be easier for contributors to test
     tags:
       - 'v*.*.*'


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>
