### PR TITLE
Add more fields into branch structure

### DIFF
--- a/controllers/jenkins/pipeline/metadata_converter.go
+++ b/controllers/jenkins/pipeline/metadata_converter.go
@@ -32,14 +32,15 @@ func convertLatestRun(jobLatestRun *job.PipelineRunSummary) *pipeline.LatestRun 
 		return nil
 	}
 	return &pipeline.LatestRun{
-		ID:        jobLatestRun.ID,
-		Name:      jobLatestRun.Name,
-		Pipeline:  jobLatestRun.Pipeline,
-		Result:    jobLatestRun.Result,
-		State:     jobLatestRun.State,
-		StartTime: jobLatestRun.StartTime,
-		EndTime:   jobLatestRun.EndTime,
-		Causes:    convertCauses(jobLatestRun.Causes),
+		ID:               jobLatestRun.ID,
+		Name:             jobLatestRun.Name,
+		Pipeline:         jobLatestRun.Pipeline,
+		Result:           jobLatestRun.Result,
+		State:            jobLatestRun.State,
+		StartTime:        jobLatestRun.StartTime,
+		EndTime:          jobLatestRun.EndTime,
+		DurationInMillis: jobLatestRun.DurationInMillis,
+		Causes:           convertCauses(jobLatestRun.Causes),
 	}
 }
 
@@ -64,6 +65,8 @@ func convertBranches(jobBranches []job.PipelineBranch) []pipeline.Branch {
 			WeatherScore: jobBranch.WeatherScore,
 			Branch:       jobBranch.Branch,
 			PullRequest:  jobBranch.PullRequest,
+			Parameters:   jobBranch.Parameters,
+			Disabled:     jobBranch.Disabled,
 			LatestRun:    convertLatestRun(jobBranch.LatestRun),
 		})
 	}

--- a/pkg/models/pipeline/pipeline.go
+++ b/pkg/models/pipeline/pipeline.go
@@ -25,11 +25,13 @@ type Metadata struct {
 
 // Branch contains branch metadata, like branch and pull request, and latest PipelineRun.
 type Branch struct {
-	Name         string           `json:"name,omitempty"`
-	WeatherScore int              `json:"weatherScore,omitempty"`
-	LatestRun    *LatestRun       `json:"latestRun,omitempty"`
-	Branch       *job.Branch      `json:"branch,omitempty"`
-	PullRequest  *job.PullRequest `json:"pullRequest,omitempty"`
+	Name         string                    `json:"name,omitempty"`
+	WeatherScore int                       `json:"weatherScore,omitempty"`
+	Disabled     bool                      `json:"disabled,omitempty"`
+	LatestRun    *LatestRun                `json:"latestRun,omitempty"`
+	Branch       *job.Branch               `json:"branch,omitempty"`
+	PullRequest  *job.PullRequest          `json:"pullRequest,omitempty"`
+	Parameters   []job.ParameterDefinition `json:"parameters,omitempty"`
 }
 
 // BranchSlice is alias of branch slice.
@@ -51,14 +53,15 @@ func (branches BranchSlice) SearchByName(name string) (bool, *Branch) {
 
 // LatestRun contains metadata of latest PipelineRun.
 type LatestRun struct {
-	Causes    []Cause  `json:"causes,omitempty"`
-	EndTime   job.Time `json:"endTime,omitempty"`
-	StartTime job.Time `json:"startTime,omitempty"`
-	ID        string   `json:"id,omitempty"`
-	Name      string   `json:"name,omitempty"`
-	Pipeline  string   `json:"pipeline,omitempty"`
-	Result    string   `json:"result,omitempty"`
-	State     string   `json:"state,omitempty"`
+	Causes           []Cause  `json:"causes,omitempty"`
+	EndTime          job.Time `json:"endTime,omitempty"`
+	DurationInMillis *int64   `json:"durationInMillis,omitempty"`
+	StartTime        job.Time `json:"startTime,omitempty"`
+	ID               string   `json:"id,omitempty"`
+	Name             string   `json:"name,omitempty"`
+	Pipeline         string   `json:"pipeline,omitempty"`
+	Result           string   `json:"result,omitempty"`
+	State            string   `json:"state,omitempty"`
 }
 
 // Cause contains short description of cause.


### PR DESCRIPTION
### What this PR dose?

- Add `DurationInMillis` field into `pipeline.LatestRun` structure.
- Add `Parameters` field into `pipeline.Branch` structure.

### Why we need it?

Please see: https://github.com/kubesphere/console/issues/2509.

### Which issue dose this PR fix?

Fix https://github.com/kubesphere/console/issues/2509.

/kind bug
/area devops
/cc @kubesphere/sig-devops 