### PR TITLE
Create DOCKER_USER variable for developer to build and push docker image for test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@
 COMMIT := $(shell git rev-parse --short HEAD)
 VERSION := dev-$(shell git describe --tags $(shell git rev-list --tags --max-count=1))
 
-CONTROLLER_IMG ?= surenpi/devops-controller:$(VERSION)-$(COMMIT)
-APISERVER_IMG ?= surenpi/devops-apiserver:$(VERSION)-$(COMMIT)
-TOOLS_IMG ?= surenpi/devops-tools:$(VERSION)-$(COMMIT)
+DOCKER_USER ?= surenpi
+
+CONTROLLER_IMG ?= $(DOCKER_USER)/devops-controller:$(VERSION)-$(COMMIT)
+APISERVER_IMG ?= $(DOCKER_USER)/devops-apiserver:$(VERSION)-$(COMMIT)
+TOOLS_IMG ?= $(DOCKER_USER)/devops-tools:$(VERSION)-$(COMMIT)
+
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 


### PR DESCRIPTION
### What this PR dose?

Create DOCKER_USER variable for developer to build and push docker image for test

### Why we need it?

Before this PR, if we want to build and push a docker image for test, we may do with the following steps:

**Approach 1**

1. Change `Makefile` and modify `surenpai/devops-controller:$(VERSION)-$(COMMIT)` to `johnniang/devops-controller:$(VERSION)-$(COMMIT)`
2. Execute command: `make docker-build-push-controller`

**Approach 2**

1. Execute `make docker-build-push-controller`
2. Execute `docker tag surenpi/devops-controller:dev-v3.2.0-alpha.1-7244edd johnniang/devops-controller:dev-v3.2.0-alpha.1-7244edd`
3. Execute `docker push johnniang/devops-controller:dev-v3.2.0-alpha.1-7244edd`

But now, we just need to execute `DOCKER_USER=johnniang make docker-build-push-controller` to archive task above.

/kind feature