### PR TITLE
Fix the problem of handling multi submitted input step incorrectly

### DIFF
--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -428,7 +428,7 @@ func (h *ProjectPipelineHandler) hasSubmitPermission(req *restful.Request) (hasP
 					continue
 				}
 				if step.Input == nil {
-					err = errors.New("the step state was unapprovable")
+					err = fmt.Errorf("the step '%s' is not approvable", step.DisplayName)
 				}
 				hasPermit = step.Approvable
 				break

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -20,10 +20,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"kubesphere.io/devops/pkg/apiserver/query"
-	"kubesphere.io/devops/pkg/apiserver/request"
 	"net/http"
 	"strings"
+
+	"kubesphere.io/devops/pkg/apiserver/query"
+	"kubesphere.io/devops/pkg/apiserver/request"
 
 	"github.com/emicklei/go-restful"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -35,6 +36,7 @@ import (
 	"kubesphere.io/devops/pkg/api"
 	clientDevOps "kubesphere.io/devops/pkg/client/devops"
 	"kubesphere.io/devops/pkg/client/devops/jenkins"
+
 	//"kubesphere.io/devops/pkg/apiserver/authorization/authorizer"
 	//"kubesphere.io/devops/pkg/apiserver/request"
 	"kubesphere.io/devops/pkg/constants"
@@ -422,10 +424,12 @@ func (h *ProjectPipelineHandler) hasSubmitPermission(req *restful.Request) (hasP
 			}
 
 			for _, step := range node.Steps {
-				if step.ID != stepId || step.Input == nil {
+				if step.ID != stepId {
 					continue
 				}
-
+				if step.Input == nil {
+					err = errors.New("the step state was unapprovable")
+				}
 				hasPermit = step.Approvable
 				break
 			}


### PR DESCRIPTION
### What this PR dose

Return friendly error if current step is unapprovable.

### Why we need it

Please see #366 

### Which issue this PR fixes

#366 

### Steps to test

Please replace docker image of `devops-apiserver` deployment with image name below:

```bash
johnniang/devops-apiserver:dev-v3.2.0-43358c2
```

- Create a simple approvable Pipeline and run, which Jenkinsfile is below:

```groovy
pipeline {
  agent none
  stages {
    stage('Input test') {
      steps {
        input(id: 'deploy-to-prod', message: 'deploy to prod?')
      }
    }
  }
}
```

- Approve the PipelineRun and copy request `http://demo:30880/kapis/devops.kubesphere.io/v1alpha2/devops/test-projectl82l5/pipelines/approable-test/runs/33/nodes/4/steps/5/` as CURL(bash)

![image](https://user-images.githubusercontent.com/16865714/143214630-f9c450e5-7f17-450b-bfbb-1f948c075557.png)

- Request the same request again, and you will get the response:

```bash
* upload completely sent off: 23 out of 23 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Vary: Accept-Encoding
< content-length: 61
< content-type: text/plain; charset=utf-8
< date: Wed, 24 Nov 2021 09:49:48 GMT
< connection: close
<
* Closing connection 0
{"allow":"false","message":"the step state was unapprovable"}%
```

/kind bug
/cc @kubesphere/sig-devops 