### PR TITLE
Add an override flag to the tool cmd jwt

### DIFF
--- a/cmd/tools/jwt/app/configmap_updater.go
+++ b/cmd/tools/jwt/app/configmap_updater.go
@@ -37,7 +37,7 @@ func (o *jwtOption) updateJenkinsToken(jwt, ns, configMapName string) (err error
 		cfg = content
 	}
 
-	cfg = updateToken(cfg, jwt)
+	cfg = updateToken(cfg, jwt, o.overrideJenkinsToken)
 
 	configMap.Data[config.DefaultConfigurationFileName] = cfg
 	_, err = o.configMapUpdater.UpdateConfigMap(ctx, configMap)

--- a/cmd/tools/jwt/app/jwt_root_test.go
+++ b/cmd/tools/jwt/app/jwt_root_test.go
@@ -37,8 +37,9 @@ func Test_generateJWT(t *testing.T) {
 
 func Test_updateToken(t *testing.T) {
 	type args struct {
-		content string
-		token   string
+		content  string
+		token    string
+		override bool
 	}
 	tests := []struct {
 		name string
@@ -47,13 +48,15 @@ func Test_updateToken(t *testing.T) {
 	}{{
 		name: "invalid yaml content",
 		args: args{
-			content: "fake",
+			content:  "fake",
+			override: true,
 		},
 		want: "fake",
 	}, {
 		name: "valid yaml without devops.token",
 		args: args{
-			content: "name: rick",
+			content:  "name: rick",
+			override: true,
 		},
 		want: "name: rick",
 	}, {
@@ -61,14 +64,25 @@ func Test_updateToken(t *testing.T) {
 		args: args{
 			content: `devops:
   password: fake`,
-			token: "token",
+			token:    "token",
+			override: true,
 		},
 		want: `devops:
   password: token`,
+	}, {
+		name: "do not override",
+		args: args{
+			content: `devops:
+  password: fake`,
+			token:    "token",
+			override: false,
+		},
+		want: `devops:
+  password: fake`,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := updateToken(tt.args.content, tt.args.token); got != tt.want {
+			if got := updateToken(tt.args.content, tt.args.token, tt.args.override); got != tt.want {
 				t.Errorf("updateToken() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Users cannot set a customized token of the Jenkins if there's no the override flag.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
You can use the following image to test it.
```
surenpi/devops-tools:dev-v3.2.1-f4b07eb
```

you can add the flag like this: `--override-jenkins-token=false`

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
