### PR TITLE
Recovery from panic to prevent APIServer from down

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -20,6 +20,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	rt "runtime"
+	"time"
+
 	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
@@ -32,10 +36,7 @@ import (
 	"kubesphere.io/devops/pkg/apiserver/request"
 	"kubesphere.io/devops/pkg/kapis/oauth"
 	"kubesphere.io/devops/pkg/models/auth"
-	"net/http"
-	rt "runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 
 	"github.com/emicklei/go-restful"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -106,6 +107,8 @@ func (s *APIServer) PrepareRun(stopCh <-chan struct{}) error {
 	s.container = restful.NewContainer()
 	s.container.Filter(logRequestAndResponse)
 	s.container.Router(restful.CurlyRouter{})
+	// reference: https://pkg.go.dev/github.com/emicklei/go-restful#hdr-Performance_options
+	s.container.DoNotRecover(false)
 	s.container.RecoverHandler(func(panicReason interface{}, httpWriter http.ResponseWriter) {
 		logStackOnRecover(panicReason, httpWriter)
 	})


### PR DESCRIPTION
### What this PR dose?

Recovery from panic to prevent APIServer from down.

> https://pkg.go.dev/github.com/emicklei/go-restful#hdr-Performance_options

### Why we need it?

If web services panic, our APIServer process will be stopped right now instead of responding http status 500. So we need to recovery from panic to prevent APIServer from down.

**Last result**

![image](https://user-images.githubusercontent.com/16865714/137682471-f37beab5-6932-4648-a5b6-f14276251a89.png)

/kind bug
/area devops
/cc @kubesphere/sig-devops 