### PR TITLE
Bump ks cli to v0.0.55

### DIFF
--- a/config/dockerfiles/tools/Dockerfile
+++ b/config/dockerfiles/tools/Dockerfile
@@ -18,8 +18,8 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o jwt cmd/tools/jwt/jwt_cmd.go
 
 FROM golang:1.16 as downloader
-RUN go install github.com/linuxsuren/http-downloader@v0.0.41
-RUN http-downloader install kubesphere-sigs/ks@v0.0.52
+RUN go install github.com/linuxsuren/http-downloader@v0.0.49
+RUN http-downloader install kubesphere-sigs/ks@v0.0.55
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
bump downloader tools hd to v0.0.49

This is my test output:
```shell
➜  ~ hd version
Version: 0.0.49
Last Commit: 4128c61
Build Date: 2021-10-22T02:15:21Z
➜  ~ hd install kubesphere-sigs/ks@v0.0.55 --force
start to fetch the config
start to download from https://gh.api.99988866.xyz/github.com/kubesphere-sigs/ks/releases/download/v0.0.55/ks-darwin-amd64.tar.gz
start to download with 6 threads, size: 9868964, unit: 1644827
Downloading part 3:  [====================================================================] 100%
Downloading part 5:  [====================================================================] 100%
Downloading part 0:  [====================================================================] 100%
Downloading part 2:  [====================================================================] 100%
Downloading part 4:  [====================================================================] 100%
Downloading part 1:  [====================================================================] 100%
install ./ks to /usr/local/bin/ks
➜  ~ ks version
Version: 0.0.55
Last Commit: e6f66fb
Build Date: 2021-10-29T02:13:53Z
```

/cc @kubesphere/sig-devops 