### PR TITLE
Build APIServer, controller manager and tools only when tests passed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,8 @@ on:
 jobs:
   BuildController:
     runs-on: ubuntu-20.04
+    needs:
+      - UnitTest
     steps:
       - uses: actions/checkout@v2
       - name: Docker meta for kubesphere
@@ -90,6 +92,8 @@ jobs:
 
   BuildAPIServer:
     runs-on: ubuntu-20.04
+    needs:
+      - UnitTest
     steps:
       - uses: actions/checkout@v2
       - name: Docker meta for kubesphere
@@ -157,6 +161,8 @@ jobs:
 
   BuildTools:
     runs-on: ubuntu-20.04
+    needs:
+      - UnitTest
     steps:
       - uses: actions/checkout@v2
       - name: Docker meta for kubesphere


### PR DESCRIPTION
### What this PR dose

Add `needs` configuration in jobs `BuildController`, `BuildAPIServer` and `BuildTools`.

### Why we need it

Make jobs `BuildController`, `BuildAPIServer` and `BuildTools` buildable only when tests passed. If tests don't pass, the built things are meaningless.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/16865714/132171902-cda88649-2d87-4628-9fc8-c033960fb66d.png)|![image](https://user-images.githubusercontent.com/16865714/132171471-02b6529f-ff32-4bfe-8b94-754db6c29b35.png) |