### PR TITLE
Fix the controller panic due to Jenkins job parse error

### DIFF
--- a/pkg/client/devops/jenkins/pipeline_internal.go
+++ b/pkg/client/devops/jenkins/pipeline_internal.go
@@ -122,7 +122,9 @@ func parsePipelineConfigXml(config string) (*devopsv1alpha3.NoScmPipeline, error
 	if flow == nil {
 		return nil, fmt.Errorf("can not find pipeline definition")
 	}
-	pipeline.Description = flow.SelectElement("description").Text()
+	if node := flow.SelectElement("description"); node != nil {
+		pipeline.Description = node.Text()
+	}
 
 	properties := flow.SelectElement("properties")
 	if properties.


### PR DESCRIPTION
no description in flow-definition if a Jenkins job was created via JSON API

Please see the file config.xml which was created via JSON API:
```
# cat config.xml
<?xml version='1.1' encoding='UTF-8'?>
<flow-definition plugin="workflow-job@2.40">
  <keepDependencies>false</keepDependencies>
  <properties/>
  <triggers/>
  <disabled>false</disabled>
</flow-definition>
```

Images:
* `surenpi/devops-apiserver:dev--1376445`
* `surenpi/devops-controller:dev--1376445`

