### PR TITLE
Set the threshold of patch to 0% for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,3 +12,7 @@ coverage:
       default:
         target: auto
         threshold: 0.1%
+    patch:
+      default:
+        target: auto
+        threshold: 0%


### PR DESCRIPTION
For many cases, it's hard to add new test coverage. Such as the modification of markdown files. So, we don't need to let the ci to failed.

## References
* https://docs.codecov.com/docs/commit-status#patch-status