### PR TITLE
Enable exported rule of revive for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,7 +96,54 @@ run:
     - pkg/server/params/params.go
     - pkg/utils/idutils/id_utils.go
     - pkg/utils/idutils/id_utils_test.go
-
+    - pkg/client/sonarqube/options.go
+    - pkg/client/sonarqube/sonarqube.go
+    - pkg/client/cache/simple_cache.go
+    - pkg/kapis/devops/v1alpha2.handler.go
+    - pkg/client/s3/s3.go
+    - pkg/utils/reflectutils/deep.go
+    - pkg/models/auth/token.go
+    - pkg/utils/hash.go
+    - pkg/utils/sliceutil/sliceutils.go
+    - pkg/apiserver/authentication/options/authenticate_options.go
+    - pkg/client/cache/redis.go
+    - pkg/models/devops/s2ibinary_handler.go
+    - pkg/client/devops/jenkins/options.go
+    - pkg/client/devops/jenkins/role.go
+    - pkg/client/devops/role.go
+    - pkg/api/devops/v1alpha3/devopsproject_types.go
+    - pkg/client/devops/jenkins/internal/pull_request.go
+    - controllers/fake_controller.go
+    - controllers/s2irun/s2irun_controller.go
+    - pkg/client/s3/interface.go
+    - pkg/client/k8s/options.go
+    - pkg/models/devops/jkerror.go
+    - pkg/client/devops/jenkins/devops.go
+    - pkg/utils/reflectutils/reflect.go
+    - pkg/api/devops/v1alpha1/s2ibinary_type.go
+    - pkg/client/devops/interface.go
+    - pkg/utils/stringutils/string.go
+    - pkg/models/resources/v1alpha3/devops/devops.go
+    - pkg/models/resources/v1alpha3/interface.go
+    - pkg/apiserver/query/field.go
+    - pkg/api/utils.go
+    - pkg/utils/readerutils/MD5Reader.go
+    - cmd/controller/app/options/options.go
+    - cmd/tools/jwt/app/kubernetes.go
+    - cmd/apiserver/app/options/options.go
+    - pkg/utils/net/net.go
+    - pkg/utils/hashutil/MD5.go
+    - pkg/kapis/oauth/register.go
+    - pkg/apiserver/authentication/authenticators/bearertoken/bearertoken.go
+    - pkg/apiserver/authentication/request/anonymous/anonymous.go
+    - pkg/client/cache/options.go
+    - pkg/api/devops/v1alpha1/s2ibuildertemplate_types.go
+    - pkg/api/devops/v1alpha1/s2ibinary_types.go
+    - pkg/client/cache/cache.go
+issues:
+  exclude:
+    - EXC0012
+  exclude-use-default: false
 linters:
   enable:
     - revive # replacement for golint

--- a/controllers/jenkins/pipelinerun/pipelinerun_controller.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller.go
@@ -146,7 +146,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		if pipelineRunCopied.Annotations == nil {
 			pipelineRunCopied.Annotations = make(map[string]string)
 		}
-		pipelineRunCopied.Annotations[v1alpha3.JenkinsPipelineRunStatusKey] = string(runResultJSON)
+		pipelineRunCopied.Annotations[v1alpha3.JenkinsPipelineRunStatusAnnoKey] = string(runResultJSON)
 		pipelineRunCopied.Annotations[v1alpha3.JenkinsPipelineRunStagesStatusKey] = string(prNodesJSON)
 
 		// update PipelineRun
@@ -197,7 +197,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if pipelineRunCopied.Annotations == nil {
 		pipelineRunCopied.Annotations = make(map[string]string)
 	}
-	pipelineRunCopied.Annotations[v1alpha3.JenkinsPipelineRunIDKey] = jobRun.ID
+	pipelineRunCopied.Annotations[v1alpha3.JenkinsPipelineRunIDAnnoKey] = jobRun.ID
 
 	// the Update method only updates fields except subresource: status
 	if err := r.updateLabelsAndAnnotations(ctx, pipelineRunCopied); err != nil {

--- a/controllers/jenkins/pipelinerun/pipelinerun_controller_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller_test.go
@@ -121,7 +121,7 @@ func Test_getJenkinsBuildNumber(t *testing.T) {
 			pipelineRun: &v1alpha3.PipelineRun{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
-						v1alpha3.JenkinsPipelineRunIDKey: "a",
+						v1alpha3.JenkinsPipelineRunIDAnnoKey: "a",
 					},
 				},
 			},
@@ -133,7 +133,7 @@ func Test_getJenkinsBuildNumber(t *testing.T) {
 			pipelineRun: &v1alpha3.PipelineRun{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
-						v1alpha3.JenkinsPipelineRunIDKey: "2",
+						v1alpha3.JenkinsPipelineRunIDAnnoKey: "2",
 					},
 				},
 			},
@@ -203,7 +203,7 @@ var _ = Describe("Test deleteJenkinsJobHistory", func() {
 			ObjectMeta: v1.ObjectMeta{
 				Namespace: namespace,
 				Annotations: map[string]string{
-					v1alpha3.JenkinsPipelineRunIDKey: "2",
+					v1alpha3.JenkinsPipelineRunIDAnnoKey: "2",
 				},
 			},
 			Spec: v1alpha3.PipelineRunSpec{
@@ -244,7 +244,7 @@ var _ = Describe("Test deleteJenkinsJobHistory", func() {
 			ObjectMeta: v1.ObjectMeta{
 				Namespace: namespace,
 				Annotations: map[string]string{
-					v1alpha3.JenkinsPipelineRunIDKey: "2",
+					v1alpha3.JenkinsPipelineRunIDAnnoKey: "2",
 				},
 			},
 			Spec: v1alpha3.PipelineRunSpec{
@@ -285,7 +285,7 @@ var _ = Describe("Test deleteJenkinsJobHistory", func() {
 			ObjectMeta: v1.ObjectMeta{
 				Namespace: namespace,
 				Annotations: map[string]string{
-					v1alpha3.JenkinsPipelineRunIDKey: "2",
+					v1alpha3.JenkinsPipelineRunIDAnnoKey: "2",
 				},
 			},
 			Spec: v1alpha3.PipelineRunSpec{
@@ -334,7 +334,7 @@ var _ = Describe("TestReconciler_hasSamePipelineRun", func() {
 				Name:      "pipeline-run-2",
 				Namespace: "default",
 				Annotations: map[string]string{
-					v1alpha3.JenkinsPipelineRunIDKey: "123",
+					v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 				},
 				Labels: map[string]string{
 					v1alpha3.PipelineNameLabelKey: "general-pipeline",
@@ -347,7 +347,7 @@ var _ = Describe("TestReconciler_hasSamePipelineRun", func() {
 				Name:      "pipeline-run-1",
 				Namespace: "default",
 				Annotations: map[string]string{
-					v1alpha3.JenkinsPipelineRunIDKey: "123",
+					v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 				},
 				Labels: map[string]string{
 					v1alpha3.SCMRefNameLabelKey:   "main",

--- a/controllers/jenkins/pipelinerun/pipelinerun_finder.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_finder.go
@@ -30,7 +30,7 @@ func newPipelineRunFinder(pipelineRuns []v1alpha3.PipelineRun) pipelineRunFinder
 	for i := range pipelineRuns {
 		pipelineRun := pipelineRuns[i]
 		pipelineRunIdentity := pipelineRunIdentity{
-			id: pipelineRun.Annotations[v1alpha3.JenkinsPipelineRunIDKey],
+			id: pipelineRun.Annotations[v1alpha3.JenkinsPipelineRunIDAnnoKey],
 		}
 		if pipelineRun.Spec.SCM != nil {
 			pipelineRunIdentity.refName = pipelineRun.Spec.SCM.RefName

--- a/controllers/jenkins/pipelinerun/pipelinerun_finder_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_finder_test.go
@@ -14,7 +14,7 @@ var (
 		ObjectMeta: v1.ObjectMeta{
 			Name: "pipeline1",
 			Annotations: map[string]string{
-				v1alpha3.JenkinsPipelineRunIDKey: "123",
+				v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 			},
 		},
 	}
@@ -23,7 +23,7 @@ var (
 		ObjectMeta: v1.ObjectMeta{
 			Name: "pipeline11",
 			Annotations: map[string]string{
-				v1alpha3.JenkinsPipelineRunIDKey: "123",
+				v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 			},
 		},
 	}
@@ -32,7 +32,7 @@ var (
 		ObjectMeta: v1.ObjectMeta{
 			Name: "pipeline2",
 			Annotations: map[string]string{
-				v1alpha3.JenkinsPipelineRunIDKey: "456",
+				v1alpha3.JenkinsPipelineRunIDAnnoKey: "456",
 			},
 		},
 	}
@@ -41,7 +41,7 @@ var (
 		ObjectMeta: v1.ObjectMeta{
 			Name: "pipeline1",
 			Annotations: map[string]string{
-				v1alpha3.JenkinsPipelineRunIDKey: "123",
+				v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 			},
 		},
 		Spec: v1alpha3.PipelineRunSpec{
@@ -55,7 +55,7 @@ var (
 		ObjectMeta: v1.ObjectMeta{
 			Name: "pipeline11",
 			Annotations: map[string]string{
-				v1alpha3.JenkinsPipelineRunIDKey: "123",
+				v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 			},
 		},
 		Spec: v1alpha3.PipelineRunSpec{
@@ -69,7 +69,7 @@ var (
 		ObjectMeta: v1.ObjectMeta{
 			Name: "pipeline2",
 			Annotations: map[string]string{
-				v1alpha3.JenkinsPipelineRunIDKey: "456",
+				v1alpha3.JenkinsPipelineRunIDAnnoKey: "456",
 			},
 		},
 		Spec: v1alpha3.PipelineRunSpec{

--- a/controllers/jenkins/pipelinerun/pipelinerun_synchronizer.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_synchronizer.go
@@ -127,7 +127,7 @@ func createBarePipelineRun(pipeline *v1alpha3.Pipeline, run *job.PipelineRun) (*
 		scm.RefName = run.Pipeline
 	}
 	pr := pipelinerun.CreatePipelineRun(pipeline, nil, scm)
-	pr.Annotations[v1alpha3.JenkinsPipelineRunIDKey] = run.ID
+	pr.Annotations[v1alpha3.JenkinsPipelineRunIDAnnoKey] = run.ID
 	return pr, nil
 }
 

--- a/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
@@ -137,7 +137,7 @@ func Test_createBarePipelineRun(t *testing.T) {
 					*v1.NewControllerRef(multiBranchPipeline, multiBranchPipeline.GroupVersionKind()),
 				},
 				Annotations: map[string]string{
-					v1alpha3.JenkinsPipelineRunIDKey: "123",
+					v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 				},
 				Labels: map[string]string{
 					v1alpha3.PipelineNameLabelKey: "fake-pipeline",
@@ -174,7 +174,7 @@ func Test_createBarePipelineRun(t *testing.T) {
 						*v1.NewControllerRef(generalPipeline, generalPipeline.GroupVersionKind()),
 					},
 					Annotations: map[string]string{
-						v1alpha3.JenkinsPipelineRunIDKey: "123",
+						v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 					},
 					Labels: map[string]string{
 						v1alpha3.PipelineNameLabelKey: "fake-pipeline",

--- a/controllers/jenkins/pipelinerun/utils.go
+++ b/controllers/jenkins/pipelinerun/utils.go
@@ -8,32 +8,48 @@ import (
 	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
 )
 
+// JenkinsRunState represents current PipelineRun state.
 type JenkinsRunState string
 
 const (
-	Queued        JenkinsRunState = "QUEUED"
-	Running       JenkinsRunState = "RUNNING"
-	Paused        JenkinsRunState = "PAUSED"
-	Skipped       JenkinsRunState = "SKIPPED"
+	// Queued indicates the PipelineRun is queued.
+	Queued JenkinsRunState = "QUEUED"
+	// Running indicates the PipelineRun is running.
+	Running JenkinsRunState = "RUNNING"
+	// Paused indicates the PipelineRun has been paused.
+	Paused JenkinsRunState = "PAUSED"
+	// Skipped indicates the PipelineRun has been skipped.
+	Skipped JenkinsRunState = "SKIPPED"
+	// NotBuiltState indicates the PipelineRun hasn't been built yet.
 	NotBuiltState JenkinsRunState = "NOT_BUILT"
-	Finished      JenkinsRunState = "FINISHED"
+	// Finished indicates the PipelineRun has finished.
+	Finished JenkinsRunState = "FINISHED"
 )
 
+// String returns string value of state of PipelineRun.
 func (state JenkinsRunState) String() string {
 	return string(state)
 }
 
+// JenkinsRunResult represents result of PipelineRun.
 type JenkinsRunResult string
 
 const (
-	Success        JenkinsRunResult = "SUCCESS"
-	Unstable       JenkinsRunResult = "UNSTABLE"
-	Failure        JenkinsRunResult = "FAILURE"
+	// Success indicates the PipelineRun runs successfully.
+	Success JenkinsRunResult = "SUCCESS"
+	// Unstable indicates the PipelineRun runs with unstable result.
+	Unstable JenkinsRunResult = "UNSTABLE"
+	// Failure indicates the PipelineRun runs with failure.
+	Failure JenkinsRunResult = "FAILURE"
+	// NotBuiltResult indicates the PipelineRun hasn't been built but finishied.
 	NotBuiltResult JenkinsRunResult = "NOT_BUILT"
-	Unknown        JenkinsRunResult = "UNKNOWN"
-	Aborted        JenkinsRunResult = "ABORTED"
+	// Unknown indicates the PipelineRun hasn't running yet or runs with unknown result.
+	Unknown JenkinsRunResult = "UNKNOWN"
+	// Aborted indicates the PipelineRun runs with aborted result.
+	Aborted JenkinsRunResult = "ABORTED"
 )
 
+// String returns string value of result of PipelineRun.
 func (result JenkinsRunResult) String() string {
 	return string(result)
 }

--- a/pkg/api/devops/v1alpha3/groupversion_info.go
+++ b/pkg/api/devops/v1alpha3/groupversion_info.go
@@ -24,14 +24,19 @@ import (
 
 const (
 	// GroupName is the group name use in this package
-	GroupName                         = "devops.kubesphere.io"
-	JenkinsPipelineRunIDKey           = GroupName + "/jenkins-pipelinerun-id"
-	JenkinsPipelineRunStatusKey       = GroupName + "/jenkins-pipelinerun-status"
+	GroupName = "devops.kubesphere.io"
+	// JenkinsPipelineRunIDAnnoKey is annotation key of Jenkins PipelineRun ID.
+	JenkinsPipelineRunIDAnnoKey = GroupName + "/jenkins-pipelinerun-id"
+	// JenkinsPipelineRunStatusAnnoKey is annotation key of status of Jenkins PipelineRun.
+	JenkinsPipelineRunStatusAnnoKey = GroupName + "/jenkins-pipelinerun-status"
+	// JenkinsPipelineRunStagesStatusKey is annotation key of Jenkins stages' status of Jenkins PipelineRun.
 	JenkinsPipelineRunStagesStatusKey = GroupName + "/jenkins-pipelinerun-stages-status"
-	PipelineRunOrphanKey              = GroupName + "/jenkins-pipelinerun-orphan"
-
+	// PipelineRunOrphanLabelKey is label key of orphan Jenkins PipelineRun which type of value is bool.
+	PipelineRunOrphanLabelKey = GroupName + "/jenkins-pipelinerun-orphan"
+	// PipelineNameLabelKey is label key of Pipeline name.
 	PipelineNameLabelKey = GroupName + "/pipeline"
-	SCMRefNameLabelKey   = GroupName + "/scm-ref-name"
+	// SCMRefNameLabelKey is label key of SCM reference name.
+	SCMRefNameLabelKey = GroupName + "/scm-ref-name"
 )
 
 var (

--- a/pkg/client/devops/jenkins/configuration.go
+++ b/pkg/client/devops/jenkins/configuration.go
@@ -24,6 +24,7 @@ func (j *Jenkins) ReloadConfiguration() (err error) {
 	return
 }
 
+// CheckNewSource checks source of Configuration as Code from new location.
 func (j *Jenkins) CheckNewSource(source string) (err error) {
 	var response *http.Response
 	if response, err = j.Requester.PostForm(checkNewSourceEndpoint, nil, nil, map[string]string{
@@ -34,6 +35,7 @@ func (j *Jenkins) CheckNewSource(source string) (err error) {
 	return
 }
 
+// ApplyNewSource applies a new config file
 func (j *Jenkins) ApplyNewSource(source string) (err error) {
 	if err = j.CheckNewSource(source); err != nil {
 		err = fmt.Errorf("failed to check the new source: %s, error: %v", source, err)

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/backwardlisthandler.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/backwardlisthandler.go
@@ -43,7 +43,7 @@ func checkPipelineRun(object runtime.Object) (*v1alpha3.PipelineRun, bool) {
 
 func (b backwardListHandler) backwardFilter(object runtime.Object) bool {
 	if pr, valid := checkPipelineRun(object); valid {
-		return pr.Annotations[v1alpha3.JenkinsPipelineRunStatusKey] != ""
+		return pr.Annotations[v1alpha3.JenkinsPipelineRunStatusAnnoKey] != ""
 	}
 	return false
 }
@@ -54,7 +54,7 @@ func (b backwardListHandler) backwardTransformer(object runtime.Object) json.Mar
 		// should never happen
 		return json.RawMessage("{}")
 	}
-	runStatusJSON := pr.Annotations[v1alpha3.JenkinsPipelineRunStatusKey]
+	runStatusJSON := pr.Annotations[v1alpha3.JenkinsPipelineRunStatusAnnoKey]
 	rawRunStatus := json.RawMessage(runStatusJSON)
 	// check if the run status is a valid JSON
 	valid = json.Valid(rawRunStatus)

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/backwardlisthandler_test.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/backwardlisthandler_test.go
@@ -21,7 +21,7 @@ func Test_compatibleTransform(t *testing.T) {
 		obj: &v1alpha3.PipelineRun{
 			ObjectMeta: v1.ObjectMeta{
 				Annotations: map[string]string{
-					v1alpha3.JenkinsPipelineRunStatusKey: `{"id": "123"}`,
+					v1alpha3.JenkinsPipelineRunStatusAnnoKey: `{"id": "123"}`,
 				},
 			},
 		},
@@ -80,7 +80,7 @@ func Test_backwardFilter(t *testing.T) {
 			obj: &v1alpha3.PipelineRun{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
-						v1alpha3.JenkinsPipelineRunIDKey: "123",
+						v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 					},
 				},
 			},
@@ -92,7 +92,7 @@ func Test_backwardFilter(t *testing.T) {
 			obj: &v1alpha3.PipelineRun{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
-						v1alpha3.JenkinsPipelineRunStatusKey: `{"id": "123"}`,
+						v1alpha3.JenkinsPipelineRunStatusAnnoKey: `{"id": "123"}`,
 					},
 				},
 			},
@@ -105,8 +105,8 @@ func Test_backwardFilter(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name: "abc",
 					Annotations: map[string]string{
-						v1alpha3.JenkinsPipelineRunStatusKey: `{"id": "123"}`,
-						v1alpha3.JenkinsPipelineRunIDKey:     "123",
+						v1alpha3.JenkinsPipelineRunStatusAnnoKey: `{"id": "123"}`,
+						v1alpha3.JenkinsPipelineRunIDAnnoKey:     "123",
 					},
 				},
 			},
@@ -123,8 +123,8 @@ func Test_backwardFilter(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name: "abc",
 					Annotations: map[string]string{
-						v1alpha3.JenkinsPipelineRunStatusKey: `{"id": "123"}`,
-						v1alpha3.JenkinsPipelineRunIDKey:     "123",
+						v1alpha3.JenkinsPipelineRunStatusAnnoKey: `{"id": "123"}`,
+						v1alpha3.JenkinsPipelineRunIDAnnoKey:     "123",
 					},
 				},
 			},

--- a/pkg/utils/reflectutils/deep.go
+++ b/pkg/utils/reflectutils/deep.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package deep provides function deep.Equal which is like reflect.DeepEqual but
+// Package reflectutils deep provides function deep.Equal which is like reflect.DeepEqual but
 // returns a list of differences. This is helpful when comparing complex types
 // like structures and maps.
 package reflectutils


### PR DESCRIPTION
### What this PR dose / why we need it?

- Enable exported rule of revive for golangci-lint

> Please see https://golangci-lint.run/usage/configuration/#config-file

```yaml
issues:
  exclude:
    - EXC0012
  exclude-use-default: false
```

- Exclude some files by hand
- Add some comment on exported fields, functions and methods according to `golangci-lint`.

> But there is a discussion about the `exported` rule, please see
> - https://github.com/golangci/golangci-lint/issues/456.
> - https://github.com/golangci/golangci-lint/issues/2114#issuecomment-878937553

/kind cleanup
