### PR TITLE
Fix the API for getting devops project

### DIFF
--- a/pkg/apiserver/filters/requestinfo.go
+++ b/pkg/apiserver/filters/requestinfo.go
@@ -78,6 +78,6 @@ func injectToken(req *http.Request) (requestWithTokenContext *http.Request) {
 	authorization := req.Header.Get("X-Authorization")
 	token := strings.ReplaceAll(authorization, "Bearer ", "")
 	token = strings.ReplaceAll(token, "bearer ", "")
-	requestWithTokenContext = req.WithContext(context.WithValue(req.Context(), constants.K8SToken, token))
+	requestWithTokenContext = req.WithContext(context.WithValue(req.Context(), constants.K8SToken, constants.ContextKeyK8SToken(token)))
 	return
 }

--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -169,8 +169,9 @@ func registerRoutes(devopsClient devopsClient.Interface, k8sClient k8s.Client, w
 		To(handler.GetDevOpsProject).
 		Param(ws.PathParameter("workspace", "workspace name")).
 		Param(ws.PathParameter("devops", "project name")).
-		Doc("Get the devopsproject of the specified workspace for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
+		Param(ws.QueryParameter("generateName", "use the name as a regular one or generate name")).
+		Doc("Get the devops project of the specified workspace for the current user").
+		Returns(http.StatusOK, api.StatusOK, v1alpha3.DevOpsProject{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
 	ws.Route(ws.PUT("/workspaces/{workspace}/devops/{devops}").

--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -169,7 +169,7 @@ func registerRoutes(devopsClient devopsClient.Interface, k8sClient k8s.Client, w
 		To(handler.GetDevOpsProject).
 		Param(ws.PathParameter("workspace", "workspace name")).
 		Param(ws.PathParameter("devops", "project name")).
-		Param(ws.QueryParameter("generateName", "use the name as a regular one or generate name")).
+		 Param(ws.QueryParameter("generateName", "use '{devops}` as a generatName if 'generateName=true', or as a regular name")).
 		Doc("Get the devops project of the specified workspace for the current user").
 		Returns(http.StatusOK, api.StatusOK, v1alpha3.DevOpsProject{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))

--- a/pkg/kapis/devops/v1alpha3/register_test.go
+++ b/pkg/kapis/devops/v1alpha3/register_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/emicklei/go-restful"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"kubesphere.io/devops/pkg/api/devops/v1alpha1"
@@ -19,14 +20,18 @@ import (
 )
 
 func TestAPIsExist(t *testing.T) {
-	httpWriter := httptest.NewRecorder()
 	schema, err := v1alpha1.SchemeBuilder.Register().Build()
 	assert.Nil(t, err)
 
 	AddToContainer(restful.DefaultContainer, fakedevops.NewFakeDevops(nil),
-		k8s.NewFakeClientSets(k8sfake.NewSimpleClientset(), nil, nil, "", nil,
+		k8s.NewFakeClientSets(k8sfake.NewSimpleClientset(&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "fake", Namespace: "fake"},
+		}), nil, nil, "", nil,
 			fakeclientset.NewSimpleClientset(&v1alpha3.DevOpsProject{
 				ObjectMeta: metav1.ObjectMeta{Name: "fake"},
+				Status:     v1alpha3.DevOpsProjectStatus{AdminNamespace: "fake"},
+			}, &v1alpha3.Pipeline{
+				ObjectMeta: metav1.ObjectMeta{Name: "fake", Namespace: "fake"},
 			})),
 		fake.NewFakeClientWithScheme(schema))
 
@@ -133,8 +138,71 @@ func TestAPIsExist(t *testing.T) {
 			httpRequest, _ := http.NewRequest(tt.args.method,
 				"http://fake.com/kapis/devops.kubesphere.io/v1alpha3"+tt.args.uri, nil)
 			httpRequest = httpRequest.WithContext(context.WithValue(context.TODO(), constants.K8SToken, constants.ContextKeyK8SToken("")))
+
+			httpWriter := httptest.NewRecorder()
 			restful.DefaultContainer.Dispatch(httpWriter, httpRequest)
 			assert.NotEqual(t, httpWriter.Code, 404)
+		})
+	}
+}
+
+func TestGetDevOpsProject(t *testing.T) {
+	schema, err := v1alpha1.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+	container := restful.NewContainer()
+
+	AddToContainer(container, fakedevops.NewFakeDevops(nil),
+		k8s.NewFakeClientSets(k8sfake.NewSimpleClientset(), nil, nil, "", nil,
+			fakeclientset.NewSimpleClientset(&v1alpha3.DevOpsProject{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "fake",
+					Name:         "generated-fake",
+					Labels: map[string]string{
+						constants.WorkspaceLabelKey: "ws",
+					},
+				},
+			})),
+		fake.NewFakeClientWithScheme(schema))
+
+	type args struct {
+		method string
+		uri    string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		expectCode int
+	}{{
+		name: "normal case",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/workspaces/ws/devops/generated-fake",
+		},
+		expectCode: http.StatusOK,
+	}, {
+		name: "find by a generateName",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/workspaces/ws/devops/fake?generateName=true",
+		},
+		expectCode: http.StatusOK,
+	}, {
+		name: "wrong workspace name",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/workspaces/fake/devops/fake?generateName=true",
+		},
+		expectCode: http.StatusBadRequest,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpRequest, _ := http.NewRequest(tt.args.method,
+				"http://fake.com/kapis/devops.kubesphere.io/v1alpha3"+tt.args.uri, nil)
+			httpRequest = httpRequest.WithContext(context.WithValue(context.TODO(), constants.K8SToken, constants.ContextKeyK8SToken("")))
+
+			httpWriter := httptest.NewRecorder()
+			container.Dispatch(httpWriter, httpRequest)
+			assert.Equal(t, tt.expectCode, httpWriter.Code)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Currently, the UI try to use this API to find if the desired name is duplicated. But for DevOpsProject, we should use the generateName instead of the resource real name.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

This PR should be able to fix part of https://github.com/kubesphere/console/issues/2707

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
```
surenpi/devops-apiserver:dev-v3.2.1-0740803
```

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
Fix the API for getting devops project
```

## Test results

![image](https://user-images.githubusercontent.com/1450685/148721350-2fb197b0-4135-4503-88d4-eac335cf73e6.png)

![image](https://user-images.githubusercontent.com/1450685/148721343-dd9b3753-b0f4-40b8-aa06-31ca33517e41.png)

/cc @kubesphere/sig-devops 