### PR TITLE
Set crumb into request header to Jenkins automatically

### DIFF
--- a/pkg/client/devops/jenkins/pure_request.go
+++ b/pkg/client/devops/jenkins/pure_request.go
@@ -48,12 +48,22 @@ func (j *Jenkins) SendPureRequestWithHeaderResp(path string, httpParameters *dev
 	client := &http.Client{Timeout: 30 * time.Second}
 
 	header := httpParameters.Header
+	if header == nil {
+		header = http.Header{}
+	}
 
 	if j.Requester != nil {
 		auth := j.Requester.BasicAuth
 
 		creds := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", auth.Username, auth.Password)))
 		header.Set("Authorization", fmt.Sprintf("Basic %s", creds))
+
+		// set crumb
+		if err := j.Requester.SetCrumbForConsumer(func(crumbRequestField, crumb string) {
+			header.Set(crumbRequestField, crumb)
+		}); err != nil {
+			return nil, nil, err
+		}
 	}
 	// TODO consider to remove below
 	SetBasicBearTokenHeader(&header)

--- a/pkg/client/devops/jenkins/pure_request.go
+++ b/pkg/client/devops/jenkins/pure_request.go
@@ -47,7 +47,7 @@ func (j *Jenkins) SendPureRequestWithHeaderResp(path string, httpParameters *dev
 	apiURL.RawQuery = httpParameters.Url.RawQuery
 	client := &http.Client{Timeout: 30 * time.Second}
 
-	header := httpParameters.Header
+	header := httpParameters.Header.Clone()
 	if header == nil {
 		header = http.Header{}
 	}
@@ -64,7 +64,7 @@ func (j *Jenkins) SendPureRequestWithHeaderResp(path string, httpParameters *dev
 			if err := j.Requester.SetCrumbForConsumer(func(crumbRequestField, crumb string) {
 				header.Set(crumbRequestField, crumb)
 			}); err != nil {
-				klog.Errorf("unable to set crumb to http parameters, err: %v", err)
+				klog.Errorf("unable to set crumb to HTTP header, err: %v", err)
 				return nil, nil, err
 			}
 		}

--- a/pkg/client/devops/jenkins/pure_request.go
+++ b/pkg/client/devops/jenkins/pure_request.go
@@ -64,7 +64,7 @@ func (j *Jenkins) SendPureRequestWithHeaderResp(path string, httpParameters *dev
 			if err := j.Requester.SetCrumbForConsumer(func(crumbRequestField, crumb string) {
 				header.Set(crumbRequestField, crumb)
 			}); err != nil {
-				klog.Error("unable to set crumb to http parameters, err: %v", err)
+				klog.Errorf("unable to set crumb to http parameters, err: %v", err)
 				return nil, nil, err
 			}
 		}

--- a/pkg/client/devops/jenkins/request.go
+++ b/pkg/client/devops/jenkins/request.go
@@ -90,6 +90,14 @@ type Requester struct {
 }
 
 func (r *Requester) SetCrumb(ar *APIRequest) error {
+	return r.SetCrumbForConsumer(func(crumbRequestField, crumb string) {
+		ar.SetHeader(crumbRequestField, crumb)
+	})
+}
+
+// SetCrumbForConsumer makes crumb consumer set the crumb. Crumb consumer accepts crumb request field and crumb
+// parameters and can handle the crumb whatever it likes.
+func (r *Requester) SetCrumbForConsumer(crumbConsumer func(crumbRequestField, crumb string)) error {
 	crumbData := map[string]string{}
 	response, err := r.GetJSON("/crumbIssuer/api/json", &crumbData, nil)
 	if err != nil {
@@ -100,7 +108,7 @@ func (r *Requester) SetCrumb(ar *APIRequest) error {
 		return err
 	}
 	if response.StatusCode == 200 && crumbData["crumbRequestField"] != "" {
-		ar.SetHeader(crumbData["crumbRequestField"], crumbData["crumb"])
+		crumbConsumer(crumbData["crumbRequestField"], crumbData["crumb"])
 	}
 
 	return nil


### PR DESCRIPTION
### What this PR dose

Set crumb into request header to Jenkins.

### Why we need it

1. Currently, if DevOps part of ks-console want to request some Jenkins resources, like `/kapis/devops.kubesphere.io/v1alpha2/tojson`, it have to request `/kapis/devops.kubesphere.io/v1alpha2/crumbissuer` API in advance. This design is not friendly for front-end. If do that, front-end will no longer care if any API needs to set up crumb.

2. Some reconcilers, like `PipelineReconciler, PipelineRunReconciler`, might request Jenkins APIs. It might be more useful if we  uniformly set up crumb before every request to Jenkins.

### Special notes

Because method `SetCrumbForConsumer` depends on `Requester#GetJSON` method, it's not easy to write a unit test against the method.