### PR TITLE
Add action field into PipelineRunSpec

### DIFF
--- a/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
+++ b/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
@@ -36,6 +36,9 @@ spec:
           spec:
             description: PipelineRunSpec defines the desired state of PipelineRun
             properties:
+              action:
+                description: Action indicates what we need to do with current PipelineRun.
+                type: string
               parameters:
                 description: Parameters are some key/value pairs passed to runner.
                 items:

--- a/pkg/api/devops/pipelinerun/v1alpha3/pipelinerun_types.go
+++ b/pkg/api/devops/pipelinerun/v1alpha3/pipelinerun_types.go
@@ -40,6 +40,10 @@ type PipelineRunSpec struct {
 	// SCM is a SCM configuration that target PipelineRun requires.
 	// +optional
 	SCM *SCM `json:"scm,omitempty"`
+
+	// Action indicates what we need to do with current PipelineRun.
+	// +optional
+	Action *Action `json:"action,omitempty"`
 }
 
 // PipelineRunStatus defines the observed state of PipelineRun
@@ -268,6 +272,18 @@ type Condition struct {
 	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,6,opt,name=message"`
 }
+
+// Action indicates what we need to do with current PipelineRun.
+type Action string
+
+const (
+	// Stop indicates we need to stop the current PipelineRun.
+	Stop Action = "Stop"
+	// Pause indicates we need to pause the current PipelineRun.
+	Pause Action = "Pause"
+	// Resume indicates we need to resume the current PipelineRun.
+	Resume Action = "Resume"
+)
 
 // Valid values for event reasons (new reasons could be added in future)
 const (


### PR DESCRIPTION
### What this PR dose

Add action field into PipelineRunSpec.

### Why we need it

We need to be able to control our PipelineRun.