### PR TITLE
Put the command line ks into the tools image

### DIFF
--- a/config/dockerfiles/tools/Dockerfile
+++ b/config/dockerfiles/tools/Dockerfile
@@ -17,11 +17,16 @@ COPY pkg/ pkg/
 # Build
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o jwt cmd/tools/jwt/jwt_cmd.go
 
+FROM golang:1.16 as downloader
+RUN go install github.com/linuxsuren/http-downloader@v0.0.38
+RUN http-downloader install kubesphere-sigs/ks
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/jwt .
+COPY --from=downloader /usr/local/bin/ks /usr/local/bin/ks
 USER nonroot:nonroot
 
-ENTRYPOINT ["/jwt"]
+CMD ["/jwt"]


### PR DESCRIPTION
As you can see the size of the new image increased by less than 10M.

```
gitpod /workspaces/ks-devops $ sudo docker images | grep test
test                                             no-ks               9437ba112cb2        54 seconds ago      50.9MB
test                                             with-ks             db392a18a136        2 minutes ago       60.6MB
```

Below is the image base on the new changes: `surenpi/devops-tools:with-ks@sha256:7b69c5801e6b8130eef1f418c1e7358cb26c0fda47494acf579ef52abce866f3`

## Notes for the reviewers
* Using a download tool
  * Using a download tool to download `ks` can be easier to support multiple platform: `arm64` and `amd64`
* Change `ENTRYPOINT` to `CMD`
  * There is no server in this image, it's not suitable to set an entrypoint. Set `CMD` is much reasonable. Also, users can run multiple commands of this image easier.