### PR TITLE
Provide getting PipelineRun API

### DIFF
--- a/pkg/kapis/devops/v1alpha4/handler.go
+++ b/pkg/kapis/devops/v1alpha4/handler.go
@@ -107,3 +107,24 @@ func (h *apiHandler) createPipelineRuns(request *restful.Request, response *rest
 
 	_ = response.WriteEntity(pr)
 }
+
+func (h *apiHandler) getPipelineRun(request *restful.Request, response *restful.Response) {
+	nsName := request.PathParameter("namespace")
+	pipName := request.PathParameter("pipeline")
+	prName := request.PathParameter("pipelinerun")
+
+	// validate the pipeline
+	var pipeline v1alpha3.Pipeline
+	if err := h.client.Get(context.Background(), client.ObjectKey{Namespace: nsName, Name: pipName}, &pipeline); err != nil {
+		api.HandleError(request, response, err)
+		return
+	}
+
+	// get pipelinerun
+	var pr v1alpha4.PipelineRun
+	if err := h.client.Get(context.Background(), client.ObjectKey{Namespace: pipeline.GetNamespace(), Name: prName}, &pr); err != nil {
+		api.HandleError(request, response, err)
+		return
+	}
+	_ = response.WriteEntity(&pr)
+}

--- a/pkg/kapis/devops/v1alpha4/handler.go
+++ b/pkg/kapis/devops/v1alpha4/handler.go
@@ -110,19 +110,11 @@ func (h *apiHandler) createPipelineRuns(request *restful.Request, response *rest
 
 func (h *apiHandler) getPipelineRun(request *restful.Request, response *restful.Response) {
 	nsName := request.PathParameter("namespace")
-	pipName := request.PathParameter("pipeline")
 	prName := request.PathParameter("pipelinerun")
-
-	// validate the pipeline
-	var pipeline v1alpha3.Pipeline
-	if err := h.client.Get(context.Background(), client.ObjectKey{Namespace: nsName, Name: pipName}, &pipeline); err != nil {
-		api.HandleError(request, response, err)
-		return
-	}
 
 	// get pipelinerun
 	var pr v1alpha4.PipelineRun
-	if err := h.client.Get(context.Background(), client.ObjectKey{Namespace: pipeline.GetNamespace(), Name: prName}, &pr); err != nil {
+	if err := h.client.Get(context.Background(), client.ObjectKey{Namespace: nsName, Name: prName}, &pr); err != nil {
 		api.HandleError(request, response, err)
 		return
 	}

--- a/pkg/kapis/devops/v1alpha4/register.go
+++ b/pkg/kapis/devops/v1alpha4/register.go
@@ -54,5 +54,13 @@ func addToContainer(o Option, ws *restful.WebService, handler *apiHandler) {
 		Reads(devops.RunPayload{}).
 		Returns(http.StatusCreated, api.StatusOK, v1alpha4.PipelineRun{}),
 	)
+	ws.Route(ws.GET("/namespaces/{namespace}/pipelines/{pipeline}/pipelineruns/{pipelinerun}").
+		To(handler.getPipelineRun).
+		Doc("Get a PipelineRun for a specified pipeline").
+		Param(ws.PathParameter("namespace", "Namespace of the pipeline")).
+		Param(ws.PathParameter("pipeline", "Name of the pipeline")).
+		Param(ws.PathParameter("pipelinerun", "Name of the PipelineRun")).
+		Returns(http.StatusOK, api.StatusOK, v1alpha4.PipelineRun{}))
+
 	o.Container.Add(ws)
 }

--- a/pkg/kapis/devops/v1alpha4/register.go
+++ b/pkg/kapis/devops/v1alpha4/register.go
@@ -54,11 +54,10 @@ func addToContainer(o Option, ws *restful.WebService, handler *apiHandler) {
 		Reads(devops.RunPayload{}).
 		Returns(http.StatusCreated, api.StatusOK, v1alpha4.PipelineRun{}),
 	)
-	ws.Route(ws.GET("/namespaces/{namespace}/pipelines/{pipeline}/pipelineruns/{pipelinerun}").
+	ws.Route(ws.GET("/namespaces/{namespace}/pipelineruns/{pipelinerun}").
 		To(handler.getPipelineRun).
 		Doc("Get a PipelineRun for a specified pipeline").
 		Param(ws.PathParameter("namespace", "Namespace of the pipeline")).
-		Param(ws.PathParameter("pipeline", "Name of the pipeline")).
 		Param(ws.PathParameter("pipelinerun", "Name of the PipelineRun")).
 		Returns(http.StatusOK, api.StatusOK, v1alpha4.PipelineRun{}))
 


### PR DESCRIPTION
### What this PR dose

- Provide getting PipelineRun API

### Why we need it

This PR is to prepare for PipelineRun feature in APIServer. At the same time, this PR is also a part of #41.

### Special notes

Docker image for test: `johnniang/devops-apiserver:get-pipelinerun`

### API usage

```bash
curl "http://ip:30880/kapis/devops.kubesphere.io/v1alpha4/namespaces/{namespace}/pipelines/{pipeline}/pipelineruns/{pipelinerun}"
```

```json
{
 "kind": "PipelineRun",
 "apiVersion": "devops.kubesphere.io/v1alpha4",
 "metadata": {
  "name": "my-pipeline-runs-jpw4z",
  "generateName": "my-pipeline-runs-",
  "namespace": "my-second-devops-project97bzf",
  "selfLink": "/apis/devops.kubesphere.io/v1alpha4/namespaces/my-second-devops-project97bzf/pipelineruns/my-pipeline-runs-jpw4z",
  "uid": "f22420fa-1636-4af7-8654-8df5723b7daa",
  "resourceVersion": "6884135",
  "generation": 1,
  "creationTimestamp": "2021-09-14T03:40:16Z",
  "labels": {
   "devops.kubesphere.io/pipeline": "my-pipeline"
  },
  "annotations": {
   "devops.kubesphere.io/jenkins-pipelinerun-id": "6",
   "devops.kubesphere.io/jenkins-pipelinerun-stages-status": "[{\"displayName\":\"stage-9ra6o\",\"durationInMillis\":13191,\"id\":\"6\",\"result\":\"SUCCESS\",\"startTime\":\"2021-09-14T03:40:42.933Z\",\"state\":\"FINISHED\",\"type\":\"STAGE\",\"edges\":[{\"id\":\"12\",\"type\":\"STAGE\"}],\"restartable\":true},{\"displayName\":\"stage-4f12u\",\"durationInMillis\":24552,\"id\":\"12\",\"result\":\"FAILURE\",\"startTime\":\"2021-09-14T03:40:56.214Z\",\"state\":\"FINISHED\",\"type\":\"STAGE\",\"edges\":[{\"id\":\"17\",\"type\":\"STAGE\"}],\"firstParent\":\"6\",\"restartable\":true},{\"displayName\":\"stage-hl1qp\",\"id\":\"17\",\"result\":\"NOT_BUILT\",\"startTime\":\"0001-01-01T00:00:00Z\",\"state\":\"SKIPPED\",\"type\":\"STAGE\",\"firstParent\":\"12\"}]",
   "devops.kubesphere.io/jenkins-pipelinerun-status": "{\"causes\":[{\"_class\":\"io.jenkins.blueocean.service.embedded.rest.AbstractRunImpl$BlueCauseImpl\",\"shortDescription\":\"Started by user admin\",\"userId\":\"admin\",\"userName\":\"admin\"}],\"durationInMillis\":64601,\"enQueueTime\":\"2021-09-14T03:40:16.419Z\",\"endTime\":\"2021-09-14T03:41:21.027Z\",\"estimatedDurationInMillis\":52004,\"id\":\"6\",\"organization\":\"jenkins\",\"pipeline\":\"my-pipeline\",\"replayable\":true,\"result\":\"FAILURE\",\"runSummary\":\"broken since build #4\",\"startTime\":\"2021-09-14T03:40:16.426Z\",\"state\":\"FINISHED\",\"type\":\"WorkflowRun\"}"
  },
  "ownerReferences": [
   {
    "apiVersion": "devops.kubesphere.io/v1alpha3",
    "kind": "Pipeline",
    "name": "my-pipeline",
    "uid": "19b0cf48-3845-4a0a-b2b2-49632229d41c",
    "controller": true,
    "blockOwnerDeletion": true
   }
  ],
  "managedFields": [...]
 },
 "spec": {
  "pipelineRef": {
   "kind": "Pipeline",
   "namespace": "my-second-devops-project97bzf",
   "name": "my-pipeline"
  },
  "pipelineSpec": {
   "type": "pipeline",
   "pipeline": {
    "name": "my-pipeline",
    "discarder": {
     "days_to_keep": "7",
     "num_to_keep": "10"
    },
    "jenkinsfile": "pipeline {\n  agent any\n  stages {\n    stage('stage-9ra6o') {\n      agent none\n      steps {\n        echo 'Hello, DevOps'\n        sh ''\n      }\n    }\n\n    stage('stage-4f12u') {\n      agent none\n      steps {\n        checkout(scm: [$class: 'SubversionSCM', locations: [[cancelProcessOnExternalsFail: true,   depthOption: 'infinity', ignoreExternalsOption: true, local: '.', remote: 'a']], quietOperation: true, workspaceUpdater: [$class: 'UpdateUpdater']], poll: false)\n        checkout(scm: [$class: 'SubversionSCM', locations: [[cancelProcessOnExternalsFail: true,   depthOption: 'infinity', ignoreExternalsOption: true, local: '.', remote: 'https://github.com/johnniang/johnniang.git']], quietOperation: true, workspaceUpdater: [$class: 'UpdateUpdater']], poll: false)\n        sh 'hello'\n      }\n    }\n\n    stage('stage-hl1qp') {\n      agent none\n      steps {\n        sh ''\n      }\n    }\n\n  }\n}"
   }
  }
 },
 "status": {
  "startTime": "2021-09-14T03:40:16Z",
  "completionTime": "2021-09-14T03:41:21Z",
  "updateTime": "2021-09-14T03:41:21Z",
  "conditions": [
   {
    "type": "Succeeded",
    "status": "False",
    "lastProbeTime": "2021-09-14T03:41:21Z",
    "lastTransitionTime": "2021-09-14T03:41:21Z",
    "reason": "FINISHED"
   },
   {
    "type": "Ready",
    "status": "Unknown",
    "lastProbeTime": "2021-09-14T03:41:21Z",
    "lastTransitionTime": "2021-09-14T03:41:21Z",
    "reason": "RUNNING"
   }
  ],
  "phase": "Failed"
 }
}
```

- Get Jenkins run status

    See `.annotations["devops.kubesphere.io/jenkins-pipelinerun-status"]`

- Get Jenkins stages status

    See `.annotations["devops.kubesphere.io/jenkins-pipelinerun-stages-status"]`
