### PR TITLE
Fix the image tag name from x.x.x to vx.x.x

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,7 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern=v{{version}}
+            type=semver,pattern={{raw}}
             type=sha
       - name: Docker meta for Contributors
         id: metaContributors
@@ -72,7 +72,7 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern=v{{version}}
+            type=semver,pattern={{raw}}
             type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -126,7 +126,7 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern=v{{version}}
+            type=semver,pattern={{raw}}
             type=sha
       - name: Docker meta for Contributors
         id: metaContributors
@@ -139,7 +139,7 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern=v{{version}}
+            type=semver,pattern={{raw}}
             type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -193,7 +193,7 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern=v{{version}}
+            type=semver,pattern={{raw}}
             type=sha
       - name: Docker meta for Contributors
         id: metaContributors
@@ -206,7 +206,7 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern=v{{version}}
+            type=semver,pattern={{raw}}
             type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
/cherrypick release-3.2

This is [the official document](https://github.com/docker/metadata-action#typesemver) which is related to the new changes.