### PR TITLE
Support to install minikube in CodeSpaces automatically

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version: bionic, focal
+ARG VARIANT="focal"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+RUN apt update -y && \
+    apt install docker.io -y && \
+    sudo apt install bash-completion -y
+
+RUN sudo apt install golang-1.16 -y
+
+RUN sudo apt install make -y
+
+RUN sudo rm -rf /usr/bin/hd && \
+    curl -L https://github.com/linuxsuren/http-downloader/releases/latest/download/hd-linux-amd64.tar.gz | tar xzv && \
+    mv hd /usr/local/bin && \
+    hd fetch && \
+    hd install cli/cli && \
+    hd install ks && \
+    hd install minikube && \
+    hd install helm
+
+RUN ks alias init && \
+    ks completion bash > /etc/bash_completion.d/ks
+
+RUN echo "export PATH=/usr/lib/go-1.16/bin:$PATH" >> /etc/bash.bashrc && \
+    /usr/lib/go-1.16/bin/go get -v golang.org/x/tools/gopls
+
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/go
 {
-	"name": "Existing Dockerfile",
-	"context": "..",
-	"dockerFile": "../.gitpod.Dockerfile",
-	"settings": {},
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "focal",
+		}
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.useLanguageServer": true,
+		"go.gopath": "/home/vscode/go",
+		"go.goroot": "/usr/lib/go-1.16"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"golang.go",
+		"golang.Go",
 		"ms-azuretools.vscode-docker"
 	],
 
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [30880, 30180],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash .devcontainer/init.sh",
+
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	"remoteUser": "vscode"
 }

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# start minikube
+sudo chown vscode:vscode /var/run/docker.sock
+minikube-linux-amd64 start --ports=30880
+
+# ks init
+ks alias init

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,4 +3,6 @@ FROM gitpod/workspace-full
 # More information: https://www.gitpod.io/docs/config-docker/
 RUN sudo rm -rf /usr/bin/hd && \
     brew install linuxsuren/linuxsuren/hd && \
-    hd install cli/cli
+    hd install cli/cli && \
+    hd install ks && \
+    hd install minikube


### PR DESCRIPTION
You can use the following tools in CodeSpaces:

* ks (with autocompletion support)
* helm
* kubectl
* minikube

Test result:
```
👋 Welcome to Codespaces! You are on a custom image defined in your devcontainer.json file.

🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P)

📝 Edit away, then run your build command to see your code running in the browser.
vscode ➜ /workspaces/ks-devops (add-more-dev-tools) $ ks 
alias       completion  help        option      registry    token       user        
auth        component   install     pipeline    s2i         tool        version     
vscode ➜ /workspaces/ks-devops (add-more-dev-tools) $ ks ^C
vscode ➜ /workspaces/ks-devops (add-more-dev-tools) $ ks get ns
NAME              STATUS   AGE
default           Active   37s
kube-node-lease   Active   42s
kube-public       Active   43s
kube-system       Active   43s
vscode ➜ /workspaces/ks-devops (add-more-dev-tools) $
```