### PR TITLE
Enable build workflow on pushing to release branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - release-*
       - tekton-support
       - jenkins-client-refactor
       - feat/*
@@ -37,6 +38,7 @@ on:
       - "PROJECT"
     branches:
       - 'master'
+      - 'release-*'
       - 'tekton-support'
       - 'jenkins-client-refactor'
       - 'feat/*'


### PR DESCRIPTION
Enable build workflow on pushing to release branch, so that we can use docker image: `kubespheredev/devops-apiserver:release-3.2`.

/kind chore