### PR TITLE
Avoid returning secret value of the DevOps credential by creating credential mask

### DIFF
--- a/pkg/api/devops/v1alpha3/credential_types.go
+++ b/pkg/api/devops/v1alpha3/credential_types.go
@@ -82,9 +82,9 @@ var supportedCredentialTypes = []v1.SecretType{
 	SecretTypeKubeConfig,
 }
 
-// GetSupportedCredentialTypes gets all supported credential types.
+// GetSupportedCredentialTypes gets all supported credential types. The return value is unmodifiable.
 func GetSupportedCredentialTypes() []v1.SecretType {
-	copiedCredentialTypes := []v1.SecretType{}
+	copiedCredentialTypes := make([]v1.SecretType, len(supportedCredentialTypes))
 	copy(copiedCredentialTypes, supportedCredentialTypes)
 	return copiedCredentialTypes
 }

--- a/pkg/api/devops/v1alpha3/credential_types.go
+++ b/pkg/api/devops/v1alpha3/credential_types.go
@@ -74,3 +74,17 @@ const (
 	CredentialSyncTimeAnnoKey   = DevOpsCredentialPrefix + "synctime"
 	CredentialSyncMsgAnnoKey    = DevOpsCredentialPrefix + "syncmsg"
 )
+
+var supportedCredentialTypes = []v1.SecretType{
+	SecretTypeBasicAuth,
+	SecretTypeSSHAuth,
+	SecretTypeSecretText,
+	SecretTypeKubeConfig,
+}
+
+// GetSupportedCredentialTypes gets all supported credential types.
+func GetSupportedCredentialTypes() []v1.SecretType {
+	copiedCredentialTypes := []v1.SecretType{}
+	copy(copiedCredentialTypes, supportedCredentialTypes)
+	return copiedCredentialTypes
+}

--- a/pkg/api/devops/v1alpha3/credential_types_test.go
+++ b/pkg/api/devops/v1alpha3/credential_types_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSupportedCredentialTypes(t *testing.T) {
+	// test basic return
+	types := GetSupportedCredentialTypes()
+	assert.Equal(t, supportedCredentialTypes, types)
+
+	// test unmodifiable
+	// try to modify the types
+	types = append(types, SecretTypeBasicAuth)
+	// check if the return value is modified
+	assert.NotEqual(t, types, GetSupportedCredentialTypes())
+	assert.Equal(t, supportedCredentialTypes, GetSupportedCredentialTypes())
+}

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -293,7 +293,11 @@ func (d devopsOperator) CreateCredentialObj(projectName string, secret *v1.Secre
 	secret.Annotations[devopsv1alpha3.CredentialAutoSyncAnnoKey] = "true"
 	secret.Annotations[devopsv1alpha3.CredentialSyncStatusAnnoKey] = StatusPending
 	secret.Annotations[devopsv1alpha3.CredentialSyncTimeAnnoKey] = GetSyncNowTime()
-	return d.k8sclient.CoreV1().Secrets(projectObj.Status.AdminNamespace).Create(d.context, secret, metav1.CreateOptions{})
+	if secret, err := d.k8sclient.CoreV1().Secrets(projectObj.Status.AdminNamespace).Create(d.context, secret, metav1.CreateOptions{}); err != nil {
+		return nil, err
+	} else {
+		return secretutil.MaskCredential(secret), nil
+	}
 }
 
 func (d devopsOperator) GetCredentialObj(projectName string, secretName string) (*v1.Secret, error) {
@@ -324,7 +328,11 @@ func (d devopsOperator) UpdateCredentialObj(projectName string, secret *v1.Secre
 	secret.Annotations[devopsv1alpha3.CredentialAutoSyncAnnoKey] = "true"
 	secret.Annotations[devopsv1alpha3.CredentialSyncStatusAnnoKey] = StatusPending
 	secret.Annotations[devopsv1alpha3.CredentialSyncTimeAnnoKey] = GetSyncNowTime()
-	return d.k8sclient.CoreV1().Secrets(projectObj.Status.AdminNamespace).Update(d.context, secret, metav1.UpdateOptions{})
+	if secret, err := d.k8sclient.CoreV1().Secrets(projectObj.Status.AdminNamespace).Update(d.context, secret, metav1.UpdateOptions{}); err != nil {
+		return nil, err
+	} else {
+		return secretutil.MaskCredential(secret), nil
+	}
 }
 
 func (d devopsOperator) ListCredentialObj(projectName string, query *query.Query) (api.ListResult, error) {

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -308,7 +308,9 @@ func (d devopsOperator) GetCredentialObj(projectName string, secretName string) 
 	if secret, err := d.k8sclient.CoreV1().Secrets(projectObj.Status.AdminNamespace).Get(d.context, secretName, metav1.GetOptions{}); err != nil {
 		return nil, err
 	} else {
-		return secretutil.MaskCredential(secret), nil
+		// TODO Mask the secret if there is no place to use plain secret.
+		// return secretutil.MaskCredential(secret), nil
+		return secret, nil
 	}
 }
 

--- a/pkg/utils/secretutil/secret_mask.go
+++ b/pkg/utils/secretutil/secret_mask.go
@@ -1,0 +1,52 @@
+package secretutil
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+)
+
+type credentialMask func(*v1.Secret) *v1.Secret
+
+var defaultMasque = []byte("")
+var credentialMaskHolder = map[v1.SecretType]credentialMask{}
+
+func basicAuthCredentialMask(secret *v1.Secret) *v1.Secret {
+	secret.Data[v1alpha3.BasicAuthPasswordKey] = defaultMasque
+	return secret
+}
+
+func sshAuthCredentialMask(secret *v1.Secret) *v1.Secret {
+	secret.Data[v1alpha3.SSHAuthPassphraseKey] = defaultMasque
+	secret.Data[v1alpha3.SSHAuthPrivateKey] = defaultMasque
+	return secret
+}
+
+func secretTextCredentialMask(secret *v1.Secret) *v1.Secret {
+	secret.Data[v1alpha3.SecretTextSecretKey] = defaultMasque
+	return secret
+}
+
+func kubeconfigCredentialMask(secret *v1.Secret) *v1.Secret {
+	secret.Data[v1alpha3.KubeConfigSecretKey] = defaultMasque
+	return secret
+}
+
+// MaskCredential masks sensetive data inside credential.
+func MaskCredential(secret *v1.Secret) *v1.Secret {
+	if secret == nil || secret.Data == nil {
+		return secret
+	}
+	credentialMask := credentialMaskHolder[secret.Type]
+	if credentialMask != nil {
+		return credentialMask(secret)
+	}
+	return secret
+}
+
+func init() {
+	// register credential masks
+	credentialMaskHolder[v1alpha3.SecretTypeBasicAuth] = basicAuthCredentialMask
+	credentialMaskHolder[v1alpha3.SecretTypeSSHAuth] = sshAuthCredentialMask
+	credentialMaskHolder[v1alpha3.SecretTypeSecretText] = secretTextCredentialMask
+	credentialMaskHolder[v1alpha3.SecretTypeKubeConfig] = kubeconfigCredentialMask
+}

--- a/pkg/utils/secretutil/secret_mask_test.go
+++ b/pkg/utils/secretutil/secret_mask_test.go
@@ -1,0 +1,120 @@
+package secretutil
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+)
+
+func Test_maskCredential(t *testing.T) {
+	type args struct {
+		secret *v1.Secret
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v1.Secret
+	}{{
+		name: "Mask basic auth secret",
+		args: args{
+			secret: &v1.Secret{
+				Type: v1alpha3.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					v1alpha3.BasicAuthPasswordKey: []byte("fake password"),
+					v1alpha3.BasicAuthUsernameKey: []byte("fake username"),
+				},
+			},
+		},
+		want: &v1.Secret{
+			Type: v1alpha3.SecretTypeBasicAuth,
+			Data: map[string][]byte{
+				v1alpha3.BasicAuthPasswordKey: []byte(""),
+				v1alpha3.BasicAuthUsernameKey: []byte("fake username"),
+			},
+		},
+	}, {
+		name: "Mask ssh auth secret",
+		args: args{
+			secret: &v1.Secret{
+				Type: v1alpha3.SecretTypeSSHAuth,
+				Data: map[string][]byte{
+					v1alpha3.SSHAuthPassphraseKey: []byte("fake password"),
+					v1alpha3.SSHAuthPrivateKey:    []byte("fake private key"),
+					v1alpha3.SSHAuthUsernameKey:   []byte("fake username"),
+				},
+			},
+		},
+		want: &v1.Secret{
+			Type: v1alpha3.SecretTypeSSHAuth,
+			Data: map[string][]byte{
+				v1alpha3.SSHAuthPassphraseKey: []byte(""),
+				v1alpha3.SSHAuthPrivateKey:    []byte(""),
+				v1alpha3.SSHAuthUsernameKey:   []byte("fake username"),
+			},
+		},
+	}, {
+		name: "Mask secret text secret",
+		args: args{
+			secret: &v1.Secret{
+				Type: v1alpha3.SecretTypeSecretText,
+				Data: map[string][]byte{
+					v1alpha3.SecretTextSecretKey: []byte("fake secret text"),
+				},
+			},
+		},
+		want: &v1.Secret{
+			Type: v1alpha3.SecretTypeSecretText,
+			Data: map[string][]byte{
+				v1alpha3.SecretTextSecretKey: []byte(""),
+			},
+		},
+	}, {
+		name: "Mask kubeconfig secret",
+		args: args{
+			secret: &v1.Secret{
+				Type: v1alpha3.SecretTypeKubeConfig,
+				Data: map[string][]byte{
+					v1alpha3.KubeConfigSecretKey: []byte("fake kubeconfig"),
+				},
+			},
+		},
+		want: &v1.Secret{
+			Type: v1alpha3.SecretTypeKubeConfig,
+			Data: map[string][]byte{
+				v1alpha3.KubeConfigSecretKey: []byte(""),
+			},
+		},
+	}, {
+		name: "Nil secret",
+		args: args{
+			secret: nil,
+		},
+		want: nil,
+	}, {
+		name: "Other secret",
+		args: args{
+			secret: &v1.Secret{
+				Type: v1.SecretType("fake-type"),
+				Data: map[string][]byte{
+					"fake_key": []byte("fake_value"),
+				},
+			},
+		},
+		want: &v1.Secret{
+			Type: v1.SecretType("fake-type"),
+			Data: map[string][]byte{
+				"fake_key": []byte("fake_value"),
+			},
+		},
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MaskCredential(tt.args.secret); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("maskCredential() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/area devops

### What this PR does / why we need it:

- Add credential mask;
- Apply the mask into listing, getting, updating and creating credential.

### Which issue(s) this PR fixes:

Fixes #299

### Special notes for reviewers:

#### Steps to test

Docker image for test:

```bash
johnniang/devops-apiserver:dev-v3.2.1-29e5c8b
```

1. Replace the docker image of `devops-apiserver` with test image above;
2. Create a credential for a DevOps Project and see response in browser debug network;
3. Update the credential and see response in browser debug network;
4. Back to credential list and see response in browser debug network;
5. Go into a credential and see response in browser debug network;

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```