### PR TITLE
Fix the problem caused by strange branch names that contain special characters

### DIFF
--- a/cmd/controller/app/server.go
+++ b/cmd/controller/app/server.go
@@ -28,6 +28,7 @@ import (
 	"kubesphere.io/devops/pkg/client/k8s"
 	"kubesphere.io/devops/pkg/client/s3"
 	"kubesphere.io/devops/pkg/config"
+	"kubesphere.io/devops/pkg/indexers"
 	"kubesphere.io/devops/pkg/informers"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
@@ -187,6 +188,10 @@ func Run(s *options.DevOpsControllerManagerOptions, stopCh <-chan struct{}) erro
 		s,
 		stopCh); err != nil {
 		return fmt.Errorf("unable to register controllers to the manager: %v", err)
+	}
+
+	if err := indexers.CreatePipelineRunSCMRefNameIndexer(mgr.GetCache()); err != nil {
+		return err
 	}
 
 	// Start cache data after all informer is registered

--- a/controllers/jenkins/pipeline/metadata_converter.go
+++ b/controllers/jenkins/pipeline/metadata_converter.go
@@ -75,6 +75,7 @@ func convertBranches(jobBranches []job.PipelineBranch) []pipeline.Branch {
 	for _, jobBranch := range jobBranches {
 		branches = append(branches, pipeline.Branch{
 			Name:         jobBranch.Name,
+			RawName:      jobBranch.DisplayName,
 			WeatherScore: jobBranch.WeatherScore,
 			Branch:       jobBranch.Branch,
 			PullRequest:  jobBranch.PullRequest,

--- a/controllers/jenkins/pipelinerun/pipelinerun_controller_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller_test.go
@@ -82,7 +82,7 @@ func Test_getBranch(t *testing.T) {
 		},
 		want: "main",
 	}, {
-		name: "Multi-branch Pipeline and SCM set, but the name is invalid",
+		name: "Multi-branch Pipeline and SCM set, but the name is written in Chinese",
 		args: args{
 			prSpec: &v1alpha3.PipelineRunSpec{
 				PipelineSpec: &v1alpha3.PipelineSpec{
@@ -94,7 +94,7 @@ func Test_getBranch(t *testing.T) {
 				},
 			},
 		},
-		wantErr: true,
+		want: "测试分支",
 	},
 	}
 	for _, tt := range tests {
@@ -159,7 +159,6 @@ var _ = Describe("TestReconciler_hasSamePipelineRun", func() {
 					v1alpha3.JenkinsPipelineRunIDAnnoKey: "123",
 				},
 				Labels: map[string]string{
-					v1alpha3.SCMRefNameLabelKey:   "main",
 					v1alpha3.PipelineNameLabelKey: "multi-branch-pipeline",
 				},
 			},

--- a/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
@@ -143,7 +143,6 @@ func Test_createBarePipelineRun(t *testing.T) {
 				},
 				Labels: map[string]string{
 					v1alpha3.PipelineNameLabelKey: "fake-pipeline",
-					v1alpha3.SCMRefNameLabelKey:   "main",
 				},
 			},
 			Spec: v1alpha3.PipelineRunSpec{

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/jenkins-zh/jenkins-client v0.0.6
+	github.com/jenkins-zh/jenkins-client v0.0.7
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jenkins-zh/jenkins-cli v0.0.32/go.mod h1:uE1mH9PNITrg0sugv6HXuM/CSddg0zxXoYu3w57I3JY=
-github.com/jenkins-zh/jenkins-client v0.0.6 h1:Rs10HIXBP6evnmW+zeASJye/VSwrtT1bgXj+IC+oXXk=
-github.com/jenkins-zh/jenkins-client v0.0.6/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
+github.com/jenkins-zh/jenkins-client v0.0.7 h1:E0EUOx1G3RVEUrvj8WGvI5WjDTRD4tcLm8FAg0iqJJ8=
+github.com/jenkins-zh/jenkins-client v0.0.7/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
 github.com/jenkins-zh/jenkins-formulas v0.0.5/go.mod h1:zS8fm8u5L6FcjZM0QznXsLV9T2UtSVK+hT6Sm76iUZ4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/pkg/api/devops/v1alpha3/groupversion_info.go
+++ b/pkg/api/devops/v1alpha3/groupversion_info.go
@@ -35,10 +35,10 @@ const (
 	PipelineRunOrphanLabelKey = GroupName + "/jenkins-pipelinerun-orphan"
 	// PipelineNameLabelKey is label key of Pipeline name.
 	PipelineNameLabelKey = GroupName + "/pipeline"
-	// SCMRefNameLabelKey is label key of SCM reference name.
-	SCMRefNameLabelKey = GroupName + "/scm-ref-name"
 	// PipelineRunCreatorAnnoKey is annotation key of PipelineRun's creator
 	PipelineRunCreatorAnnoKey = GroupName + "/creator"
+	// PipelineRunSCMRefNameField is the field name of SCM reference name in PipelineRun spec.
+	PipelineRunSCMRefNameField = "spec.scm.ref-name"
 )
 
 var (

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -34,6 +34,7 @@ import (
 	"kubesphere.io/devops/pkg/apiserver/authentication/request/anonymous"
 	"kubesphere.io/devops/pkg/apiserver/filters"
 	"kubesphere.io/devops/pkg/apiserver/request"
+	"kubesphere.io/devops/pkg/indexers"
 	"kubesphere.io/devops/pkg/kapis/oauth"
 	"kubesphere.io/devops/pkg/models/auth"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -154,7 +155,9 @@ func (s *APIServer) installKubeSphereAPIs() {
 }
 
 func (s *APIServer) Run(stopCh <-chan struct{}) (err error) {
-
+	if err := indexers.CreatePipelineRunSCMRefNameIndexer(s.RuntimeCache); err != nil {
+		return err
+	}
 	err = s.waitForResourceSync(stopCh)
 	if err != nil {
 		return err

--- a/pkg/indexers/indexers.go
+++ b/pkg/indexers/indexers.go
@@ -1,0 +1,26 @@
+package indexers
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+// CreatePipelineRunSCMRefNameIndexer creates field indexer which could speed up listing PipelineRun by SCM reference name.
+func CreatePipelineRunSCMRefNameIndexer(runtimeCache cache.Cache) error {
+	return runtimeCache.IndexField(context.Background(),
+		&v1alpha3.PipelineRun{},
+		v1alpha3.PipelineRunSCMRefNameField,
+		func(o runtime.Object) []string {
+			pipelineRun, ok := o.(*v1alpha3.PipelineRun)
+			if !ok || pipelineRun == nil {
+				return []string{}
+			}
+			if pipelineRun.Spec.SCM == nil {
+				return []string{}
+			}
+			return []string{pipelineRun.Spec.SCM.RefName}
+		})
+}

--- a/pkg/kapis/devops/v1alpha3/pipeline/branch_filter.go
+++ b/pkg/kapis/devops/v1alpha3/pipeline/branch_filter.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"github.com/jenkins-zh/jenkins-client/pkg/job"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"kubesphere.io/devops/pkg/models/pipeline"
 )
 
@@ -13,9 +12,6 @@ type branchSlice []pipeline.Branch
 func (branches branchSlice) filter(predicate branchPredicate) []pipeline.Branch {
 	var resultBranches []pipeline.Branch
 	for _, branch := range branches {
-		if errors := validation.IsValidLabelValue(branch.Name); len(errors) != 0 {
-			continue
-		}
 		if predicate != nil && predicate(branch) {
 			resultBranches = append(resultBranches, branch)
 		}

--- a/pkg/kapis/devops/v1alpha3/pipeline/branch_filter_test.go
+++ b/pkg/kapis/devops/v1alpha3/pipeline/branch_filter_test.go
@@ -64,7 +64,7 @@ func Test_filterBranches(t *testing.T) {
 			PullRequest: &job.PullRequest{},
 		}},
 	}, {
-		name: "With filter: origin, but name is invalid",
+		name: "With filter: origin, but name is written in Chinese",
 		args: args{
 			branches: []pipeline.Branch{{
 				Name:        "main1",
@@ -83,6 +83,9 @@ func Test_filterBranches(t *testing.T) {
 		want: []pipeline.Branch{{
 			Name:        "main1",
 			PullRequest: nil,
+		}, {
+			Name:        "主分支2",
+			PullRequest: &job.PullRequest{},
 		}},
 	}, {
 		name: "With filter: pull-requests",
@@ -108,7 +111,7 @@ func Test_filterBranches(t *testing.T) {
 			},
 		}},
 	}, {
-		name: "With filter: pull-requests， but name is invalid",
+		name: "With filter: pull-requests, but name is written in Chinese",
 		args: args{
 			branches: []pipeline.Branch{{
 				Name:        "main1",
@@ -133,6 +136,11 @@ func Test_filterBranches(t *testing.T) {
 			Name: "PR1",
 			PullRequest: &job.PullRequest{
 				ID: "1",
+			},
+		}, {
+			Name: "分支2",
+			PullRequest: &job.PullRequest{
+				ID: "2",
 			},
 		}},
 	}, {

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/util_test.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/util_test.go
@@ -25,7 +25,6 @@ func Test_buildLabelSelector(t *testing.T) {
 	type args struct {
 		queryParam   *query.Query
 		pipelineName string
-		branchName   string
 	}
 	tests := []struct {
 		name    string
@@ -37,9 +36,8 @@ func Test_buildLabelSelector(t *testing.T) {
 		args: args{
 			queryParam:   &query.Query{},
 			pipelineName: "pipelineA",
-			branchName:   "branchA",
 		},
-		want: parseSelector(fmt.Sprintf("%s=pipelineA,%s=branchA", v1alpha3.PipelineNameLabelKey, v1alpha3.SCMRefNameLabelKey)),
+		want: parseSelector(fmt.Sprintf("%s=pipelineA", v1alpha3.PipelineNameLabelKey)),
 	}, {
 		name: "Label selector was provided",
 		args: args{
@@ -47,22 +45,12 @@ func Test_buildLabelSelector(t *testing.T) {
 				LabelSelector: "a=b",
 			},
 			pipelineName: "pipelineA",
-			branchName:   "branchA",
 		},
-		want: parseSelector(fmt.Sprintf("%s=pipelineA,%s=branchA,a=b", v1alpha3.PipelineNameLabelKey, v1alpha3.SCMRefNameLabelKey)),
-	}, {
-		name: "No label selector was provided",
-		args: args{
-			queryParam:   &query.Query{},
-			pipelineName: "pipelineA",
-			branchName:   "分支A",
-		},
-		wantErr: true,
-	},
-	}
+		want: parseSelector(fmt.Sprintf("%s=pipelineA,a=b", v1alpha3.PipelineNameLabelKey)),
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildLabelSelector(tt.args.queryParam, tt.args.pipelineName, tt.args.branchName)
+			got, err := buildLabelSelector(tt.args.queryParam, tt.args.pipelineName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("buildLabelSelector() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/models/pipeline/pipeline.go
+++ b/pkg/models/pipeline/pipeline.go
@@ -25,7 +25,10 @@ type Metadata struct {
 
 // Branch contains branch metadata, like branch and pull request, and latest PipelineRun.
 type Branch struct {
-	Name         string                    `json:"name,omitempty"`
+	// Name is branch name, like "feat%2FfeatureA"
+	Name string `json:"name,omitempty"`
+	// RawName is the display branch name, like "feat/featureA"
+	RawName      string                    `json:"rawName,omitempty"`
 	WeatherScore int                       `json:"weatherScore"`
 	Disabled     bool                      `json:"disabled,omitempty"`
 	LatestRun    *LatestRun                `json:"latestRun,omitempty"`


### PR DESCRIPTION
### What this PR dose

- Replace label of SCM ref name with field indexer.
- Remove branch name validation

### Why we need it

Please see:
- #104
- #397

### Which issue this PR fixes

Fix #397

### How to test it

Docker images for test:

```bash
johnniang/devops-apiserver:dev-v3.2.1-rc.1-fe5d958
johnniang/devops-controller:dev-v3.2.1-rc.1-fe5d958
```

1. Create Multi-branch Pipeline, using repo <https://gitlab.com/johnniang/jenkinsfile-multi-demo>.
2. Click `Branches` tab and see all branches.
    ![image](https://user-images.githubusercontent.com/16865714/144750161-a9366601-562d-437c-a64a-381ece98fdc3.png)
3. Click into branch naming `中文测试分支`
    ![image](https://user-images.githubusercontent.com/16865714/144750190-d703f7b2-0af6-4d49-9d03-c37620727cce.png)

**Please note that KubeSphere console didn't escape the branch name, so we cannot click branch naming `feat/featureA` util console fixes it:**
    ![image](https://user-images.githubusercontent.com/16865714/144750278-3a59b6bf-c43b-4244-a8a1-26288d8043f9.png)

/kind bug
/cc @kubesphere/sig-devops 
/cc @mangoGoForward 