### PR TITLE
Improve the error message with getting Pipeline

### DIFF
--- a/pkg/client/devops/jenkins/pipeline.go
+++ b/pkg/client/devops/jenkins/pipeline.go
@@ -98,7 +98,7 @@ func (p *Pipeline) GetPipeline() (*devops.Pipeline, error) {
 
 	err = json.Unmarshal(res, &pipeline)
 	if err != nil {
-		klog.Error(err)
+		err = fmt.Errorf("failed to unmarshal JSON data to Pipeline, raw: %s, error: %v", res, err)
 		return nil, err
 	}
 	return &pipeline, err

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -382,12 +382,7 @@ func (d devopsOperator) filterCredentialObj(object runtime.Object, filter query.
 
 // others
 func (d devopsOperator) GetPipeline(projectName, pipelineName string, req *http.Request) (*devops.Pipeline, error) {
-
-	res, err := d.devopsClient.GetPipeline(projectName, pipelineName, convertToHttpParameters(req))
-	if err != nil {
-		klog.Error(err)
-	}
-	return res, err
+	return d.devopsClient.GetPipeline(projectName, pipelineName, convertToHttpParameters(req))
 }
 
 func (d devopsOperator) ListPipelines(req *http.Request) (*devops.PipelineList, error) {


### PR DESCRIPTION
The log output:

Before this PR:
```
E0819 11:29:40.139579       1 pipeline.go:99] invalid character '<' looking for beginning of value
E0819 11:29:40.139598       1 devops.go:405] invalid character '<' looking for beginning of value
E0819 11:29:40.139604       1 devops.go:900] invalid character '<' looking for beginning of value
I0819 11:29:40.139627       1 apiserver.go:613] 10.233.90.68 - "GET /kapis/devops.kubesphere.io/v1alpha2/devops/testnnbnc/pipelines/asdf/ HTTP/1.1" 500 52 60ms
```

Like you can see, the same log was printed three times.