### PR TITLE
Skip golangci-lint cache due to flaky behaviors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -244,29 +244,3 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true
-
-  Lint:
-    name: Lint
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v2.1.3
-        with:
-          go-version: 1.13
-      - uses: actions/checkout@v2
-      # See also https://github.com/GoogleCloudPlatform/golang-samples/blob/78dfa41f10b449ba7a06d9793cbd81878d44a4fb/.github/workflows/go.yaml#L29-L53
-      - name: Run go mod tidy on root modules
-        run: go mod tidy
-      # If there are any diffs from goimports or go mod tidy, fail.
-      - name: Verify no changes from goimports and go mod tidy.
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo 'To fix this check, run "go mod tidy"'
-            git status # Show the files that failed to pass the check.
-            exit 1
-          fi
-      - name: golint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.41.1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  - push
+  - pull_request
+  - release
+
+jobs:
+  Lint:
+    name: Lint
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: 1.13
+      - uses: actions/checkout@v2
+      # See also https://github.com/GoogleCloudPlatform/golang-samples/blob/78dfa41f10b449ba7a06d9793cbd81878d44a4fb/.github/workflows/go.yaml#L29-L53
+      - name: Run go mod tidy on root modules
+        run: go mod tidy
+      # If there are any diffs from goimports or go mod tidy, fail.
+      - name: Verify no changes from goimports and go mod tidy.
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo 'To fix this check, run "go mod tidy"'
+            git status # Show the files that failed to pass the check.
+            exit 1
+          fi
+      - name: golint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.41.1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,3 +31,5 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.41.1
+          skip-build-cache: true
+          skip-pkg-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
   concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 2m
+  timeout: 5m
 
   skip-dirs:
     - .git


### PR DESCRIPTION
### What this PR dose

1. Extract lint stage
2. Run lint stage on push, pull request and release
3. Increase timeout of golangci
4. Skip cache due to flaky behaviours

### Why we need it

There are too many flaky error logs confusing every committer.

![image](https://user-images.githubusercontent.com/16865714/129533732-e721853a-25e8-4d05-83b0-7bceef048886.png)

### Result

![image](https://user-images.githubusercontent.com/16865714/129533952-3e460bf5-6c78-4d12-becb-7f76f8df86a0.png)
