### PR TITLE
Bump up version of kubephere-sigs/ks to v0.0.60

### DIFF
--- a/config/dockerfiles/tools/Dockerfile
+++ b/config/dockerfiles/tools/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o jwt cmd/tools/jwt/jwt_cmd.go
 
 FROM golang:1.16 as downloader
 RUN go install github.com/linuxsuren/http-downloader@v0.0.49
-RUN http-downloader install kubesphere-sigs/ks@v0.0.58
+RUN http-downloader install kubesphere-sigs/ks@v0.0.60
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
### What this PR dose

Bump version of kubephere-sigs/ks tool, from suggestion https://github.com/kubesphere-sigs/ks/pull/245#pullrequestreview-819847883.

Upstream PR: 
- https://github.com/kubesphere-sigs/ks/pull/245

Meanwhile, this PR also needs to wait for next release of https://github.com/kubesphere-sigs/ks.

/kind chore
/hold