### PR TITLE
Bump ks which in the tool image to v0.0.52

### DIFF
--- a/config/dockerfiles/tools/Dockerfile
+++ b/config/dockerfiles/tools/Dockerfile
@@ -18,8 +18,8 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o jwt cmd/tools/jwt/jwt_cmd.go
 
 FROM golang:1.16 as downloader
-RUN go install github.com/linuxsuren/http-downloader@v0.0.38
-RUN http-downloader install kubesphere-sigs/ks
+RUN go install github.com/linuxsuren/http-downloader@v0.0.41
+RUN http-downloader install kubesphere-sigs/ks@v0.0.52
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
See

* https://github.com/kubesphere-sigs/ks/releases
* https://github.com/kubesphere-sigs/ks/pull/219
* https://github.com/kubesphere-sigs/ks-devops-helm-chart/pull/24