### PR TITLE
Provide Pipeline metadata controller to update metadata from Jenkins

### DIFF
--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -23,6 +23,7 @@ import (
 	"kubesphere.io/devops/controllers/devopscredential"
 	"kubesphere.io/devops/controllers/devopsproject"
 	"kubesphere.io/devops/controllers/jenkins/config"
+	jenkinspipeline "kubesphere.io/devops/controllers/jenkins/pipeline"
 	"kubesphere.io/devops/controllers/jenkins/pipelinerun"
 	"kubesphere.io/devops/controllers/pipeline"
 	"kubesphere.io/devops/controllers/s2ibinary"
@@ -104,6 +105,14 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 			JenkinsCore: jenkinsCore,
 		}).SetupWithManager(mgr); err != nil {
 			klog.Errorf("unable to create pipelinerun-synchronizer, err: %v", err)
+			return err
+		}
+
+		// add Pipeline metadata controller
+		if err := (&jenkinspipeline.Reconciler{
+			Client:      mgr.GetClient(),
+			JenkinsCore: jenkinsCore,
+		}).SetupWithManager(mgr); err != nil {
 			return err
 		}
 	}

--- a/controllers/jenkins/pipeline/metadata_converter.go
+++ b/controllers/jenkins/pipeline/metadata_converter.go
@@ -1,0 +1,46 @@
+package pipeline
+
+import "github.com/jenkins-zh/jenkins-client/pkg/job"
+
+// metadata holds some of pipeline fields that are only things we needed instead of whole job.Pipeline.
+type metadata struct {
+	WeatherScore                   int                       `json:"weatherScore,omitempty"`
+	EstimatedDurationInMillis      int64                     `json:"estimatedDurationInMillis,omitempty"`
+	Parameters                     []job.ParameterDefinition `json:"parameters,omitempty"`
+	Name                           string                    `json:"name,omitempty"`
+	Disabled                       bool                      `json:"disabled,omitempty"`
+	NumberOfPipelines              int                       `json:"numberOfPipelines,omitempty"`
+	NumberOfFolders                int                       `json:"numberOfFolders,omitempty"`
+	PipelineFolderNames            []string                  `json:"pipelineFolderNames,omitempty"`
+	TotalNumberOfBranches          int                       `json:"totalNumberOfBranches,omitempty"`
+	NumberOfFailingBranches        int                       `json:"numberOfFailingBranches,omitempty"`
+	NumberOfSuccessfulBranches     int                       `json:"numberOfSuccessfulBranches,omitempty"`
+	TotalNumberOfPullRequests      int                       `json:"totalNumberOfPullRequests,omitempty"`
+	NumberOfFailingPullRequests    int                       `json:"numberOfFailingPullRequests,omitempty"`
+	NumberOfSuccessfulPullRequests int                       `json:"numberOfSuccessfulPullRequests,omitempty"`
+	BranchNames                    []string                  `json:"branchNames,omitempty"`
+	SCMSource                      *job.SCMSource            `json:"scmSource,omitempty"`
+	ScriptPath                     string                    `json:"scriptPath,omitempty"`
+}
+
+func convert(jobPipeline *job.Pipeline) *metadata {
+	return &metadata{
+		WeatherScore:                   jobPipeline.WeatherScore,
+		EstimatedDurationInMillis:      jobPipeline.EstimatedDurationInMillis,
+		Parameters:                     jobPipeline.Parameters,
+		Name:                           jobPipeline.Name,
+		Disabled:                       jobPipeline.Disabled,
+		NumberOfPipelines:              jobPipeline.NumberOfPipelines,
+		NumberOfFolders:                jobPipeline.NumberOfFolders,
+		PipelineFolderNames:            jobPipeline.PipelineFolderNames,
+		TotalNumberOfBranches:          jobPipeline.TotalNumberOfBranches,
+		TotalNumberOfPullRequests:      jobPipeline.TotalNumberOfPullRequests,
+		NumberOfFailingBranches:        jobPipeline.NumberOfFailingBranches,
+		NumberOfFailingPullRequests:    jobPipeline.NumberOfFailingPullRequests,
+		NumberOfSuccessfulBranches:     jobPipeline.NumberOfSuccessfulBranches,
+		NumberOfSuccessfulPullRequests: jobPipeline.NumberOfSuccessfulPullRequests,
+		BranchNames:                    jobPipeline.BranchNames,
+		SCMSource:                      jobPipeline.SCMSource,
+		ScriptPath:                     jobPipeline.ScriptPath,
+	}
+}

--- a/controllers/jenkins/pipeline/pipeline_metadata_controller.go
+++ b/controllers/jenkins/pipeline/pipeline_metadata_controller.go
@@ -68,7 +68,8 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
-func (r *Reconciler) updateMetadata(metadata *job.Pipeline, pipelineKey client.ObjectKey) error {
+func (r *Reconciler) updateMetadata(jobPipeline *job.Pipeline, pipelineKey client.ObjectKey) error {
+	metadata := convert(jobPipeline)
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		pipeline := &v1alpha3.Pipeline{}
 		if err := r.Get(context.Background(), pipelineKey, pipeline); err != nil {

--- a/controllers/jenkins/pipeline/pipeline_metadata_controller.go
+++ b/controllers/jenkins/pipeline/pipeline_metadata_controller.go
@@ -19,7 +19,9 @@ import (
 )
 
 const (
-	MetaUpdated      = "MetaUpdated"
+	// MetaUpdated indicates the metadata of Pipeline has updated into annotations of Pipeline CR.
+	MetaUpdated = "MetaUpdated"
+	// FailedMetaUpdate indicates the controller fails to update metadata of Pipeline.
 	FailedMetaUpdate = "FailedMetaUpdate"
 )
 
@@ -109,6 +111,7 @@ var pipelineMetadataPredicate = predicate.Funcs{
 	},
 }
 
+// SetupWithManager setups reconciler with controller manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.recorder = mgr.GetEventRecorderFor("pipeline-metadata-controller")
 	r.log = ctrl.Log.WithName("pipeline-metadata-controller")

--- a/controllers/jenkins/pipeline/pipeline_metadata_controller.go
+++ b/controllers/jenkins/pipeline/pipeline_metadata_controller.go
@@ -1,0 +1,109 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
+	"github.com/jenkins-zh/jenkins-client/pkg/job"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Reconciler reconciles metadata of Pipeline.
+type Reconciler struct {
+	client.Client
+	JenkinsCore core.JenkinsCore
+	recorder    record.EventRecorder
+	log         logr.Logger
+}
+
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=pipelines,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=pipelines/status,verbs=get;update;patch
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	// log := r.log.WithValues("Pipeline", req.NamespacedName)
+	pipeline := &v1alpha3.Pipeline{}
+	if err := r.Get(ctx, req.NamespacedName, pipeline); err != nil {
+		// ignore resource not found due to deletion
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	// fetch pipeline metadata from Jenkins
+	boClient := job.BlueOceanClient{
+		JenkinsCore:  r.JenkinsCore,
+		Organization: "jenkins",
+	}
+	pipelineMetadata, err := boClient.GetPipeline(pipeline.Name)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// update pipeline metadata
+	if err := r.updateMetadata(pipelineMetadata, req.NamespacedName); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// re-synch after 10 seconds
+	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+func (r *Reconciler) updateMetadata(metadata *job.Pipeline, pipelineKey client.ObjectKey) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pipeline := &v1alpha3.Pipeline{}
+		if err := r.Get(context.Background(), pipelineKey, pipeline); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		metadataJSON, err := json.Marshal(metadata)
+		if err != nil {
+			return err
+		}
+		// diff pipeline metadata
+		if pipeline.Annotations[v1alpha3.PipelineJenkinsMetadataAnnoKey] == string(metadataJSON) {
+			// skip updation if metadata unchanged
+			return nil
+		}
+		// update annotations
+		if pipeline.Annotations == nil {
+			pipeline.Annotations = map[string]string{}
+		}
+		pipeline.Annotations[v1alpha3.PipelineJenkinsMetadataAnnoKey] = string(metadataJSON)
+		return r.Update(context.Background(), pipeline)
+	})
+}
+
+// getPipelineMetadataPredicate returns a predicate which only cares CreateEvent and GenericEvent.
+func getPipelineMetadataPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(ce event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(de event.DeleteEvent) bool {
+			return false
+		},
+		UpdateFunc: func(ue event.UpdateEvent) bool {
+			return false
+		},
+		GenericFunc: func(ge event.GenericEvent) bool {
+			return true
+		},
+	}
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.recorder = mgr.GetEventRecorderFor("pipeline-metadata-controller")
+	r.log = ctrl.Log.WithName("pipeline-metadata-controller")
+	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(getPipelineMetadataPredicate()).
+		For(&v1alpha3.Pipeline{}).
+		Complete(r)
+}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/jenkins-zh/jenkins-client v0.0.3
+	github.com/jenkins-zh/jenkins-client v0.0.4
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
@@ -52,7 +52,6 @@ require (
 replace (
 	github.com/golang/example => github.com/golang/example v0.0.0-20170904185048-46695d81d1fa
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.0
-	github.com/jenkins-zh/jenkins-client => github.com/johnniang/jenkins-client v0.0.0-20210928142137-4e7111402985
 	github.com/kubesphere/sonargo => github.com/kubesphere/sonargo v0.0.2
 	k8s.io/api => k8s.io/api v0.18.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.6

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 replace (
 	github.com/golang/example => github.com/golang/example v0.0.0-20170904185048-46695d81d1fa
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.0
-	github.com/jenkins-zh/jenkins-client => github.com/johnniang/jenkins-client v0.0.0-20210928082423-310f968b9fab
+	github.com/jenkins-zh/jenkins-client => github.com/johnniang/jenkins-client v0.0.0-20210928142137-4e7111402985
 	github.com/kubesphere/sonargo => github.com/kubesphere/sonargo v0.0.2
 	k8s.io/api => k8s.io/api v0.18.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.6

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 replace (
 	github.com/golang/example => github.com/golang/example v0.0.0-20170904185048-46695d81d1fa
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.0
+	github.com/jenkins-zh/jenkins-client => github.com/johnniang/jenkins-client v0.0.0-20210928082423-310f968b9fab
 	github.com/kubesphere/sonargo => github.com/kubesphere/sonargo v0.0.2
 	k8s.io/api => k8s.io/api v0.18.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,6 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jenkins-zh/jenkins-cli v0.0.32/go.mod h1:uE1mH9PNITrg0sugv6HXuM/CSddg0zxXoYu3w57I3JY=
-github.com/jenkins-zh/jenkins-client v0.0.3 h1:sLI0BksLd+NInZdhdyCE1wOEcBY2+D8leZ8pdLt33iM=
-github.com/jenkins-zh/jenkins-client v0.0.3/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
 github.com/jenkins-zh/jenkins-formulas v0.0.5/go.mod h1:zS8fm8u5L6FcjZM0QznXsLV9T2UtSVK+hT6Sm76iUZ4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
@@ -326,6 +324,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/johnniang/jenkins-client v0.0.0-20210928082423-310f968b9fab h1:qCN02u3n4nw4sLJYLF+c/JmO0mobrMxrSLVku+adPlY=
+github.com/johnniang/jenkins-client v0.0.0-20210928082423-310f968b9fab/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/johnniang/jenkins-client v0.0.0-20210928082423-310f968b9fab h1:qCN02u3n4nw4sLJYLF+c/JmO0mobrMxrSLVku+adPlY=
-github.com/johnniang/jenkins-client v0.0.0-20210928082423-310f968b9fab/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
+github.com/johnniang/jenkins-client v0.0.0-20210928142137-4e7111402985 h1:h+xvw5gzyTFmUhboMZ/CY+GUqLG7obWDWadNCJGcKvg=
+github.com/johnniang/jenkins-client v0.0.0-20210928142137-4e7111402985/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/go.sum
+++ b/go.sum
@@ -317,6 +317,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jenkins-zh/jenkins-cli v0.0.32/go.mod h1:uE1mH9PNITrg0sugv6HXuM/CSddg0zxXoYu3w57I3JY=
+github.com/jenkins-zh/jenkins-client v0.0.4 h1:CFwc8DzPEReoCaXDS354E1TEDBwpVINeCMN1Vdng57U=
+github.com/jenkins-zh/jenkins-client v0.0.4/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
 github.com/jenkins-zh/jenkins-formulas v0.0.5/go.mod h1:zS8fm8u5L6FcjZM0QznXsLV9T2UtSVK+hT6Sm76iUZ4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
@@ -324,8 +326,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/johnniang/jenkins-client v0.0.0-20210928142137-4e7111402985 h1:h+xvw5gzyTFmUhboMZ/CY+GUqLG7obWDWadNCJGcKvg=
-github.com/johnniang/jenkins-client v0.0.0-20210928142137-4e7111402985/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/pkg/api/devops/v1alpha3/pipeline_types.go
+++ b/pkg/api/devops/v1alpha3/pipeline_types.go
@@ -34,6 +34,8 @@ const (
 	PipelineSyncStatusAnnoKey = PipelinePrefix + "syncstatus"
 	PipelineSyncTimeAnnoKey   = PipelinePrefix + "synctime"
 	PipelineSyncMsgAnnoKey    = PipelinePrefix + "syncmsg"
+	// PipelineJenkinsMetadataAnnoKey is the key of Jenkins Pipeline data.
+	PipelineJenkinsMetadataAnnoKey = PipelinePrefix + "jenkins-metadata"
 	// PipelineRequestToSyncRunsAnnoKey is the key of requesting to synchronize PipelineRun after a dedicated time.
 	PipelineRequestToSyncRunsAnnoKey = PipelinePrefix + "request-to-sync-pipelineruns"
 )


### PR DESCRIPTION
### What this PR dose / why we need it?

Provide Pipeline metadata controller to update metadata from Jenkins in every 10 seconds.

And this controller only cares about the newly created Pipelines and the Pipelines that can be obtained when it is restarted.

### Steps to test

1. Replace devops controller with docker image `johnniang/devops-controller:dev-v3.2.0-alpha.0-ca751a7`
2. See annotations of Pipeline resources

### TODO

- [ ] Bump version of Jenkins client after https://github.com/jenkins-zh/jenkins-client/pull/27 gets merged

/kind feature