### PR TITLE
Fix Pipeline WeatherScore error based on gitlab

### DIFF
--- a/pkg/models/pipeline/pipeline.go
+++ b/pkg/models/pipeline/pipeline.go
@@ -4,7 +4,7 @@ import "github.com/jenkins-zh/jenkins-client/pkg/job"
 
 // Metadata holds some of pipeline fields that are only things we needed instead of whole job.Pipeline.
 type Metadata struct {
-	WeatherScore                   int                       `json:"weatherScore,omitempty"`
+	WeatherScore                   int                       `json:"weatherScore"`
 	EstimatedDurationInMillis      int64                     `json:"estimatedDurationInMillis,omitempty"`
 	Parameters                     []job.ParameterDefinition `json:"parameters,omitempty"`
 	Name                           string                    `json:"name,omitempty"`
@@ -26,7 +26,7 @@ type Metadata struct {
 // Branch contains branch metadata, like branch and pull request, and latest PipelineRun.
 type Branch struct {
 	Name         string                    `json:"name,omitempty"`
-	WeatherScore int                       `json:"weatherScore,omitempty"`
+	WeatherScore int                       `json:"weatherScore"`
 	Disabled     bool                      `json:"disabled,omitempty"`
 	LatestRun    *LatestRun                `json:"latestRun,omitempty"`
 	Branch       *job.Branch               `json:"branch,omitempty"`


### PR DESCRIPTION
### What this PR does?

Remove `omitempty` in JSON tag of `WeatherScore` field in Pipeline metadata and branch structure.

### Why we need it?

Please see #256.

### Which issue dose this PR fix?

Fix #256.

### Steps to test

Docker image for test:

```bash
johnniang/devops-apiserver:dev-v3.2.0-rc.1-70428be
johnniang/devops-controller:dev-v3.2.0-rc.1-70428be
```

1. Replace container image of deployment `devops-apiserver` and `devops-controller` with test images above;
2. Create Git pipeline with repository <https://gitlab.com/johnniang/jenkinsfile-demo.git> and with script path `Jenkinsfile-fail`;
3. See weather score in Pipeline list page

![image](https://user-images.githubusercontent.com/16865714/138388296-b7ddf135-b988-482d-943e-fbf41507046a.png)
![image](https://user-images.githubusercontent.com/16865714/138388315-f41dafcc-7d20-475c-b453-e9a435a175c3.png)
![image](https://user-images.githubusercontent.com/16865714/138388336-9a4401f8-3d18-4b56-a6e4-271b584afb73.png)
![image](https://user-images.githubusercontent.com/16865714/138388360-0c0d5e7a-a30b-408f-bf29-f99d57a2faa4.png)

/kind bug
/area devops
/cc @kubesphere/sig-devops 
