### PR TITLE
Provide basic E2E testing to validate whether it is normal after installing ks-devops

### DIFF
--- a/.github/build-for-e2e/action.yaml
+++ b/.github/build-for-e2e/action.yaml
@@ -1,0 +1,31 @@
+name: Build for E2E testing
+description: Build APIServer, Controller Manager and Tools for E2E testing.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Build Docker images for Controller Manager
+      uses: docker/build-push-action@v2.4.0
+      with:
+        file: config/dockerfiles/controller-manager/Dockerfile
+        tags: kubespheredev/devops-controller:e2e
+        push: false
+
+    - name: Build Docker images for APIServer
+      uses: docker/build-push-action@v2.4.0
+      with:
+        file: config/dockerfiles/apiserver/Dockerfile
+        tags: kubespheredev/devops-apiserver:e2e
+        push: false
+
+    - name: Build Docker images for Tools
+      uses: docker/build-push-action@v2.4.0
+      with:
+        file: config/dockerfiles/tools/Dockerfile
+        tags: kubespheredev/devops-tools:e2e
+        push: false
+
+

--- a/.github/workflows/e2e.install.yaml
+++ b/.github/workflows/e2e.install.yaml
@@ -18,29 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Build Docker images for Controller Manager
-        uses: docker/build-push-action@v2.4.0
-        with:
-          file: config/dockerfiles/controller-manager/Dockerfile
-          tags: kubespheredev/devops-controller:e2e
-          push: false
-
-      - name: Build Docker images for APIServer
-        uses: docker/build-push-action@v2.4.0
-        with:
-          file: config/dockerfiles/apiserver/Dockerfile
-          tags: kubespheredev/devops-apiserver:e2e
-          push: false
-
-      - name: Build Docker images for Tools
-        uses: docker/build-push-action@v2.4.0
-        with:
-          file: config/dockerfiles/tools/Dockerfile
-          tags: kubespheredev/devops-tools:e2e
-          push: false
+      - name: Build docker images for E2E testing
+        uses: ./.github/build-for-e2e
 
       - name: Run E2E Test
         uses: apache/skywalking-infra-e2e@main

--- a/.github/workflows/e2e.install.yaml
+++ b/.github/workflows/e2e.install.yaml
@@ -1,0 +1,52 @@
+name: E2E - Chart Install
+
+on:
+  pull_request:
+    paths:
+      - "**"
+      - "!**.md"
+  workflow_dispatch:
+
+jobs:
+  Install:
+    name: Chart Install
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build Docker images for Controller Manager
+        uses: docker/build-push-action@v2.4.0
+        with:
+          file: config/dockerfiles/controller-manager/Dockerfile
+          tags: kubespheredev/devops-controller:e2e
+          push: false
+
+      - name: Build Docker images for APIServer
+        uses: docker/build-push-action@v2.4.0
+        with:
+          file: config/dockerfiles/apiserver/Dockerfile
+          tags: kubespheredev/devops-apiserver:e2e
+          push: false
+
+      - name: Build Docker images for Tools
+        uses: docker/build-push-action@v2.4.0
+        with:
+          file: config/dockerfiles/tools/Dockerfile
+          tags: kubespheredev/devops-tools:e2e
+          push: false
+
+      - name: Run E2E Test
+        uses: johnniang/skywalking-infra-e2e@main
+        with:
+          e2e-file: $GITHUB_WORKSPACE/test/e2e/cases/chart-install/e2e.yaml
+
+      - name: Upload E2E Log
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }} # Only upload the artifact when E2E testing failure
+        with:
+          name: e2e-log
+          path: "${{ env.SW_INFRA_E2E_LOG_DIR }}" # The SkyWalking Infra E2E action sets SW_INFRA_E2E_LOG_DIR automatically.

--- a/.github/workflows/e2e.install.yaml
+++ b/.github/workflows/e2e.install.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - "**"
       - "!**.md"
+  push:
+    branches:
+      - feat/*
   workflow_dispatch:
 
 jobs:
@@ -40,7 +43,7 @@ jobs:
           push: false
 
       - name: Run E2E Test
-        uses: johnniang/skywalking-infra-e2e@main
+        uses: apache/skywalking-infra-e2e@main
         with:
           e2e-file: $GITHUB_WORKSPACE/test/e2e/cases/chart-install/e2e.yaml
 

--- a/.github/workflows/e2e.install.yaml
+++ b/.github/workflows/e2e.install.yaml
@@ -5,15 +5,11 @@ on:
     paths:
       - "**"
       - "!**.md"
-  push:
-    branches:
-      - feat/*
-  workflow_dispatch:
 
 jobs:
   Install:
     name: Chart Install
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
@@ -22,7 +18,7 @@ jobs:
         uses: ./.github/build-for-e2e
 
       - name: Run E2E Test
-        uses: apache/skywalking-infra-e2e@main
+        uses: apache/skywalking-infra-e2e@v1.1.0
         with:
           e2e-file: $GITHUB_WORKSPACE/test/e2e/cases/chart-install/e2e.yaml
 

--- a/test/e2e/cases/chart-install/e2e.yaml
+++ b/test/e2e/cases/chart-install/e2e.yaml
@@ -14,7 +14,6 @@ setup:
                  --set image.controller.tag=e2e \
                  --set image.apiserver.tag=e2e \
                  --set image.tools.tag=e2e
-      retryWaitAfter: 1m
       wait:
         - namespace: kubesphere-devops-system
           resource: deployment
@@ -31,3 +30,11 @@ setup:
       - namespace: kubesphere-devops-system
         resource: deployment/devops-apiserver
         port: 9090
+
+verify:
+  retry:
+    count: 60
+    interval: 1s
+  cases:
+    - query: "kubectl get pod -n kubesphere-devops-system -o yaml | yq e '{.items[].metadata.name: .items[].status.phase}' -"
+      expected: ./expected.yaml

--- a/test/e2e/cases/chart-install/e2e.yaml
+++ b/test/e2e/cases/chart-install/e2e.yaml
@@ -1,0 +1,33 @@
+setup:
+  env: kind
+  file: ../../common/kind.yaml
+  timeout: 60m
+  steps:
+    - name: Install ks-devops via helm chart
+      command: |
+        helm repo add ks-devops https://kubesphere-sigs.github.io/ks-devops-helm-chart/
+        helm repo update
+        helm install devops ks-devops/ks-devops -n kubesphere-devops-system --create-namespace \
+                 --set jenkins.ksAuth.enabled=true \
+                 --set image.pullPolicy=Never \
+                 --set image.registry=kubespheredev \
+                 --set image.controller.tag=e2e \
+                 --set image.apiserver.tag=e2e \
+                 --set image.tools.tag=e2e
+      retryWaitAfter: 1m
+      wait:
+        - namespace: kubesphere-devops-system
+          resource: deployment
+          for: condition=Available
+        - namespace: kubesphere-devops-system
+          resource: pod/s2ioperator-0
+          for: condition=Ready
+  kind:
+    import-images:
+      - kubespheredev/devops-controller:e2e
+      - kubespheredev/devops-apiserver:e2e
+      - kubespheredev/devops-tools:e2e
+    expose-ports:
+      - namespace: kubesphere-devops-system
+        resource: deployment/devops-apiserver
+        port: 9090

--- a/test/e2e/cases/chart-install/expected.yaml
+++ b/test/e2e/cases/chart-install/expected.yaml
@@ -1,0 +1,5 @@
+{{ range $name, $phase := . }}
+  {{ if or (eq $phase "Running") (eq $phase "Succeeded") }}
+    {{ $name }}: {{ $phase }}
+  {{ end }}
+{{ end }}

--- a/test/e2e/common/kind.yaml
+++ b/test/e2e/common/kind.yaml
@@ -1,0 +1,26 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# patch the generated kubeadm config with some extra settings
+kubeadmConfigPatches:
+- |
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  kind: KubeletConfiguration
+  evictionHard:
+    nodefs.available: "0%"
+# patch it further using a JSON 6902 patch
+kubeadmConfigPatchesJSON6902:
+- group: kubeadm.k8s.io
+  version: v1beta2
+  kind: ClusterConfiguration
+  patch: |
+    - op: add
+      path: /apiServer/certSANs/-
+      value: ks-devops-e2e
+# 1 control plane node and 1 workers
+nodes:
+# the control plane node config
+- role: control-plane
+  image: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+# the one worker
+- role: worker
+  image: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047


### PR DESCRIPTION
### What this PR dose?

Install helm charts to start ks-devops and validate all Running Pods is running stably.

Last result:
> https://github.com/kubesphere/ks-devops/runs/4149272728?check_suite_focus=true

![image](https://user-images.githubusercontent.com/16865714/140887261-dad01649-d6f6-482d-b13d-21170b0c4186.png)


### Which issue dose this PR fix?

Fix #342

### Special notes for reviewers

This PR uses [Apache SkyWalking Infra E2E](https://github.com/apache/skywalking-infra-e2e) to implement our E2E testing.

Learn more from https://skywalking.apache.org/docs/skywalking-infra-e2e/latest/readme/.

/kind feature