### PR TITLE
Fix that devops-ks-devops-controller is always CrashLoopBackOff due to missing PipelineRun CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Want to go into deep? Please checkout the [documentation](docs).
 ### Install it as a Helm Chart
 
 First, please clone this git repository. Then run command: `make install-chart`
- - Because the default registry uses `ghcr.io/kubesphere-sigs`, if you want to use `docker.io` as the registry for image pull, you can exec `helm install ks-devops chart/ks-devops --set image.registry=kubespheredev`
+ - Because the default registry uses `ghcr.io/kubesphere`, if you want to use `docker.io` as the registry for image pull, you can exec `helm install ks-devops chart/ks-devops --set image.registry=kubespheredev`
 
 ### Run it locally
 

--- a/charts/ks-devops/crds/devops.kubesphere.io_pipelineruns.yaml
+++ b/charts/ks-devops/crds/devops.kubesphere.io_pipelineruns.yaml
@@ -1,0 +1,137 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+  creationTimestamp: null
+  name: pipelineruns.devops.kubesphere.io
+spec:
+  group: devops.kubesphere.io
+  names:
+    kind: PipelineRun
+    listKind: PipelineRunList
+    plural: pipelineruns
+    singular: pipelinerun
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: PipelineRun is the Schema for the pipelineruns API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PipelineRunSpec defines the desired state of PipelineRun
+          properties:
+            parameters:
+              description: Parameters are some key/value pairs passed to runner.
+              items:
+                description: Parameter is an option that can be passed with the endpoint
+                  to influence the Pipeline Run
+                properties:
+                  name:
+                    description: Name indicates that name of the parameter.
+                    type: string
+                  value:
+                    description: Value indicates that value of the parameter.
+                    type: string
+                required:
+                - name
+                - value
+                type: object
+              type: array
+            scm:
+              description: Scm is a SCM configuration that target pipeline run requires.
+              properties:
+                refName:
+                  description: RefName indicates that SCM reference name, such as
+                    master, dev, release-v1.
+                  type: string
+                refType:
+                  description: RefType indicates that SCM reference type, such as
+                    branch, tag, pr, mr.
+                  type: string
+              required:
+              - refName
+              - refType
+              type: object
+          type: object
+        status:
+          description: PipelineRunStatus defines the observed state of PipelineRun
+          properties:
+            completionTime:
+              description: Completion timestamp of the pipeline run.
+              format: date-time
+              type: string
+            conditions:
+              description: Current state of pipeline run.
+              items:
+                description: Condition contains details for the current condition
+                  of this pipeline run. Reference from PodCondition
+                properties:
+                  lastProbeTime:
+                    description: Last time we probed the condition.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, one-word, CamelCase reason for the condition's
+                      last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. Can be True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            phase:
+              description: Current phase of pipeline run.
+              type: string
+            startTime:
+              description: Start timestamp of the pipeline run.
+              format: date-time
+              type: string
+            updateTime:
+              description: Update timestamp of the pipeline run.
+              format: date-time
+              type: string
+          type: object
+      type: object
+  version: v1alpha4
+  versions:
+  - name: v1alpha4
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/ks-devops/crds/devops.kubesphere.io_pipelineruns.yaml
+++ b/charts/ks-devops/crds/devops.kubesphere.io_pipelineruns.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: pipelineruns.devops.kubesphere.io
 spec:
@@ -15,120 +15,119 @@ spec:
     plural: pipelineruns
     singular: pipelinerun
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: PipelineRun is the Schema for the pipelineruns API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PipelineRunSpec defines the desired state of PipelineRun
-          properties:
-            parameters:
-              description: Parameters are some key/value pairs passed to runner.
-              items:
-                description: Parameter is an option that can be passed with the endpoint
-                  to influence the Pipeline Run
-                properties:
-                  name:
-                    description: Name indicates that name of the parameter.
-                    type: string
-                  value:
-                    description: Value indicates that value of the parameter.
-                    type: string
-                required:
-                - name
-                - value
-                type: object
-              type: array
-            scm:
-              description: SCM is a SCM configuration that target pipeline run requires.
-              properties:
-                refName:
-                  description: RefName indicates that SCM reference name, such as
-                    master, dev, release-v1.
-                  type: string
-                refType:
-                  description: RefType indicates that SCM reference type, such as
-                    branch, tag, pr, mr.
-                  type: string
-              required:
-              - refName
-              - refType
-              type: object
-          type: object
-        status:
-          description: PipelineRunStatus defines the observed state of PipelineRun
-          properties:
-            completionTime:
-              description: Completion timestamp of the pipeline run.
-              format: date-time
-              type: string
-            conditions:
-              description: Current state of pipeline run.
-              items:
-                description: Condition contains details for the current condition
-                  of this pipeline run. Reference from PodCondition
-                properties:
-                  lastProbeTime:
-                    description: Last time we probed the condition.
-                    format: date-time
-                    type: string
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human-readable message indicating details about last
-                      transition.
-                    type: string
-                  reason:
-                    description: Unique, one-word, CamelCase reason for the condition's
-                      last transition.
-                    type: string
-                  status:
-                    description: Status is the status of the condition. Can be True,
-                      False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            phase:
-              description: Current phase of pipeline run.
-              type: string
-            startTime:
-              description: Start timestamp of the pipeline run.
-              format: date-time
-              type: string
-            updateTime:
-              description: Update timestamp of the pipeline run.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha4
   versions:
   - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: PipelineRun is the Schema for the pipelineruns API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PipelineRunSpec defines the desired state of PipelineRun
+            properties:
+              parameters:
+                description: Parameters are some key/value pairs passed to runner.
+                items:
+                  description: Parameter is an option that can be passed with the
+                    endpoint to influence the Pipeline Run
+                  properties:
+                    name:
+                      description: Name indicates that name of the parameter.
+                      type: string
+                    value:
+                      description: Value indicates that value of the parameter.
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              scm:
+                description: SCM is a SCM configuration that target pipeline run requires.
+                properties:
+                  refName:
+                    description: RefName indicates that SCM reference name, such as
+                      master, dev, release-v1.
+                    type: string
+                  refType:
+                    description: RefType indicates that SCM reference type, such as
+                      branch, tag, pr, mr.
+                    type: string
+                required:
+                - refName
+                - refType
+                type: object
+            type: object
+          status:
+            description: PipelineRunStatus defines the observed state of PipelineRun
+            properties:
+              completionTime:
+                description: Completion timestamp of the pipeline run.
+                format: date-time
+                type: string
+              conditions:
+                description: Current state of pipeline run.
+                items:
+                  description: Condition contains details for the current condition
+                    of this pipeline run. Reference from PodCondition
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition. Can be True,
+                        False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Current phase of pipeline run.
+                type: string
+              startTime:
+                description: Start timestamp of the pipeline run.
+                format: date-time
+                type: string
+              updateTime:
+                description: Update timestamp of the pipeline run.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/ks-devops/crds/devops.kubesphere.io_pipelineruns.yaml
+++ b/charts/ks-devops/crds/devops.kubesphere.io_pipelineruns.yaml
@@ -54,7 +54,7 @@ spec:
                 type: object
               type: array
             scm:
-              description: Scm is a SCM configuration that target pipeline run requires.
+              description: SCM is a SCM configuration that target pipeline run requires.
               properties:
                 refName:
                   description: RefName indicates that SCM reference name, such as

--- a/charts/ks-devops/values.yaml
+++ b/charts/ks-devops/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 
 image:
-  # support 'ghcr.io/kubesphere-sigs' or 'kubespheredev'
-  registry: ghcr.io/kubesphere-sigs
+  # support 'ghcr.io/kubesphere' or 'kubespheredev'
+  registry: ghcr.io/kubesphere
   controller:
     repository: devops-controller
     tag: master

--- a/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
+++ b/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: pipelineruns.devops.kubesphere.io
 spec:
@@ -15,120 +15,119 @@ spec:
     plural: pipelineruns
     singular: pipelinerun
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: PipelineRun is the Schema for the pipelineruns API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PipelineRunSpec defines the desired state of PipelineRun
-          properties:
-            parameters:
-              description: Parameters are some key/value pairs passed to runner.
-              items:
-                description: Parameter is an option that can be passed with the endpoint
-                  to influence the Pipeline Run
-                properties:
-                  name:
-                    description: Name indicates that name of the parameter.
-                    type: string
-                  value:
-                    description: Value indicates that value of the parameter.
-                    type: string
-                required:
-                - name
-                - value
-                type: object
-              type: array
-            scm:
-              description: SCM is a SCM configuration that target pipeline run requires.
-              properties:
-                refName:
-                  description: RefName indicates that SCM reference name, such as
-                    master, dev, release-v1.
-                  type: string
-                refType:
-                  description: RefType indicates that SCM reference type, such as
-                    branch, tag, pr, mr.
-                  type: string
-              required:
-              - refName
-              - refType
-              type: object
-          type: object
-        status:
-          description: PipelineRunStatus defines the observed state of PipelineRun
-          properties:
-            completionTime:
-              description: Completion timestamp of the pipeline run.
-              format: date-time
-              type: string
-            conditions:
-              description: Current state of pipeline run.
-              items:
-                description: Condition contains details for the current condition
-                  of this pipeline run. Reference from PodCondition
-                properties:
-                  lastProbeTime:
-                    description: Last time we probed the condition.
-                    format: date-time
-                    type: string
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human-readable message indicating details about last
-                      transition.
-                    type: string
-                  reason:
-                    description: Unique, one-word, CamelCase reason for the condition's
-                      last transition.
-                    type: string
-                  status:
-                    description: Status is the status of the condition. Can be True,
-                      False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            phase:
-              description: Current phase of pipeline run.
-              type: string
-            startTime:
-              description: Start timestamp of the pipeline run.
-              format: date-time
-              type: string
-            updateTime:
-              description: Update timestamp of the pipeline run.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha4
   versions:
   - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: PipelineRun is the Schema for the pipelineruns API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PipelineRunSpec defines the desired state of PipelineRun
+            properties:
+              parameters:
+                description: Parameters are some key/value pairs passed to runner.
+                items:
+                  description: Parameter is an option that can be passed with the
+                    endpoint to influence the Pipeline Run
+                  properties:
+                    name:
+                      description: Name indicates that name of the parameter.
+                      type: string
+                    value:
+                      description: Value indicates that value of the parameter.
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              scm:
+                description: SCM is a SCM configuration that target pipeline run requires.
+                properties:
+                  refName:
+                    description: RefName indicates that SCM reference name, such as
+                      master, dev, release-v1.
+                    type: string
+                  refType:
+                    description: RefType indicates that SCM reference type, such as
+                      branch, tag, pr, mr.
+                    type: string
+                required:
+                - refName
+                - refType
+                type: object
+            type: object
+          status:
+            description: PipelineRunStatus defines the observed state of PipelineRun
+            properties:
+              completionTime:
+                description: Completion timestamp of the pipeline run.
+                format: date-time
+                type: string
+              conditions:
+                description: Current state of pipeline run.
+                items:
+                  description: Condition contains details for the current condition
+                    of this pipeline run. Reference from PodCondition
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition. Can be True,
+                        False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Current phase of pipeline run.
+                type: string
+              startTime:
+                description: Start timestamp of the pipeline run.
+                format: date-time
+                type: string
+              updateTime:
+                description: Update timestamp of the pipeline run.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
+++ b/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
@@ -54,7 +54,7 @@ spec:
                 type: object
               type: array
             scm:
-              description: Scm is a SCM configuration that target pipeline run requires.
+              description: SCM is a SCM configuration that target pipeline run requires.
               properties:
                 refName:
                   description: RefName indicates that SCM reference name, such as


### PR DESCRIPTION
### What this PR dose

1. Synchronize PipelineRun CRD into chart
2. Change default image registry from ghcr.io/kubesphere-sigs into ghcr.io/kubesphere

### Why we need it

The controller refuses to start due to missing PipelineRun CRD which should be installed before start, see logs below:

```go
I0817 11:46:24.860802  523091 server.go:144] setting up manager
I0817 11:46:24.872965  523091 listener.go:44] controller-runtime/metrics "msg"="metrics server is starting to listen"  "addr"=":8080"
I0817 11:46:24.873673  523091 server.go:179] Starting cache resource from apiserver...
I0817 11:46:24.873692  523091 server.go:182] Starting the controllers.
I0817 11:46:24.873749  523091 reflector.go:175] Starting reflector *v1alpha1.S2iRun (10m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873749  523091 reflector.go:175] Starting reflector *v1.ConfigMap (10m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873770  523091 reflector.go:211] Listing and watching *v1alpha1.S2iRun from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873796  523091 reflector.go:211] Listing and watching *v1.ConfigMap from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873816  523091 reflector.go:175] Starting reflector *v1alpha3.DevOpsProject (10m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873750  523091 reflector.go:175] Starting reflector *v1.Secret (10m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873838  523091 reflector.go:211] Listing and watching *v1.Secret from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873844  523091 reflector.go:211] Listing and watching *v1alpha3.DevOpsProject from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873863  523091 shared_informer.go:253] caches populated
I0817 11:46:24.873921  523091 internal.go:391] controller-runtime/manager "msg"="starting metrics server"  "path"="/metrics"
I0817 11:46:24.873819  523091 reflector.go:175] Starting reflector *v1alpha3.Pipeline (10m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873951  523091 reflector.go:211] Listing and watching *v1alpha3.Pipeline from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873961  523091 pipeline_controller.go:182] starting pipeline controller
I0817 11:46:24.873958  523091 s2irun_controller.go:172] starting s2irun controller
I0817 11:46:24.873981  523091 devopscredential_controller.go:192] starting devopscredential controller
I0817 11:46:24.873989  523091 jenkinsconfig_controller.go:128] starting jenkinsconfig controller
I0817 11:46:24.874006  523091 devopsproject_controller.go:187] starting devops project controller
I0817 11:46:24.873764  523091 reflector.go:175] Starting reflector *v1alpha1.S2iBinary (10m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.874033  523091 reflector.go:211] Listing and watching *v1alpha1.S2iBinary from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.873756  523091 reflector.go:175] Starting reflector *v1.Namespace (10m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.874048  523091 reflector.go:211] Listing and watching *v1.Namespace from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0817 11:46:24.874063  523091 s2ibinary_controller.go:170] starting s2ibinary controller
I0817 11:46:24.874404  523091 controller.go:142] controller "msg"="Starting EventSource" "controller"="pipelinerun" "reconcilerGroup"="devops.kubesphere.io" "reconcilerKind"="PipelineRun" "source"={"Type":{"metadata":{"creationTimestamp":null},"spec":{},"status":{}}}
E0817 11:46:24.890078  523091 source.go:117] controller-runtime/source "msg"="if kind is a CRD, it should be installed before calling Start" "error"="no matches for kind \"PipelineRun\" in version \"devops.kubesphere.io/v1alpha4\""  "kind"={"Group":"devops.kubesphere.io","Kind":"PipelineRun"}
I0817 11:46:24.890120  523091 shared_informer.go:249] stop requested
I0817 11:46:24.890130  523091 shared_informer.go:249] stop requested
I0817 11:46:24.890134  523091 shared_informer.go:249] stop requested
I0817 11:46:24.890137  523091 shared_informer.go:249] stop requested
I0817 11:46:24.890141  523091 devopsproject_controller.go:191] shutting down devops project controller
I0817 11:46:24.890144  523091 devopscredential_controller.go:196] shutting down  devopscredential controller
I0817 11:46:24.890146  523091 s2irun_controller.go:176] shutting down s2irun controller
I0817 11:46:24.890134  523091 s2ibinary_controller.go:174] shutting down s2ibinary controller
I0817 11:46:24.890123  523091 shared_informer.go:249] stop requested
I0817 11:46:24.890123  523091 shared_informer.go:249] stop requested
I0817 11:46:24.890160  523091 jenkinsconfig_controller.go:132] shutting down jenkinsconfig controller
I0817 11:46:24.890163  523091 pipeline_controller.go:186] shutting down  pipeline controller
E0817 11:46:24.890214  523091 internal.go:521] controller-runtime/manager "msg"="error received after stop sequence was engaged" "error"="failed to wait for caches to sync"  
E0817 11:46:24.890230  523091 internal.go:521] controller-runtime/manager "msg"="error received after stop sequence was engaged" "error"="failed to wait for caches to sync"  
E0817 11:46:24.890242  523091 internal.go:521] controller-runtime/manager "msg"="error received after stop sequence was engaged" "error"="failed to wait for caches to sync"  
E0817 11:46:24.890250  523091 internal.go:521] controller-runtime/manager "msg"="error received after stop sequence was engaged" "error"="failed to wait for caches to sync"  
E0817 11:46:24.890261  523091 internal.go:521] controller-runtime/manager "msg"="error received after stop sequence was engaged" "error"="failed to wait for caches to sync"  
E0817 11:46:24.890268  523091 internal.go:521] controller-runtime/manager "msg"="error received after stop sequence was engaged" "error"="failed to wait for caches to sync"  
F0817 11:46:24.890277  523091 server.go:184] unable to run the manager: no matches for kind "PipelineRun" in version "devops.kubesphere.io/v1alpha4"
```

It works well after change:

```go

ks-ctl-ks-devops-controller-8446d8f597-kpx84 W0817 06:17:33.107133       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.107658       1 server.go:144] setting up manager
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.118526       1 listener.go:44] controller-runtime/metrics "msg"="metrics server is starting to listen"  "addr"=":8080"
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119239       1 server.go:179] Starting cache resource from apiserver...
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119257       1 server.go:182] Starting the controllers.
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119378       1 s2ibinary_controller.go:170] starting s2ibinary controller
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119405       1 devopsproject_controller.go:187] starting devops project controller
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119416       1 pipeline_controller.go:182] starting pipeline controller
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119434       1 s2irun_controller.go:172] starting s2irun controller
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119436       1 jenkinsconfig_controller.go:128] starting jenkinsconfig controller
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119440       1 internal.go:391] controller-runtime/manager "msg"="starting metrics server"  "path"="/metrics"
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119465       1 devopscredential_controller.go:192] starting devopscredential controller
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.119642       1 controller.go:142] controller "msg"="Starting EventSource" "controller"="pipelinerun" "reconcilerGroup"="devops.kubesphere.io" "reconcilerKind"="PipelineRun" "source"={"Type":{"metadata":{"creationTimestamp":null},"spec":{},"status":{}}}
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.219582       1 jenkinsconfig_controller.go:178] syncing key:kubesphere-devops-system/jenkins-agent-config
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.219641       1 jenkinsconfig_controller.go:203] Jenkins agent pod resource limit: "default"
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.219827       1 controller.go:149] controller "msg"="Starting Controller" "controller"="pipelinerun" "reconcilerGroup"="devops.kubesphere.io" "reconcilerKind"="PipelineRun" 
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:17:33.219871       1 controller.go:176] controller "msg"="Starting workers" "controller"="pipelinerun" "reconcilerGroup"="devops.kubesphere.io" "reconcilerKind"="PipelineRun" "worker count"=1
ks-ctl-ks-devops-controller-8446d8f597-kpx84 I0817 06:18:45.303304       1 jenkinsconfig_controller.go:271] synced key: kubesphere-devops-system/jenkins-agent-config
```

/kind bug