### PR TITLE
Disable CI for non code change

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,29 @@ on:
       - test-* # make it be easier for contributors to test
     tags:
       - 'v*.*.*'
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".devcontainer/**"
+      - "*.ya?ml" # ignore all yaml files(with suffix yaml or yml) in the root of the repository
+      - "!codecov.yml"
+      - "!.golangci.yml"
+      - "!config/**"
+      - "OWNERS"
+      - "PROJECT"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".devcontainer/**"
+      - "*.ya?ml" # ignore all yaml files(with suffix yaml or yml) in the root of the repository
+      - "!codecov.yml"
+      - "!.golangci.yml"
+      - "!config/**"
+      - "OWNERS"
+      - "PROJECT"
     branches:
       - 'master'
       - 'tekton-support'

--- a/.github/workflows/e2e.install.yaml
+++ b/.github/workflows/e2e.install.yaml
@@ -2,9 +2,17 @@ name: E2E - Chart Install
 
 on:
   pull_request:
-    paths:
-      - "**"
-      - "!**.md"
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".devcontainer/**"
+      - "*.ya?ml" # ignore all yaml files(with suffix yaml or yml) in the root of the repository
+      - "!codecov.yml"
+      - "!.golangci.yml"
+      - "!config/**"
+      - "OWNERS"
+      - "PROJECT"
 
 jobs:
   Install:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,31 @@
 name: Lint
 
 on:
-  - push
-  - pull_request
-  - release
+  push:
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".devcontainer/**"
+      - "*.ya?ml" # ignore all yaml files(with suffix yaml or yml) in the root of the repository
+      - "!codecov.yml"
+      - "!.golangci.yml"
+      - "!config/**"
+      - "OWNERS"
+      - "PROJECT"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".devcontainer/**"
+      - "*.ya?ml" # ignore all yaml files(with suffix yaml or yml) in the root of the repository
+      - "!codecov.yml"
+      - "!.golangci.yml"
+      - "!config/**"
+      - "OWNERS"
+      - "PROJECT"
+  release:
 
 jobs:
   Lint:


### PR DESCRIPTION
### What this PR dose?

Configure `paths-ignore` list to disable CI for non-code change according to https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-ignoring-paths.

Manual test result:

![image](https://user-images.githubusercontent.com/16865714/141145686-81b27e27-193e-4bbc-8a4e-fd5eed7d9054.png)

### Why we need it?

This would reduce unnecessary workflow runs for non-code change.

### Which issue dose this PR fix?

Fix #349 

/kind chore
/cc @kubesphere/sig-devops 

