### PR TITLE
WIP: Add cronjob to gc PipelineRuns

### DIFF
--- a/charts/ks-devops/templates/cronjob-gc.yaml
+++ b/charts/ks-devops/templates/cronjob-gc.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "ks-devops.apiserver-fullname" . }}
+  labels:
+    app: devops-pipelinerun-gcjobs
+spec:
+  concurrencyPolicy: {{ .Values.gcJobs.concurrencyPolicy }}
+  failedJobsHistoryLimit: {{ .Values.gcJobs.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: {{ include "ks-devops.apiserver-fullname" . }}
+            release: {{ .Release.Name }}
+{{- if .Values.gcJobs.podAnnotations }}
+          annotations:
+{{ toYaml .Values.gcJobs.podAnnotations | indent 12 }}
+{{- end }}
+        spec:
+          containers:
+            - command:
+                - ks
+                - pip
+                - gc
+              image: {{ tpl .Values.image.gc.repository . }}:{{ tpl .Values.image.gc.tag . }}
+              imagePullPolicy: {{ tpl .Values.image.pullPolicy . }}
+              args:
+                - "--max-count={{ .Values.gcJobs.maxCount }}"
+                - "--max-age={{ .Values.gcJobs.maxAge }}"
+              name: "pipeline-run-gc"
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          serviceAccountName: {{ include "ks-devops.serviceAccountName" . }}
+  successfulJobsHistoryLimit: {{ .Values.gcJobs.successfulJobsHistoryLimit }}
+  schedule: {{ .Values.gcJobs.schedule | quote }}
+  startingDeadlineSeconds: 4000
+  suspend: false

--- a/charts/ks-devops/values.yaml
+++ b/charts/ks-devops/values.yaml
@@ -12,7 +12,24 @@ image:
   tools:
     repository: devops-tools
     tag: master
+  gc:
+    repository: devops-gc
+    tag: master
   pullPolicy: IfNotPresent
+
+gcJobs:
+  # gcJobs.maxAge -- Max age from which `PipelineRun`s will be deleted
+  maxAge: 168h
+  # gcJobs.maxCount -- Max count from which `PipelineRun`'s will be deleted
+  maxCount: 10
+  # gcJobs.schedule -- Cron expression to periodically delete `PipelineRun`s
+  schedule: "0/30 * * * *"
+  # gcJobs.failedJobsHistoryLimit -- Drives the failed jobs history limit
+  failedJobsHistoryLimit: 1
+  # gcJobs.successfulJobsHistoryLimit -- Drives the successful jobs history limit
+  successfulJobsHistoryLimit: 3
+  # gcJobs.concurrencyPolicy -- Drives the job's concurrency policy
+  concurrencyPolicy: Forbid
 
 authentication:
   # If not set, jwt tools will generate and set it automatically


### PR DESCRIPTION
upstream https://github.com/kubesphere-sigs/ks/pull/179 and #191 

In order to avoid too many PipelineRuns to let etcd takes high disk pressure. We should clean up the PipelineRuns regularly.

I offered two options to clean it.

* `maxAge`
  * we only clean those PipelineRun that has finished, and it exists longer than `maxAge`
* `maxCount`
  * the max number of each Pipelines' PipelineRun

We take advantage of CronJob to run the command regularly. Also, users can run it manually.

/kind feature