### PR TITLE
Delete PipelineRun not found in Jenkins

### DIFF
--- a/controllers/jenkins/pipelinerun/pipelinerun_controller.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller.go
@@ -68,7 +68,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	pipelineRun := &v1alpha3.PipelineRun{}
 	var err error
 	if err = r.Client.Get(ctx, req.NamespacedName, pipelineRun); err != nil {
-		log.Error(err, "unable to fetch PipelineRun")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/controllers/jenkins/pipelinerun/pipelinerun_synchronizer.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_synchronizer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"github.com/jenkins-zh/jenkins-client/pkg/job"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
@@ -65,36 +65,17 @@ func (r *SyncReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		r.recorder.Eventf(pipeline, v1.EventTypeWarning, FailedPipelineRunSync, "")
 		return ctrl.Result{}, err
 	}
-	var createdPipelineRuns []v1alpha3.PipelineRun
-	finder := newPipelineRunFinder(prList.Items)
-	isMultiBranch := pipeline.Spec.Type == v1alpha3.MultiBranchPipelineType
 
-	// a set of PipelineRuns found in Jenkins
-	foundPipelineRuns := make(map[string]bool)
-	for i := range jobRuns {
-		jobRun := &jobRuns[i]
-		if foundPipelineRun, ok := finder.find(jobRun, isMultiBranch); !ok {
-			pipelineRun, err := r.createPipelineRun(pipeline, jobRun)
-			if err == nil {
-				createdPipelineRuns = append(createdPipelineRuns, *pipelineRun)
-			} else {
-				log.Error(err, "failed to create bare PipelineRun", "JenkinsRun", jobRun)
-			}
-		} else {
-			foundPipelineRuns[foundPipelineRun.GetName()] = true
-		}
+	finder := newPipelineRunFinder(prList.Items)
+
+	pipelineRunsToBeCreated := createBarePipelineRunsIfNotPresent(finder, pipeline, jobRuns)
+	if errs := r.createPipelineRuns(ctx, pipelineRunsToBeCreated); len(errs) > 0 {
+		log.V(5).Error(utilerrors.NewAggregate(errs), "failed to create all of PipelineRuns", "pipelineRunsToBeCreated", pipelineRunsToBeCreated)
 	}
 
-	for i := range prList.Items {
-		pipelineRun := &prList.Items[i]
-		if _, found := foundPipelineRuns[pipelineRun.GetName()]; !found {
-			// delete it directly if not found in Jenkins
-			if err := r.Client.Delete(ctx, pipelineRun); err != nil && !errors.IsNotFound(err) {
-				log.Error(err, "failed to delete PipelineRun", "PipelineRun", pipelineRun)
-			} else {
-				log.V(5).Info("deleted PipelineRun which was not found in Jenkins", "PipelineRun", pipelineRun)
-			}
-		}
+	pipelineRunsToBeDeleted := collectPipelineRunsDeletedInJenkins(finder, pipeline.IsMultiBranch(), jobRuns, prList.Items)
+	if errs := r.deletePipelineRuns(ctx, pipelineRunsToBeDeleted); len(errs) > 0 {
+		log.V(5).Error(utilerrors.NewAggregate(errs), "failed to delete all of PipelineRuns", "pipelineRunsToBeDeleted", pipelineRunsToBeDeleted)
 	}
 
 	if err := r.synchronizedSuccessfully(req.NamespacedName); err != nil {
@@ -104,8 +85,61 @@ func (r *SyncReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	log.Info("synchronized PipelineRun successfully")
 
 	r.recorder.Eventf(pipeline, v1.EventTypeNormal, PipelineRunSynced,
-		"Successfully synchronized %d PipelineRuns(s). PipelineRuns/JenkinsRuns proportion is %d/%d", len(createdPipelineRuns), len(prList.Items), len(jobRuns))
+		"Successfully synchronized %d PipelineRuns(s). PipelineRuns/JenkinsRuns proportion is %d/%d", len(pipelineRunsToBeCreated), len(prList.Items), len(jobRuns))
 	return ctrl.Result{}, nil
+}
+
+func createBarePipelineRunsIfNotPresent(finder pipelineRunFinder, pipeline *v1alpha3.Pipeline, jobRuns []job.PipelineRun) []v1alpha3.PipelineRun {
+	var pipelineRunsToBeCreated []v1alpha3.PipelineRun
+	for i := range jobRuns {
+		jobRun := &jobRuns[i]
+		if _, ok := finder.find(jobRun, pipeline.IsMultiBranch()); !ok {
+			pipelineRunsToBeCreated = append(pipelineRunsToBeCreated, *createBarePipelineRun(pipeline, jobRun))
+		}
+	}
+	return pipelineRunsToBeCreated
+}
+
+func collectPipelineRunsDeletedInJenkins(finder pipelineRunFinder, isMultiBranch bool, jobRuns []job.PipelineRun, pipelineRuns []v1alpha3.PipelineRun) []v1alpha3.PipelineRun {
+	var pipelineRunsToBeDeleted []v1alpha3.PipelineRun
+	existingPipelineRunNameSet := map[string]bool{}
+	for i := range jobRuns {
+		jobRun := &jobRuns[i]
+		if pipelineRun, found := finder.find(jobRun, isMultiBranch); found {
+			existingPipelineRunNameSet[pipelineRun.Name] = true
+		}
+	}
+	for i := range pipelineRuns {
+		pipelineRun := &pipelineRuns[i]
+		if _, exist := existingPipelineRunNameSet[pipelineRun.Name]; !exist {
+			pipelineRunsToBeDeleted = append(pipelineRunsToBeDeleted, *pipelineRun)
+		}
+	}
+	return pipelineRunsToBeDeleted
+}
+
+func (r *SyncReconciler) createPipelineRuns(ctx context.Context, pipelineRuns []v1alpha3.PipelineRun) []error {
+	var errs []error
+	for i := range pipelineRuns {
+		pipelineRun := &pipelineRuns[i]
+		if err := r.Client.Create(ctx, pipelineRun); err != nil {
+			errs = append(errs, err)
+			// continue next creation
+		}
+	}
+	return errs
+}
+
+func (r *SyncReconciler) deletePipelineRuns(ctx context.Context, pipelineRuns []v1alpha3.PipelineRun) []error {
+	var errs []error
+	for i := range pipelineRuns {
+		pipelineRun := &pipelineRuns[i]
+		if err := r.Client.Delete(ctx, pipelineRun); err != nil {
+			errs = append(errs, err)
+			// continue next deletion
+		}
+	}
+	return errs
 }
 
 func (r *SyncReconciler) synchronizedSuccessfully(key client.ObjectKey) error {
@@ -127,18 +161,7 @@ func (r *SyncReconciler) synchronizedSuccessfully(key client.ObjectKey) error {
 	})
 }
 
-func (r *SyncReconciler) createPipelineRun(pipeline *v1alpha3.Pipeline, run *job.PipelineRun) (*v1alpha3.PipelineRun, error) {
-	pipelineRun, err := createBarePipelineRun(pipeline, run)
-	if err != nil {
-		return nil, err
-	}
-	if err := r.Client.Create(context.Background(), pipelineRun); err != nil {
-		return nil, err
-	}
-	return pipelineRun, nil
-}
-
-func createBarePipelineRun(pipeline *v1alpha3.Pipeline, run *job.PipelineRun) (*v1alpha3.PipelineRun, error) {
+func createBarePipelineRun(pipeline *v1alpha3.Pipeline, run *job.PipelineRun) *v1alpha3.PipelineRun {
 	var scm *v1alpha3.SCM
 	if pipeline.Spec.Type == v1alpha3.MultiBranchPipelineType {
 		// if the Pipeline is a multip-branch Pipeline, the run#Pipeline is the name of the branch
@@ -147,7 +170,7 @@ func createBarePipelineRun(pipeline *v1alpha3.Pipeline, run *job.PipelineRun) (*
 	}
 	pr := pipelinerun.CreatePipelineRun(pipeline, nil, scm)
 	pr.Annotations[v1alpha3.JenkinsPipelineRunIDAnnoKey] = run.ID
-	return pr, nil
+	return pr
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/api/devops/v1alpha3/pipeline_types.go
+++ b/pkg/api/devops/v1alpha3/pipeline_types.go
@@ -82,8 +82,12 @@ type PipelineList struct {
 	Items           []Pipeline `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&Pipeline{}, &PipelineList{})
+// IsMultiBranch returns true if this is a multi-branch Pipeline, false otherwise.
+func (p *Pipeline) IsMultiBranch() bool {
+	if p == nil {
+		return false
+	}
+	return p.Spec.Type == MultiBranchPipelineType
 }
 
 const (

--- a/pkg/api/devops/v1alpha3/pipeline_types_test.go
+++ b/pkg/api/devops/v1alpha3/pipeline_types_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The KubeSphere Authors.
+Copyright 2022 The KubeSphere Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/api/devops/v1alpha3/pipeline_types_test.go
+++ b/pkg/api/devops/v1alpha3/pipeline_types_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+)
+
+func TestPipeline_IsMultiBranch(t *testing.T) {
+	tests := []struct {
+		name     string
+		pipeline *Pipeline
+		want     bool
+	}{{
+		name:     "Should return false if the Pipeline is nil",
+		pipeline: nil,
+		want:     false,
+	}, {
+		name: "Should return false if the type of Pipeline is empty",
+		pipeline: &Pipeline{
+			Spec: PipelineSpec{
+				Type: "",
+			},
+		},
+		want: false,
+	}, {name: "Should return false if the type of Pipeline is pipeline",
+		pipeline: &Pipeline{
+			Spec: PipelineSpec{
+				Type: NoScmPipelineType,
+			},
+		},
+		want: false,
+	}, {
+		name: "Should return true if the type of Pipeline is multi-branch-pipeline",
+		pipeline: &Pipeline{
+			Spec: PipelineSpec{
+				Type: MultiBranchPipelineType,
+			},
+		},
+		want: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.pipeline.IsMultiBranch(); got != tt.want {
+				t.Errorf("Pipeline.IsMultiBranch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:

Delete PipelineRun not found in Jenkins when synchronizing PipelineRuns.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #332.

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
```
Docker image for test: johnniang/devops-controller:dev-v3.2.1-3d87bb3
```

#### Steps to test

1. Replace docker image of devops-controller deployment
2. Create a simple Pipeline
    ```groovy
    pipeline {
      agent none
      
      stages {
        stage('Echo') {
          steps {
            echo "Hello World!"
          }
        }
      }
    }
    ```
3. Run it multiple times
4. Go into Jenkins dashboard
5. Delete any of Jenkins builds
6. Go into KubeSphere DevOps and see PipelineRuns

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
