### PR TITLE
Bump go version from 1.13 to 1.16

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -226,10 +226,10 @@ jobs:
     name: Test
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.13
+          go-version: 1.16
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,10 +10,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.13
+          go-version: 1.16
       - uses: actions/checkout@v2
       # See also https://github.com/GoogleCloudPlatform/golang-samples/blob/78dfa41f10b449ba7a06d9793cbd81878d44a4fb/.github/workflows/go.yaml#L29-L53
       - name: Run go mod tidy on root modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome to go through the contribution guide!
 
 Before you get started to contribute. Please the following requirements:
 
-* [Golang](https://golang.org/) 1.13
+* [Golang](https://golang.org/) 1.16
 
 | Technical area | Level requires | Links |
 |---|---|---|

--- a/config/dockerfiles/apiserver/Dockerfile
+++ b/config/dockerfiles/apiserver/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 ARG GOPROXY
 WORKDIR /workspace

--- a/config/dockerfiles/controller-manager/Dockerfile
+++ b/config/dockerfiles/controller-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 ARG GOPROXY
 WORKDIR /workspace

--- a/config/dockerfiles/tools/Dockerfile
+++ b/config/dockerfiles/tools/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 ARG GOPROXY
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubesphere.io/devops
 
-go 1.13
+go 1.16
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20210524144015-27119551aaea

--- a/go.sum
+++ b/go.sum
@@ -604,7 +604,6 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCc
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
### What this PR dose

Bump go version from 1.13 to 1.16

### Why we need it

Some new features of go have been released in go 1.16 and some dependency are using go 1.16, like [jenkins-zh/jenkins-client](https://github.com/jenkins-zh/jenkins-client).

/kind chore