### PR TITLE
Add shortNames,category for pipeline and pipelinerun

### DIFF
--- a/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
+++ b/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
@@ -10,9 +10,13 @@ metadata:
 spec:
   group: devops.kubesphere.io
   names:
+    categories:
+    - devops
     kind: PipelineRun
     listKind: PipelineRunList
     plural: pipelineruns
+    shortNames:
+    - pr
     singular: pipelinerun
   scope: Namespaced
   versions:

--- a/config/crd/bases/devops.kubesphere.io_pipelines.yaml
+++ b/config/crd/bases/devops.kubesphere.io_pipelines.yaml
@@ -10,9 +10,13 @@ metadata:
 spec:
   group: devops.kubesphere.io
   names:
+    categories:
+    - devops
     kind: Pipeline
     listKind: PipelineList
     plural: pipelines
+    shortNames:
+    - pip
     singular: pipeline
   scope: Namespaced
   versions:

--- a/pkg/api/devops/v1alpha3/pipeline_types.go
+++ b/pkg/api/devops/v1alpha3/pipeline_types.go
@@ -60,6 +60,7 @@ type PipelineStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`,description="The type of a Pipeline"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of a Pipeline"
+// +kubebuilder:resource:shortName="pip",categories="devops"
 type Pipeline struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/api/devops/v1alpha3/pipelinerun_types.go
+++ b/pkg/api/devops/v1alpha3/pipelinerun_types.go
@@ -78,7 +78,7 @@ type PipelineRunStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The phase of a PipelineRun"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of a PipelineRun"
-
+// +kubebuilder:resource:shortName="pr",categories="devops"
 // PipelineRun is the Schema for the pipelineruns API
 type PipelineRun struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Get pipelines from a shortName:
```shell
➜  ks git:(dashboard) ks get pip --all-namespaces
NAMESPACE         NAME           TYPE                    AGE
godlpfcg          test           pipeline                29h
godlpfcg          gitlab         multi-branch-pipeline   26h
queenglory4zjpr   servantsolar   pipeline                6h42m
```

Get pipelineruns from a shortName:
```shell
➜  ks git:(dashboard) ks get pr --all-namespaces
NAMESPACE         NAME                PHASE       AGE
hellohb82v        craneglowts8xz      Succeeded   46h
godlpfcg          test-g7m8w          Succeeded   29h
hellohb82v        craneglowwv2zx      Succeeded   46h
```

Get pipeline and pipelienruns via category `devops`:
```shell
➜  ks git:(dashboard) ks get devops --all-namespaces
NAMESPACE         NAME                                         TYPE                    AGE
godlpfcg          pipeline.devops.kubesphere.io/test           pipeline                29h
godlpfcg          pipeline.devops.kubesphere.io/gitlab         multi-branch-pipeline   26h
queenglory4zjpr   pipeline.devops.kubesphere.io/servantsolar   pipeline                6h39m
hellohb82v        pipeline.devops.kubesphere.io/craneglow      pipeline                47h

NAMESPACE   NAME                                                 AGE
            devopsproject.devops.kubesphere.io/hellohb82v        47h
            devopsproject.devops.kubesphere.io/godlpfcg          30h
            devopsproject.devops.kubesphere.io/queenglory4zjpr   6h39m

NAMESPACE         NAME                                                 PHASE       AGE
hellohb82v        pipelinerun.devops.kubesphere.io/craneglowts8xz      Succeeded   46h
godlpfcg          pipelinerun.devops.kubesphere.io/test-g7m8w          Succeeded   29h
hellohb82v        pipelinerun.devops.kubesphere.io/craneglowwv2zx      Succeeded   46h
```
