### PR TITLE
Bump ks cli to version v0.0.58

### DIFF
--- a/config/dockerfiles/tools/Dockerfile
+++ b/config/dockerfiles/tools/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o jwt cmd/tools/jwt/jwt_cmd.go
 
 FROM golang:1.16 as downloader
 RUN go install github.com/linuxsuren/http-downloader@v0.0.49
-RUN http-downloader install kubesphere-sigs/ks@v0.0.55
+RUN http-downloader install kubesphere-sigs/ks@v0.0.58
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
https://github.com/kubesphere-sigs/ks/pull/241 fixed a potential issue that might cause the token of Jenkins to be empty.

See the release request https://github.com/kubesphere-sigs/ks-versions/pull/10

/kind bug
/label no-changelog