### PR TITLE
Provide Pipeline Synchronizer to synchronize PipelineRun from Jenkins

### DIFF
--- a/controllers/devopsproject/devopsproject_controller.go
+++ b/controllers/devopsproject/devopsproject_controller.go
@@ -161,7 +161,6 @@ func (c *Controller) processNextWorkItem() bool {
 	}(obj)
 
 	if err != nil {
-		klog.Error(err, "could not reconcile devopsProject")
 		utilruntime.HandleError(err)
 		return true
 	}

--- a/controllers/jenkins/pipelinerun/pipelinerun_synchronizer.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_synchronizer.go
@@ -3,6 +3,7 @@ package pipelinerun
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"github.com/jenkins-zh/jenkins-client/pkg/job"
@@ -123,6 +124,7 @@ func (r *SyncReconciler) createPipelineRun(pipeline *v1alpha3.Pipeline, run *job
 func createBarePipelineRun(pipeline *v1alpha3.Pipeline, run *job.PipelineRun) (*prv1alpha3.PipelineRun, error) {
 	branch := ""
 	if run.Branch != nil {
+		// TODO(johnniang): Refine the branch structure in Jenkins client.
 		branch = fmt.Sprint(run.Branch.(map[string]interface{})["url"])
 	}
 	scm, err := pipelinerun.CreateScm(&pipeline.Spec, branch)
@@ -130,17 +132,7 @@ func createBarePipelineRun(pipeline *v1alpha3.Pipeline, run *job.PipelineRun) (*
 		return nil, err
 	}
 	pr := pipelinerun.CreatePipelineRun(pipeline, nil, scm)
-	if pr.Annotations == nil {
-		pr.Annotations = make(map[string]string)
-	}
 	pr.Annotations[prv1alpha3.JenkinsPipelineRunIDKey] = run.ID
-	// set a **unique** name for PipelineRun to synchronize and reset generate name
-	pr.Name = pr.GenerateName
-	if branch != "" {
-		pr.Name = pr.Name + branch + "-"
-	}
-	pr.Name = pr.Name + run.ID
-	pr.GenerateName = ""
 	return pr, nil
 }
 

--- a/controllers/jenkins/pipelinerun/pipelinerun_synchronizer.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_synchronizer.go
@@ -1,0 +1,175 @@
+package pipelinerun
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
+	"github.com/jenkins-zh/jenkins-client/pkg/job"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	prv1alpha3 "kubesphere.io/devops/pkg/api/devops/pipelinerun/v1alpha3"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"kubesphere.io/devops/pkg/kapis/devops/v1alpha3/pipelinerun"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Valid values for event reasons(new reasons could be added in the future)
+const (
+	PipelineRunSynced     = "PipelineRunSynced"
+	FailedPipelineRunSync = "FailedPipelineRunSync"
+)
+
+// SyncReconciler is a reconciler for synchronizing PipelineRuns from Jenkins.
+// This reconciler is an intermediate reconciler. When we complete the issue
+// https://github.com/kubesphere/ks-devops/issues/65, we will remove it.
+type SyncReconciler struct {
+	client.Client
+	log         logr.Logger
+	recorder    record.EventRecorder
+	JenkinsCore core.JenkinsCore
+}
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *SyncReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	log := r.log.WithValues("Pipeline", req.NamespacedName)
+	pipeline := &v1alpha3.Pipeline{}
+	if err := r.Client.Get(ctx, req.NamespacedName, pipeline); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// get all pipelineruns
+	var prList prv1alpha3.PipelineRunList
+	if err := r.Client.List(ctx, &prList, client.InNamespace(pipeline.Namespace), client.MatchingLabels{
+		prv1alpha3.PipelineNameLabelKey: pipeline.Name,
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+	prContainer := make(map[string]prv1alpha3.PipelineRun)
+	for _, pr := range prList.Items {
+		runID := pr.Annotations[prv1alpha3.JenkinsPipelineRunIDKey]
+		prContainer[runID] = pr
+	}
+
+	boClient := job.BlueOceanClient{
+		JenkinsCore:  r.JenkinsCore,
+		Organization: "jenkins",
+	}
+
+	jenkinsRuns, err := boClient.GetPipelineRuns(pipeline.Name, pipeline.Namespace)
+	if err != nil {
+		r.recorder.Eventf(pipeline, v1.EventTypeWarning, FailedPipelineRunSync, "")
+		return ctrl.Result{}, err
+	}
+	var createdPipelineRuns []prv1alpha3.PipelineRun
+	for _, jenkinsRun := range jenkinsRuns {
+		if _, ok := prContainer[jenkinsRun.ID]; !ok {
+			pipelineRun, err := r.createPipelineRun(pipeline, &jenkinsRun)
+			if err == nil {
+				createdPipelineRuns = append(createdPipelineRuns, *pipelineRun)
+			} else {
+				log.Error(err, "failed to create bare PipelineRun", "JenkinsRun", jenkinsRun)
+			}
+		}
+	}
+
+	if err := r.synchronizedSuccessfully(req.NamespacedName); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.Info("synchronized PipelineRun successfully")
+
+	r.recorder.Eventf(pipeline, v1.EventTypeNormal, PipelineRunSynced,
+		"Successfully synchronized %d PipelineRuns(s). PipelineRuns/JenkinsRuns proportion is %d/%d", len(createdPipelineRuns), len(prList.Items), len(jenkinsRuns))
+	return ctrl.Result{}, nil
+}
+
+func (r *SyncReconciler) synchronizedSuccessfully(key client.ObjectKey) error {
+	//pipelineToUpdate := *pipeline.DeepCopy()
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pipelineToUpdate := &v1alpha3.Pipeline{}
+		if err := r.Client.Get(context.Background(), key, pipelineToUpdate); err != nil {
+			return err
+		}
+		if _, ok := pipelineToUpdate.Annotations[v1alpha3.PipelineRequestToSyncRunsAnnoKey]; !ok {
+			return nil
+		}
+		// remove the annotation
+		delete(pipelineToUpdate.Annotations, v1alpha3.PipelineRequestToSyncRunsAnnoKey)
+		// update the Pipeline
+
+		// ignore the conflict
+		return r.Client.Update(context.Background(), pipelineToUpdate)
+	})
+}
+
+func (r *SyncReconciler) createPipelineRun(pipeline *v1alpha3.Pipeline, run *job.PipelineRun) (*prv1alpha3.PipelineRun, error) {
+	pipelineRun, err := createBarePipelineRun(pipeline, run)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.Client.Create(context.Background(), pipelineRun); err != nil {
+		return nil, err
+	}
+	return pipelineRun, nil
+}
+
+func createBarePipelineRun(pipeline *v1alpha3.Pipeline, run *job.PipelineRun) (*prv1alpha3.PipelineRun, error) {
+	branch := ""
+	if run.Branch != nil {
+		branch = fmt.Sprint(run.Branch.(map[string]interface{})["url"])
+	}
+	scm, err := pipelinerun.CreateScm(&pipeline.Spec, branch)
+	if err != nil {
+		return nil, err
+	}
+	pr := pipelinerun.CreatePipelineRun(pipeline, nil, scm)
+	if pr.Annotations == nil {
+		pr.Annotations = make(map[string]string)
+	}
+	pr.Annotations[prv1alpha3.JenkinsPipelineRunIDKey] = run.ID
+	// set a **unique** name for PipelineRun to synchronize and reset generate name
+	pr.Name = pr.GenerateName
+	if branch != "" {
+		pr.Name = pr.Name + branch + "-"
+	}
+	pr.Name = pr.Name + run.ID
+	pr.GenerateName = ""
+	return pr, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.recorder = mgr.GetEventRecorderFor("pipeline-synchronizer")
+	r.log = ctrl.Log.WithName("pipelinerun-synchronizer")
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha3.Pipeline{}).
+		WithEventFilter(predicate.And(predicate.ResourceVersionChangedPredicate{}, requestSyncPredicate())).
+		Complete(r)
+}
+
+func requestSyncPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			_, ok := e.Meta.GetAnnotations()[v1alpha3.PipelineRequestToSyncRunsAnnoKey]
+			return ok
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			_, ok := e.MetaNew.GetAnnotations()[v1alpha3.PipelineRequestToSyncRunsAnnoKey]
+			return ok
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}

--- a/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
@@ -1,0 +1,198 @@
+package pipelinerun
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/job"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	prv1alpha3 "kubesphere.io/devops/pkg/api/devops/pipelinerun/v1alpha3"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+func Test_requestSyncPredicate(t *testing.T) {
+	tests := []struct {
+		name string
+		want func(predicate.Predicate)
+	}{{
+		name: "Request to sync while creating",
+		want: func(p predicate.Predicate) {
+			createEvent := event.CreateEvent{
+				Meta: &v1.ObjectMeta{
+					Annotations: map[string]string{
+						v1alpha3.PipelineRequestToSyncRunsAnnoKey: "true",
+					},
+				},
+			}
+			assert.True(t, p.Create(createEvent))
+		},
+	}, {
+		name: "Request to nothing while creating",
+		want: func(p predicate.Predicate) {
+			createEvent := event.CreateEvent{
+				Meta: &v1.ObjectMeta{},
+			}
+			assert.False(t, p.Create(createEvent))
+		},
+	}, {
+		name: "Request to sync while updating",
+		want: func(p predicate.Predicate) {
+			updateEvent := event.UpdateEvent{
+				MetaNew: &v1.ObjectMeta{
+					Annotations: map[string]string{
+						v1alpha3.PipelineRequestToSyncRunsAnnoKey: "true",
+					},
+				},
+			}
+			assert.True(t, p.Update(updateEvent))
+		},
+	}, {
+		name: "Request to nothing while updating",
+		want: func(p predicate.Predicate) {
+			updateEvent := event.UpdateEvent{
+				MetaNew: &v1.ObjectMeta{},
+			}
+			assert.False(t, p.Update(updateEvent))
+		},
+	}, {
+		name: "Nothing to do while deleting",
+		want: func(p predicate.Predicate) {
+			deleteEvent := event.DeleteEvent{
+				Meta: &v1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			}
+			assert.False(t, p.Delete(deleteEvent))
+		},
+	}, {
+		name: "Nothing to do while genericing",
+		want: func(p predicate.Predicate) {
+			genericEvent := event.GenericEvent{
+				Meta: &v1.ObjectMeta{
+					Annotations: map[string]string{
+						v1alpha3.PipelineRequestToSyncRunsAnnoKey: "true",
+					},
+				},
+			}
+			assert.False(t, p.Generic(genericEvent))
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.want(requestSyncPredicate())
+		})
+	}
+}
+
+func Test_createBarePipelineRun(t *testing.T) {
+	multiBranchPipeline := &v1alpha3.Pipeline{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "fake-pipeline",
+			Namespace: "fake-namespace",
+		},
+		Spec: v1alpha3.PipelineSpec{
+			Type: v1alpha3.MultiBranchPipelineType,
+		},
+	}
+
+	generalPipeline := &v1alpha3.Pipeline{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "fake-pipeline",
+			Namespace: "fake-namespace",
+		},
+		Spec: v1alpha3.PipelineSpec{
+			Type: v1alpha3.NoScmPipelineType,
+		},
+	}
+
+	type args struct {
+		pipeline *v1alpha3.Pipeline
+		run      *job.PipelineRun
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *prv1alpha3.PipelineRun
+		wantErr bool
+	}{{
+		name: "Multi-branch pipeline",
+		args: args{
+			pipeline: multiBranchPipeline,
+			run: &job.PipelineRun{
+				ID: "123",
+				Branch: map[string]interface{}{
+					"url": "main",
+				},
+			},
+		},
+		want: &prv1alpha3.PipelineRun{
+			ObjectMeta: v1.ObjectMeta{
+				Name:         "fake-pipeline-main-123",
+				Namespace:    "fake-namespace",
+				GenerateName: "",
+				OwnerReferences: []v1.OwnerReference{
+					*v1.NewControllerRef(multiBranchPipeline, multiBranchPipeline.GroupVersionKind()),
+				},
+				Annotations: map[string]string{
+					prv1alpha3.JenkinsPipelineRunIDKey: "123",
+				},
+			},
+			Spec: prv1alpha3.PipelineRunSpec{
+				SCM: &prv1alpha3.SCM{
+					RefName: "main",
+					RefType: "",
+				},
+				PipelineRef: &corev1.ObjectReference{
+					Namespace: "fake-namespace",
+					Name:      "fake-pipeline",
+				},
+				PipelineSpec: &multiBranchPipeline.Spec,
+			},
+		},
+	},
+		{
+			name: "No SCM pipeline",
+			args: args{
+				pipeline: generalPipeline,
+				run: &job.PipelineRun{
+					ID: "123",
+				},
+			},
+			want: &prv1alpha3.PipelineRun{
+				ObjectMeta: v1.ObjectMeta{
+					Name:         "fake-pipeline-123",
+					Namespace:    "fake-namespace",
+					GenerateName: "",
+					OwnerReferences: []v1.OwnerReference{
+						*v1.NewControllerRef(generalPipeline, generalPipeline.GroupVersionKind()),
+					},
+					Annotations: map[string]string{
+						prv1alpha3.JenkinsPipelineRunIDKey: "123",
+					},
+				},
+				Spec: prv1alpha3.PipelineRunSpec{
+					PipelineRef: &corev1.ObjectReference{
+						Namespace: "fake-namespace",
+						Name:      "fake-pipeline",
+					},
+					PipelineSpec: &generalPipeline.Spec,
+				},
+			},
+		}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := createBarePipelineRun(tt.args.pipeline, tt.args.run)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createBarePipelineRun() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("createBarePipelineRun() = \n%v, want \n%v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
@@ -131,9 +131,8 @@ func Test_createBarePipelineRun(t *testing.T) {
 		},
 		want: &prv1alpha3.PipelineRun{
 			ObjectMeta: v1.ObjectMeta{
-				Name:         "fake-pipeline-main-123",
 				Namespace:    "fake-namespace",
-				GenerateName: "",
+				GenerateName: "fake-pipeline-",
 				OwnerReferences: []v1.OwnerReference{
 					*v1.NewControllerRef(multiBranchPipeline, multiBranchPipeline.GroupVersionKind()),
 				},
@@ -164,9 +163,9 @@ func Test_createBarePipelineRun(t *testing.T) {
 			},
 			want: &prv1alpha3.PipelineRun{
 				ObjectMeta: v1.ObjectMeta{
-					Name:         "fake-pipeline-123",
+					Name:         "",
 					Namespace:    "fake-namespace",
-					GenerateName: "",
+					GenerateName: "fake-pipeline-",
 					OwnerReferences: []v1.OwnerReference{
 						*v1.NewControllerRef(generalPipeline, generalPipeline.GroupVersionKind()),
 					},

--- a/controllers/jenkins/pipelinerun/utils.go
+++ b/controllers/jenkins/pipelinerun/utils.go
@@ -39,7 +39,7 @@ func (result JenkinsRunResult) String() string {
 
 // pipelineBuildApplier applies PipelineBuilder to PipelineRunStatus.
 type pipelineBuildApplier struct {
-	*job.PipelineBuild
+	*job.PipelineRun
 }
 
 func (pbApplier pipelineBuildApplier) apply(prStatus *v1alpha3.PipelineRunStatus) {

--- a/controllers/jenkins/pipelinerun/utils_test.go
+++ b/controllers/jenkins/pipelinerun/utils_test.go
@@ -12,7 +12,7 @@ import (
 
 func Test_pipelineBuildApplier_apply(t *testing.T) {
 	type fields struct {
-		pb *job.PipelineBuild
+		pb *job.PipelineRun
 	}
 	type args struct {
 		prStatus *v1alpha3.PipelineRunStatus
@@ -33,7 +33,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}{{
 		name: "PipelineRun was in queue",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:    "1",
 				State: Queued.String(),
 			},
@@ -50,7 +50,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was running",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:    "1",
 				State: Running.String(),
 			},
@@ -67,7 +67,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was paused",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:    "1",
 				State: Paused.String(),
 			},
@@ -84,7 +84,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was skipped",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:    "1",
 				State: Skipped.String(),
 			},
@@ -101,7 +101,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was not built",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:    "1",
 				State: NotBuiltState.String(),
 			},
@@ -118,7 +118,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "Unknown PipelineRun state",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:    "1",
 				State: "this_is_an_invalid_state",
 			},
@@ -135,7 +135,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was finished with succeeded result",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:      "1",
 				State:   Finished.String(),
 				Result:  Success.String(),
@@ -155,7 +155,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was finished but with unstable result",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:     "1",
 				State:  Finished.String(),
 				Result: Unstable.String(),
@@ -173,7 +173,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was finished but failed",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:     "1",
 				State:  Finished.String(),
 				Result: Failure.String(),
@@ -191,7 +191,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was finished but with not built result",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:     "1",
 				State:  Finished.String(),
 				Result: NotBuiltResult.String(),
@@ -209,7 +209,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was finished but with unknown result",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:     "1",
 				State:  Finished.String(),
 				Result: Unknown.String(),
@@ -227,7 +227,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun was finished but with aborted result",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:     "1",
 				State:  Finished.String(),
 				Result: Aborted.String(),
@@ -245,7 +245,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	}, {
 		name: "PipelineRun with new condition",
 		fields: fields{
-			pb: &job.PipelineBuild{
+			pb: &job.PipelineRun{
 				ID:     "1",
 				State:  Finished.String(),
 				Result: Success.String(),
@@ -274,7 +274,7 @@ func Test_pipelineBuildApplier_apply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pbApplier := &pipelineBuildApplier{
-				PipelineBuild: tt.fields.pb,
+				PipelineRun: tt.fields.pb,
 			}
 			pbApplier.apply(tt.args.prStatus)
 			tt.assertion(tt.args.prStatus)

--- a/controllers/pipeline/pipeline_controller.go
+++ b/controllers/pipeline/pipeline_controller.go
@@ -19,12 +19,13 @@ package pipeline
 import (
 	"context"
 	"fmt"
-	"kubesphere.io/devops/pkg/utils"
-	"kubesphere.io/devops/pkg/utils/k8sutil"
-	"kubesphere.io/devops/pkg/utils/sliceutil"
 	"net/http"
 	"reflect"
 	"time"
+
+	"kubesphere.io/devops/pkg/utils"
+	"kubesphere.io/devops/pkg/utils/k8sutil"
+	"kubesphere.io/devops/pkg/utils/sliceutil"
 
 	"github.com/emicklei/go-restful"
 	v1 "k8s.io/api/core/v1"
@@ -196,10 +197,6 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
 
 	<-stopCh
 	return nil
-}
-
-func (c *Controller) syncPipelineRuns() {
-
 }
 
 // syncHandler compares the actual state with the desired, and attempts to

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/jenkins-zh/jenkins-client v0.0.3-0.20210915103438-8d848a9886c2
+	github.com/jenkins-zh/jenkins-client v0.0.3
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jenkins-zh/jenkins-cli v0.0.32/go.mod h1:uE1mH9PNITrg0sugv6HXuM/CSddg0zxXoYu3w57I3JY=
-github.com/jenkins-zh/jenkins-client v0.0.3-0.20210915103438-8d848a9886c2 h1:MKy6LEFZZk4WaPPCn7z7QCGFcLEJYXjAvXsGxQbMtpM=
-github.com/jenkins-zh/jenkins-client v0.0.3-0.20210915103438-8d848a9886c2/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
+github.com/jenkins-zh/jenkins-client v0.0.3 h1:sLI0BksLd+NInZdhdyCE1wOEcBY2+D8leZ8pdLt33iM=
+github.com/jenkins-zh/jenkins-client v0.0.3/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
 github.com/jenkins-zh/jenkins-formulas v0.0.5/go.mod h1:zS8fm8u5L6FcjZM0QznXsLV9T2UtSVK+hT6Sm76iUZ4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/pkg/api/devops/v1alpha3/pipeline_types.go
+++ b/pkg/api/devops/v1alpha3/pipeline_types.go
@@ -34,6 +34,8 @@ const (
 	PipelineSyncStatusAnnoKey = PipelinePrefix + "syncstatus"
 	PipelineSyncTimeAnnoKey   = PipelinePrefix + "synctime"
 	PipelineSyncMsgAnnoKey    = PipelinePrefix + "syncmsg"
+	// PipelineRequestToSyncRunsAnnoKey is the key of requesting to synchronize PipelineRun after a dedicated time.
+	PipelineRequestToSyncRunsAnnoKey = PipelinePrefix + "request-to-sync-pipelineruns"
 )
 
 // PipelineSpec defines the desired state of Pipeline

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/util.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/util.go
@@ -59,7 +59,8 @@ func convertParameters(payload *devops.RunPayload) []prv1alpha3.Parameter {
 	return parameters
 }
 
-func getScm(ps *v1alpha3.PipelineSpec, branch string) (*prv1alpha3.SCM, error) {
+// CreateScm creates SCM for multi-branch Pipeline.
+func CreateScm(ps *v1alpha3.PipelineSpec, branch string) (*prv1alpha3.SCM, error) {
 	var scm *prv1alpha3.SCM
 	if ps.Type == v1alpha3.MultiBranchPipelineType {
 		if branch == "" {
@@ -83,7 +84,8 @@ func getPipelineRef(pipeline *v1alpha3.Pipeline) *corev1.ObjectReference {
 	}
 }
 
-func createPipelineRun(pipeline *v1alpha3.Pipeline, payload *devops.RunPayload, scm *prv1alpha3.SCM) *prv1alpha3.PipelineRun {
+// CreatePipelineRun creates a bare PipelineRun.
+func CreatePipelineRun(pipeline *v1alpha3.Pipeline, payload *devops.RunPayload, scm *prv1alpha3.SCM) *prv1alpha3.PipelineRun {
 	controllerRef := metav1.NewControllerRef(pipeline, pipeline.GroupVersionKind())
 	return &prv1alpha3.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/util.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/util.go
@@ -3,6 +3,7 @@ package pipelinerun
 import (
 	"errors"
 	"fmt"
+
 	prv1alpha3 "kubesphere.io/devops/pkg/api/devops/pipelinerun/v1alpha3"
 
 	corev1 "k8s.io/api/core/v1"
@@ -89,9 +90,11 @@ func CreatePipelineRun(pipeline *v1alpha3.Pipeline, payload *devops.RunPayload, 
 	controllerRef := metav1.NewControllerRef(pipeline, pipeline.GroupVersionKind())
 	return &prv1alpha3.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
+			// the name should be like "pipeline-xyzmnt", so we set generate name "pipeline-" here.
 			GenerateName:    pipeline.GetName() + "-",
 			Namespace:       pipeline.GetNamespace(),
 			OwnerReferences: []metav1.OwnerReference{*controllerRef},
+			Annotations:     map[string]string{},
 		},
 		Spec: prv1alpha3.PipelineRunSpec{
 			PipelineRef:  getPipelineRef(pipeline),


### PR DESCRIPTION
### What this PR dose

Provide Pipeline Synchronizer to synchronize PipelineRun from Jenkins.

### Why we need it

After we've done https://github.com/kubesphere/ks-devops/issues/41, we will missing some Jenkins runs which are triggered automatically or old data. So we need a synchronizer to ensure that we can convert them into PipelineRun.

### Special notes

This is the final effect:

![7b3d61a2630705ca6da5611519da075](https://user-images.githubusercontent.com/16865714/133867582-7479c829-6c2e-4189-8f31-c753f6122f44.png)

### Steps to test

Replace the docker image of `devops-apiserver` and `devops-controller` with `johnniang/devops-apiserver:pipelinerun-syncer` and `johnniang/devops-controller:pipelinerun-syncer` respectively.

/kind feature