### PR TITLE
Support to verify SCM token directly instead of call Jenkins API

### DIFF
--- a/cmd/apiserver/app/options/options.go
+++ b/cmd/apiserver/app/options/options.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"kubesphere.io/devops/pkg/client/cache"
 	"kubesphere.io/devops/pkg/client/sonarqube"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -159,6 +160,7 @@ func (s *ServerRunOptions) NewAPIServer(stopCh <-chan struct{}) (*apiserver.APIS
 	}
 
 	sch := scheme.Scheme
+	_ = v1.SchemeBuilder.AddToScheme(sch)
 	apis.AddToScheme(sch)
 
 	// we create a manager for getting client and cache, although the manager is for creating controller. At last, we

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/h2non/gock v1.0.9
 	github.com/jenkins-zh/jenkins-client v0.0.8
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/onsi/ginkgo v1.16.4

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/pkg/apiserver/filters/requestinfo.go
+++ b/pkg/apiserver/filters/requestinfo.go
@@ -78,6 +78,7 @@ func injectToken(req *http.Request) (requestWithTokenContext *http.Request) {
 	authorization := req.Header.Get("X-Authorization")
 	token := strings.ReplaceAll(authorization, "Bearer ", "")
 	token = strings.ReplaceAll(token, "bearer ", "")
-	requestWithTokenContext = req.WithContext(context.WithValue(req.Context(), constants.K8SToken, constants.ContextKeyK8SToken(token)))
+	requestWithTokenContext = req.WithContext(context.WithValue(req.Context(), constants.K8SToken,
+		constants.ContextKeyK8SToken(token)))
 	return
 }

--- a/pkg/client/devops/jenkins/pure_request.go
+++ b/pkg/client/devops/jenkins/pure_request.go
@@ -35,8 +35,8 @@ func (j *Jenkins) SendPureRequest(path string, httpParameters *devops.HttpParame
 	return resBody, err
 }
 
-// provider request header to call jenkins api.
-// transfer bearer token to basic token for inner Oauth and Jeknins
+// SendPureRequestWithHeaderResp provider request header to call jenkins api.
+// transfer bearer token to basic token for inner Oauth and Jenkins
 func (j *Jenkins) SendPureRequestWithHeaderResp(path string, httpParameters *devops.HttpParameters) ([]byte, http.Header, error) {
 	apiURL, err := url.Parse(j.Server + path)
 	if err != nil {

--- a/pkg/client/git/client.go
+++ b/pkg/client/git/client.go
@@ -1,0 +1,93 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	goscm "github.com/drone/go-scm/scm"
+	"github.com/drone/go-scm/scm/driver/github"
+	"github.com/drone/go-scm/scm/driver/gitlab"
+	"github.com/drone/go-scm/scm/transport/oauth2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+)
+
+// ClientFactory responsible for creating a git client
+type ClientFactory struct {
+	provider  string
+	secretRef *v1.SecretReference
+	k8sClient ResourceGetter
+}
+
+// NewClientFactory creates an instance of the ClientFactory
+func NewClientFactory(provider string, secretRef *v1.SecretReference, k8sClient ResourceGetter) *ClientFactory {
+	return &ClientFactory{
+		provider:  provider,
+		secretRef: secretRef,
+		k8sClient: k8sClient,
+	}
+}
+
+// GetClient returns the git client with auth
+func (c *ClientFactory) GetClient() (client *goscm.Client, err error) {
+	switch c.provider {
+	case "github":
+		client = github.NewDefault()
+	case "gitlab":
+		client = gitlab.NewDefault()
+	default:
+		err = errors.New("not support git provider: " + c.provider)
+		return
+	}
+
+	var gitToken string
+	if gitToken, err = c.getTokenFromSecret(c.secretRef); err != nil {
+		return
+	}
+
+	client.Client = &http.Client{
+		Transport: &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(
+				&goscm.Token{
+					Token: gitToken,
+				},
+			),
+		},
+	}
+	return
+}
+
+func (c *ClientFactory) getTokenFromSecret(secretRef *v1.SecretReference) (token string, err error) {
+	var gitSecret *v1.Secret
+	if gitSecret, err = c.getSecret(secretRef); err != nil {
+		return
+	}
+
+	switch gitSecret.Type {
+	case v1.SecretTypeBasicAuth:
+		token = string(gitSecret.Data[v1.BasicAuthPasswordKey])
+	case v1.SecretTypeOpaque:
+		token = string(gitSecret.Data[v1.ServiceAccountTokenKey])
+	}
+	return
+}
+
+// getSecret returns the secret, taking the namespace from GitRepository if it is empty
+func (c *ClientFactory) getSecret(ref *v1.SecretReference) (secret *v1.Secret, err error) {
+	secret = &v1.Secret{}
+	ns := ref.Namespace
+
+	if err = c.k8sClient.Get(context.TODO(), types.NamespacedName{
+		Namespace: ns, Name: ref.Name,
+	}, secret); err != nil {
+		err = fmt.Errorf("cannot get secret %v, error is: %v", secret, err)
+	}
+	return
+}
+
+// ResourceGetter represent the interface for getting Kubernetes resource
+type ResourceGetter interface {
+	Get(ctx context.Context, key types.NamespacedName, obj runtime.Object) error
+}

--- a/pkg/client/git/client_test.go
+++ b/pkg/client/git/client_test.go
@@ -1,0 +1,116 @@
+package git
+
+import (
+	"fmt"
+	"github.com/drone/go-scm/scm"
+	"github.com/drone/go-scm/scm/driver/github"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"strings"
+	"testing"
+)
+
+func TestGetClient(t *testing.T) {
+	schema, err := v1alpha1.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+	err = v1.SchemeBuilder.AddToScheme(schema)
+	assert.Nil(t, err)
+
+	basicSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "basicSecret",
+			Namespace: "ns",
+		},
+		Type: v1.SecretTypeBasicAuth,
+		Data: map[string][]byte{
+			v1.BasicAuthPasswordKey: []byte("token"),
+		},
+	}
+	opaqueSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "opaqueSecret",
+			Namespace: "ns",
+		},
+		Type: v1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			v1.ServiceAccountTokenKey: []byte("token"),
+		},
+	}
+	type fields struct {
+		provider  string
+		secretRef *v1.SecretReference
+		k8sClient client.Client
+	}
+	type args struct {
+		repo *v1alpha1.GitRepository
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantClient *scm.Client
+		wantErr    assert.ErrorAssertionFunc
+	}{{
+		name: "not support git provider",
+		args: args{
+			repo: &v1alpha1.GitRepository{
+				Spec: v1alpha1.GitRepositorySpec{
+					Provider: "not-support",
+				},
+			},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.NotNil(t, err, i)
+			assert.Equal(t, strings.HasPrefix(err.Error(), "not support git provider: "), true, i)
+			return true
+		},
+	}, {
+		name: "no secret found",
+		fields: fields{
+			k8sClient: fake.NewFakeClientWithScheme(schema),
+			provider:  "github",
+			secretRef: &v1.SecretReference{Namespace: "fake", Name: "fake"},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.NotNil(t, err, i)
+			return true
+		},
+		wantClient: github.NewDefault(),
+	}, {
+		name: "github provider",
+		fields: fields{
+			k8sClient: fake.NewFakeClientWithScheme(schema, basicSecret.DeepCopy()),
+			provider:  "github",
+			secretRef: &v1.SecretReference{Namespace: "ns", Name: "basicSecret"},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.Nil(t, err, i)
+			return false
+		},
+	}, {
+		name: "gitlab provider",
+		fields: fields{
+			k8sClient: fake.NewFakeClientWithScheme(schema, opaqueSecret.DeepCopy()),
+			provider:  "gitlab",
+			secretRef: &v1.SecretReference{Namespace: "ns", Name: "opaqueSecret"},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.Nil(t, err, i)
+			return false
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewClientFactory(tt.fields.provider, tt.fields.secretRef, tt.fields.k8sClient)
+			gotClient, err := r.GetClient()
+			if !tt.wantErr(t, err, fmt.Sprintf("GetClient() %s", tt.name)) {
+				return
+			}
+			assert.Equalf(t, tt.wantClient, gotClient, fmt.Sprintf("GetClient() %s", tt.name))
+		})
+	}
+}

--- a/pkg/client/git/message.go
+++ b/pkg/client/git/message.go
@@ -6,8 +6,6 @@ type VerifyResponse struct {
 	Message string `json:"message"`
 	// Code represents a group of cases
 	Code int `json:"code"`
-	// Errors contain all related errors
-	Errors []interface{} `json:"errors"`
 }
 
 func VerifyPass() *VerifyResponse {
@@ -16,17 +14,16 @@ func VerifyPass() *VerifyResponse {
 	}
 }
 
-func VerifyFailed(message string, code int, err error) *VerifyResponse {
+func VerifyFailed(message string, code int) *VerifyResponse {
 	return &VerifyResponse{
 		Message: message,
 		Code:    code,
-		Errors:  []interface{}{err},
 	}
 }
 
-func VerifyResult(message string, code int, err error) *VerifyResponse {
+func VerifyResult(err error, code int) *VerifyResponse {
 	if err == nil {
 		return VerifyPass()
 	}
-	return VerifyFailed(message, code, err)
+	return VerifyFailed(err.Error(), code)
 }

--- a/pkg/client/git/message.go
+++ b/pkg/client/git/message.go
@@ -1,0 +1,32 @@
+package git
+
+// VerifyResponse represents a response of SCM auth verify
+type VerifyResponse struct {
+	// Message is the detail of the result
+	Message string `json:"message"`
+	// Code represents a group of cases
+	Code int `json:"code"`
+	// Errors contain all related errors
+	Errors []interface{} `json:"errors"`
+}
+
+func VerifyPass() *VerifyResponse {
+	return &VerifyResponse{
+		Message: "ok",
+	}
+}
+
+func VerifyFailed(message string, code int, err error) *VerifyResponse {
+	return &VerifyResponse{
+		Message: message,
+		Code:    code,
+		Errors:  []interface{}{err},
+	}
+}
+
+func VerifyResult(message string, code int, err error) *VerifyResponse {
+	if err == nil {
+		return VerifyPass()
+	}
+	return VerifyFailed(message, code, err)
+}

--- a/pkg/client/git/message_test.go
+++ b/pkg/client/git/message_test.go
@@ -37,12 +37,11 @@ func TestVerifyResult(t *testing.T) {
 		want: &VerifyResponse{
 			Message: "failed",
 			Code:    1234,
-			Errors:  []interface{}{errors.New("failed")},
 		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, VerifyResult(tt.args.message, tt.args.code, tt.args.err), "VerifyResult(%v, %v, %v)", tt.args.message, tt.args.code, tt.args.err)
+			assert.Equalf(t, tt.want, VerifyResult(tt.args.err, tt.args.code), "VerifyResult(%v, %v, %v)", tt.args.message, tt.args.code, tt.args.err)
 		})
 	}
 }

--- a/pkg/client/git/message_test.go
+++ b/pkg/client/git/message_test.go
@@ -1,0 +1,48 @@
+package git
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestVerifyPass(t *testing.T) {
+	verifyPass := VerifyPass()
+	assert.NotNil(t, verifyPass)
+	assert.Equal(t, 0, verifyPass.Code)
+	assert.Equal(t, "ok", verifyPass.Message)
+}
+
+func TestVerifyResult(t *testing.T) {
+	type args struct {
+		message string
+		code    int
+		err     error
+	}
+	tests := []struct {
+		name string
+		args args
+		want *VerifyResponse
+	}{{
+		name: "no error",
+		args: args{},
+		want: &VerifyResponse{Message: "ok"},
+	}, {
+		name: "error case",
+		args: args{
+			message: "failed",
+			code:    1234,
+			err:     errors.New("failed"),
+		},
+		want: &VerifyResponse{
+			Message: "failed",
+			Code:    1234,
+			Errors:  []interface{}{errors.New("failed")},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, VerifyResult(tt.args.message, tt.args.code, tt.args.err), "VerifyResult(%v, %v, %v)", tt.args.message, tt.args.code, tt.args.err)
+		})
+	}
+}

--- a/pkg/kapis/devops/v1alpha3/handler.go
+++ b/pkg/kapis/devops/v1alpha3/handler.go
@@ -39,7 +39,6 @@ type devopsHandler struct {
 }
 
 func newDevOpsHandler(devopsClient devopsClient.Interface, k8sClient k8s.Client) *devopsHandler {
-
 	return &devopsHandler{
 		k8sClient:    k8sClient,
 		devopsClient: devopsClient,
@@ -62,8 +61,7 @@ func (h *devopsHandler) GetDevOpsProject(request *restful.Request, response *res
 		default:
 			project, err = client.GetDevOpsProject(workspace, devopsProject)
 		}
-
-		errorHandle(err, response, request, project)
+		errorHandle(request, response, project, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -75,7 +73,7 @@ func (h *devopsHandler) ListDevOpsProject(request *restful.Request, response *re
 
 	if client, err := h.getDevOps(request); err == nil {
 		projectList, err := client.ListDevOpsProject(workspace, limit, offset)
-		errorHandle(err, response, request, projectList)
+		errorHandle(request, response, projectList, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -125,7 +123,7 @@ func (h *devopsHandler) UpdateDevOpsProject(request *restful.Request, response *
 
 	if client, err := h.getDevOps(request); err == nil {
 		project, err := client.UpdateDevOpsProject(workspace, &devOpsProject)
-		errorHandle(err, response, request, project)
+		errorHandle(request, response, project, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -137,7 +135,7 @@ func (h *devopsHandler) DeleteDevOpsProject(request *restful.Request, response *
 
 	if client, err := h.getDevOps(request); err == nil {
 		err := client.DeleteDevOpsProject(workspace, devops)
-		errorHandle(err, response, request, servererr.None)
+		errorHandle(request, response, nil, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -150,7 +148,7 @@ func (h *devopsHandler) GetPipeline(request *restful.Request, response *restful.
 
 	if client, err := h.getDevOps(request); err == nil {
 		obj, err := client.GetPipelineObj(devops, pipeline)
-		errorHandle(err, response, request, obj)
+		errorHandle(request, response, obj, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -162,7 +160,7 @@ func (h *devopsHandler) ListPipeline(request *restful.Request, response *restful
 
 	if client, err := h.getDevOps(request); err == nil {
 		objs, err := client.ListPipelineObj(devops, query)
-		errorHandle(err, response, request, objs)
+		errorHandle(request, response, objs, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -181,7 +179,7 @@ func (h *devopsHandler) CreatePipeline(request *restful.Request, response *restf
 
 	if client, err := h.getDevOps(request); err == nil {
 		created, err := client.CreatePipelineObj(devops, &pipeline)
-		errorHandle(err, response, request, created)
+		errorHandle(request, response, created, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -201,7 +199,7 @@ func (h *devopsHandler) UpdatePipeline(request *restful.Request, response *restf
 
 	if client, err := h.getDevOps(request); err == nil {
 		obj, err := client.UpdatePipelineObj(devops, &pipeline)
-		errorHandle(err, response, request, obj)
+		errorHandle(request, response, obj, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -215,20 +213,20 @@ func (h *devopsHandler) DeletePipeline(request *restful.Request, response *restf
 
 	if client, err := h.getDevOps(request); err == nil {
 		err := client.DeletePipelineObj(devops, pipeline)
-		errorHandle(err, response, request, servererr.None)
+		errorHandle(request, response, nil, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
 }
 
-//credential handler about get/list/post/put/delete
+// GetCredential handler about get/list/post/put/delete
 func (h *devopsHandler) GetCredential(request *restful.Request, response *restful.Response) {
 	devops := request.PathParameter("devops")
 	credential := request.PathParameter("credential")
 
 	if client, err := h.getDevOps(request); err == nil {
 		obj, err := client.GetCredentialObj(devops, credential)
-		errorHandle(err, response, request, obj)
+		errorHandle(request, response, obj, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -240,7 +238,7 @@ func (h *devopsHandler) ListCredential(request *restful.Request, response *restf
 
 	if client, err := h.getDevOps(request); err == nil && client != nil {
 		objs, err := client.ListCredentialObj(devops, query)
-		errorHandle(err, response, request, objs)
+		errorHandle(request, response, objs, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -259,7 +257,7 @@ func (h *devopsHandler) CreateCredential(request *restful.Request, response *res
 
 	if client, err := h.getDevOps(request); err == nil {
 		created, err := client.CreateCredentialObj(devops, &obj)
-		errorHandle(err, response, request, created)
+		errorHandle(request, response, created, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
@@ -278,25 +276,17 @@ func (h *devopsHandler) UpdateCredential(request *restful.Request, response *res
 
 	if client, err := h.getDevOps(request); err == nil {
 		updated, err := client.UpdateCredentialObj(devops, &obj)
-		errorHandle(err, response, request, updated)
+		errorHandle(request, response, updated, err)
 	} else {
 		api.HandleBadRequest(response, request, err)
 	}
 }
 
-func (h *devopsHandler) DeleteCredential(request *restful.Request, response *restful.Response) {
-	devopsProject := request.PathParameter("devops")
-	credential := request.PathParameter("credential")
-
-	if client, err := h.getDevOps(request); err == nil {
-		err := client.DeleteCredentialObj(devopsProject, credential)
-		errorHandle(err, response, request, servererr.None)
-	} else {
-		api.HandleBadRequest(response, request, err)
+func errorHandle(request *restful.Request, response *restful.Response, obj interface{}, err error) {
+	if obj == nil {
+		obj = servererr.None
 	}
-}
 
-func errorHandle(err error, response *restful.Response, request *restful.Request, obj interface{}) {
 	if err != nil {
 		klog.Error(err)
 		if errors.IsNotFound(err) {
@@ -307,6 +297,18 @@ func errorHandle(err error, response *restful.Response, request *restful.Request
 		return
 	}
 	_ = response.WriteEntity(obj)
+}
+
+func (h *devopsHandler) DeleteCredential(request *restful.Request, response *restful.Response) {
+	devopsProject := request.PathParameter("devops")
+	credential := request.PathParameter("credential")
+
+	if client, err := h.getDevOps(request); err == nil {
+		err := client.DeleteCredentialObj(devopsProject, credential)
+		errorHandle(request, response, servererr.None, err)
+	} else {
+		api.HandleBadRequest(response, request, err)
+	}
 }
 
 func (h *devopsHandler) getDevOps(request *restful.Request) (operator devops.DevopsOperator, err error) {

--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -23,7 +23,7 @@ import (
 	"kubesphere.io/devops/pkg/kapis/devops/v1alpha3/scm"
 	"net/http"
 
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -65,7 +65,6 @@ func AddToContainer(container *restful.Container, devopsClient devopsClient.Inte
 
 func registerRoutes(devopsClient devopsClient.Interface, k8sClient k8s.Client, client client.Client, ws *restful.WebService) {
 	handler := newDevOpsHandler(devopsClient, k8sClient)
-	registerRoutersForCredentials(handler, ws)
 	registerRoutersForCredentials(handler, ws)
 	registerRoutersForPipelines(handler, ws)
 	registerRoutersForWorkspace(handler, ws)

--- a/pkg/kapis/devops/v1alpha3/register_test.go
+++ b/pkg/kapis/devops/v1alpha3/register_test.go
@@ -2,7 +2,9 @@ package v1alpha3
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/emicklei/go-restful"
+	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,6 +13,7 @@ import (
 	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
 	fakeclientset "kubesphere.io/devops/pkg/client/clientset/versioned/fake"
 	fakedevops "kubesphere.io/devops/pkg/client/devops/fake"
+	"kubesphere.io/devops/pkg/client/git"
 	"kubesphere.io/devops/pkg/client/k8s"
 	"kubesphere.io/devops/pkg/constants"
 	"net/http"
@@ -23,17 +26,27 @@ func TestAPIsExist(t *testing.T) {
 	schema, err := v1alpha1.SchemeBuilder.Register().Build()
 	assert.Nil(t, err)
 
-	AddToContainer(restful.DefaultContainer, fakedevops.NewFakeDevops(nil),
+	err = v1.SchemeBuilder.AddToScheme(schema)
+	assert.Nil(t, err)
+
+	container := restful.NewContainer()
+	AddToContainer(container, fakedevops.NewFakeDevops(nil),
 		k8s.NewFakeClientSets(k8sfake.NewSimpleClientset(&v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "fake", Namespace: "fake"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fake", Namespace: "fake",
+			},
 		}), nil, nil, "", nil,
 			fakeclientset.NewSimpleClientset(&v1alpha3.DevOpsProject{
 				ObjectMeta: metav1.ObjectMeta{Name: "fake"},
 				Status:     v1alpha3.DevOpsProjectStatus{AdminNamespace: "fake"},
 			}, &v1alpha3.Pipeline{
-				ObjectMeta: metav1.ObjectMeta{Name: "fake", Namespace: "fake"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "fake", Name: "fake"},
 			})),
-		fake.NewFakeClientWithScheme(schema))
+		fake.NewFakeClientWithScheme(schema, &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fake", Namespace: "fake",
+			},
+		}))
 
 	type args struct {
 		method string
@@ -140,8 +153,109 @@ func TestAPIsExist(t *testing.T) {
 			httpRequest = httpRequest.WithContext(context.WithValue(context.TODO(), constants.K8SToken, constants.ContextKeyK8SToken("")))
 
 			httpWriter := httptest.NewRecorder()
-			restful.DefaultContainer.Dispatch(httpWriter, httpRequest)
-			assert.NotEqual(t, httpWriter.Code, 404)
+			container.Dispatch(httpWriter, httpRequest)
+			assert.NotEqual(t, 404, httpWriter.Code)
+		})
+	}
+}
+
+func TestSCMAPI(t *testing.T) {
+	schema, err := v1alpha1.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+
+	err = v1.SchemeBuilder.AddToScheme(schema)
+	assert.Nil(t, err)
+
+	container := restful.NewContainer()
+	AddToContainer(container, fakedevops.NewFakeDevops(nil),
+		k8s.NewFakeClientSets(k8sfake.NewSimpleClientset(), nil, nil, "", nil,
+			fakeclientset.NewSimpleClientset()),
+		fake.NewFakeClientWithScheme(schema, &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "token", Namespace: "default",
+			},
+			Type: v1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				v1.ServiceAccountTokenKey: []byte("token"),
+			},
+		}))
+
+	type args struct {
+		method string
+		uri    string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		prepare func()
+		verify  func(code int, response []byte, t *testing.T)
+	}{{
+		name: "verify",
+		args: args{
+			method: http.MethodPost,
+			uri:    "/scms/github/verify?secret=token&secretNamespace=default",
+		},
+		prepare: func() {
+			var mockHeaders = map[string]string{
+				"X-GitHub-Request-Id":   "DD0E:6011:12F21A8:1926790:5A2064E2",
+				"X-RateLimit-Limit":     "60",
+				"X-RateLimit-Remaining": "59",
+				"X-RateLimit-Reset":     "1512076018",
+			}
+
+			var mockPageHeaders = map[string]string{
+				"Link": `<https://api.github.com/resource?page=1>; rel="next",` +
+					`<https://api.github.com/resource?page=1>; rel="prev",` +
+					`<https://api.github.com/resource?page=1>; rel="first",` +
+					`<https://api.github.com/resource?page=1>; rel="last"`,
+			}
+
+			gock.New("https://api.github.com").
+				Get("/user/orgs").
+				MatchParam("per_page", "1").
+				MatchParam("page", "1").
+				Reply(200).
+				Type("application/json").
+				SetHeaders(mockHeaders).
+				SetHeaders(mockPageHeaders).
+				File("testdata/orgs.json")
+		},
+		verify: func(code int, response []byte, t *testing.T) {
+			assert.Equal(t, 200, code)
+
+			resp := &git.VerifyResponse{}
+			err := json.Unmarshal(response, resp)
+			assert.Nil(t, err)
+			assert.Equal(t, "ok", resp.Message)
+		},
+	}, {
+		name: "verify against a fake scm type",
+		args: args{
+			method: http.MethodPost,
+			uri:    "/scms/fake/verify?secret=token&secretNamespace=default",
+		},
+		prepare: func() {},
+		verify: func(code int, response []byte, t *testing.T) {
+			assert.Equal(t, http.StatusOK, code)
+
+			resp := &git.VerifyResponse{}
+			err := json.Unmarshal(response, resp)
+			assert.Nil(t, err, string(response))
+			assert.Equal(t, 100, resp.Code)
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer gock.Off()
+			tt.prepare()
+
+			httpRequest, _ := http.NewRequest(tt.args.method,
+				"http://fake.com/kapis/devops.kubesphere.io/v1alpha3"+tt.args.uri, nil)
+			httpRequest = httpRequest.WithContext(context.WithValue(context.TODO(), constants.K8SToken, constants.ContextKeyK8SToken("")))
+
+			httpWriter := httptest.NewRecorder()
+			container.Dispatch(httpWriter, httpRequest)
+			tt.verify(httpWriter.Code, httpWriter.Body.Bytes(), t)
 		})
 	}
 }

--- a/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
+++ b/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
@@ -1,0 +1,50 @@
+package scm
+
+import (
+	"context"
+	goscm "github.com/drone/go-scm/scm"
+	"github.com/emicklei/go-restful"
+	v1 "k8s.io/api/core/v1"
+	"kubesphere.io/devops/pkg/client/git"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Handler holds all the API handlers of SCM
+type Handler struct {
+	k8sClient client.Client
+}
+
+// NewHandler creates the instance of the SCM handler
+func NewHandler(k8sClient client.Client) *Handler {
+	return &Handler{k8sClient: k8sClient}
+}
+
+// Verify verifies a SCM auth
+func (h *Handler) Verify(request *restful.Request, response *restful.Response) {
+	scm := request.PathParameter("scm")
+	secretName := request.QueryParameter("secret")
+	secretNamespace := request.QueryParameter("secretNamespace")
+
+	factory := git.NewClientFactory(scm, &v1.SecretReference{
+		Namespace: secretNamespace, Name: secretName,
+	}, h.k8sClient)
+
+	var c *goscm.Client
+	var err error
+	var code int
+	var msg string
+
+	if c, err = factory.GetClient(); err == nil {
+		var resp *goscm.Response
+
+		if _, resp, err = c.Organizations.List(context.TODO(), goscm.ListOptions{Size: 1, Page: 1}); err == nil {
+			code = resp.Status
+		}
+	} else {
+		code = 100
+		msg = err.Error()
+	}
+
+	response.Header().Set(restful.HEADER_ContentType, restful.MIME_JSON)
+	_ = response.WriteAsJson(git.VerifyResult(msg, code, err))
+}

--- a/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
+++ b/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
@@ -32,7 +32,6 @@ func (h *Handler) Verify(request *restful.Request, response *restful.Response) {
 	var c *goscm.Client
 	var err error
 	var code int
-	var msg string
 
 	if c, err = factory.GetClient(); err == nil {
 		var resp *goscm.Response
@@ -42,9 +41,8 @@ func (h *Handler) Verify(request *restful.Request, response *restful.Response) {
 		}
 	} else {
 		code = 100
-		msg = err.Error()
 	}
 
 	response.Header().Set(restful.HEADER_ContentType, restful.MIME_JSON)
-	_ = response.WriteAsJson(git.VerifyResult(msg, code, err))
+	_ = response.WriteAsJson(git.VerifyResult(err, code))
 }

--- a/pkg/kapis/devops/v1alpha3/scm/scmhandler_test.go
+++ b/pkg/kapis/devops/v1alpha3/scm/scmhandler_test.go
@@ -1,0 +1,11 @@
+package scm
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewHandler(t *testing.T) {
+	handler := NewHandler(nil)
+	assert.NotNil(t, handler)
+}

--- a/pkg/kapis/devops/v1alpha3/testdata/orgs.json
+++ b/pkg/kapis/devops/v1alpha3/testdata/orgs.json
@@ -1,0 +1,15 @@
+[
+  {
+    "login": "github",
+    "id": 1,
+    "url": "https://api.github.com/orgs/github",
+    "repos_url": "https://api.github.com/orgs/github/repos",
+    "events_url": "https://api.github.com/orgs/github/events",
+    "hooks_url": "https://api.github.com/orgs/github/hooks",
+    "issues_url": "https://api.github.com/orgs/github/issues",
+    "members_url": "https://api.github.com/orgs/github/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "description": "A great organization"
+  }
+]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
There are two big reasons why we should have this feature:

* Verify a SCM token has no relationship with Jenkins. So, it is not reasonable to call Jenkins API
* We should avoid use a plain token text as possible as we can

Currently, we use [go-scm](https://github.com/drone/go-scm) which support multiple git providers.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
If you want to help to test it, please use the following temporary image:
```
kubespheredev/devops-apiserver:dev-v3.2.1-bdeb73d
```

![image](https://user-images.githubusercontent.com/1450685/148950444-4bee0f5b-799e-4d94-b97b-3dd19c2f5216.png)

Below is the test command:

```shell
curl -X POST 'http://ip:30880/kapis/devops.kubesphere.io/v1alpha3/scms/github/verify?secret=github&secretNamespace=default' \
Proxy-C> -H 'Proxy-Connection: keep-alive' \
> -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36' \
> -H 'content-type: application/json' \
> -H 'Accept: */*' \
> -H 'Referer: http://103.61.39.64:30880/test/clusters/default/devops/testbhhqx/pipelines' \
> -H 'Accept-Language: en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7' \
> -H 'Cookie: lang=en; oAuthLoginInfo=; token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDE5MTU1NTgsImlhdCI6MTY0MTkwODM1OCwiaXNzIjoia3ViZXNwaGVyZSIsInN1YiI6ImFkbWluIiwidG9rZW5fdHlwZSI6ImFjY2Vzc190b2tlbiIsInVzZXJuYW1lIjoiYWRtaW4ifQ.f7pn9gxptym14NrfJkn4hZ_GrtLlAZ3_Hb_ZVP2oMew; expire=1641915558246; refreshToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDE5MjI3NTgsImlhdCI6MTY0MTkwODM1OCwiaXNzIjoia3ViZXNwaGVyZSIsInN1YiI6ImFkbWluIiwidG9rZW5fdHlwZSI6InJlZnJlc2hfdG9rZW4iLCJ1c2VybmFtZSI6ImFkbWluIn0.rbIPZDCEGsaq9rerz66oitJ8_sYjkokbJIoCMVxzxj0' \
> --compressed \
> --insecure ;
{
 "message": "ok",
 "code": 0,
 "errors": null
}
```

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
Support to verify SCM token directly instead of call Jenkins API
```
