### PR TITLE
Exclude label release-notes-none for release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -37,6 +37,8 @@ categories:
 exclude-labels:
   - reverted
   - no-changelog
+  - release-note-none
+  - release-notes-none
   - skip-changelog
   - invalid
 change-template: '* $TITLE (#$NUMBER) @$AUTHOR'


### PR DESCRIPTION
### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind chore

### What this PR does / why we need it:

At present, we are using Prow to collect release notes from pull request, this is why we have pull request #410. 

Then, we don't want to give up using release-drafter, but we have made some efforts on labeling `no-changelog`, please see https://github.com/kubesphere/test-infra/pull/34, but it failed.

At last, I found a label [release-notes-none](https://github.com/kubesphere/ks-devops/labels?q=release) will be labeled if we have no release note in pull request template. So it might be helpful to let release-drafter exclude that label.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
```
```

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
