### PR TITLE
fix: Using defer in loops and end of loop call fileData.Close() can lead to resource leaks

### DIFF
--- a/pkg/client/devops/jenkins/request.go
+++ b/pkg/client/devops/jenkins/request.go
@@ -25,8 +25,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 
 	//"github.com/dgrijalva/jwt-go"
@@ -207,21 +205,10 @@ func (r *Requester) DoGet(ar *APIRequest, responseStruct interface{}, options ..
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)
 		for _, file := range files {
-			fileData, err := os.Open(file)
-			if err != nil {
+			if err := UploadFunc(file, writer); err != nil {
 				Error.Println(err.Error())
 				return nil, err
 			}
-
-			part, err := writer.CreateFormFile("file", filepath.Base(file))
-			if err != nil {
-				Error.Println(err.Error())
-				return nil, err
-			}
-			if _, err = io.Copy(part, fileData); err != nil {
-				return nil, err
-			}
-			defer fileData.Close()
 		}
 		var params map[string]string
 		json.NewDecoder(ar.Payload).Decode(&params)

--- a/pkg/client/devops/jenkins/request.go
+++ b/pkg/client/devops/jenkins/request.go
@@ -310,22 +310,28 @@ func (r *Requester) Do(ar *APIRequest, responseStruct interface{}, options ...in
 	if fileUpload {
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)
-		for _, file := range files {
-			fileData, err := os.Open(file)
+		uploadFunc := func(fileName string) error {
+			fileData, err := os.Open(fileName)
 			if err != nil {
 				Error.Println(err.Error())
-				return nil, err
-			}
-
-			part, err := writer.CreateFormFile("file", filepath.Base(file))
-			if err != nil {
-				Error.Println(err.Error())
-				return nil, err
-			}
-			if _, err = io.Copy(part, fileData); err != nil {
-				return nil, err
+				return err
 			}
 			defer fileData.Close()
+
+			part, err := writer.CreateFormFile("file", filepath.Base(fileName))
+			if err != nil {
+				return err
+			}
+			if _, err = io.Copy(part, fileData); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		for _, file := range files {
+			if err := uploadFunc(file); err != nil {
+				return nil, err
+			}
 		}
 		var params map[string]string
 		json.NewDecoder(ar.Payload).Decode(&params)

--- a/pkg/client/devops/jenkins/request.go
+++ b/pkg/client/devops/jenkins/request.go
@@ -310,26 +310,10 @@ func (r *Requester) Do(ar *APIRequest, responseStruct interface{}, options ...in
 	if fileUpload {
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)
-		uploadFunc := func(fileName string) error {
-			fileData, err := os.Open(fileName)
-			if err != nil {
-				Error.Println(err.Error())
-				return err
-			}
-			defer fileData.Close()
-
-			part, err := writer.CreateFormFile("file", filepath.Base(fileName))
-			if err != nil {
-				return err
-			}
-			if _, err = io.Copy(part, fileData); err != nil {
-				return err
-			}
-			return nil
-		}
 
 		for _, file := range files {
-			if err := uploadFunc(file); err != nil {
+			if err := UploadFunc(file, writer); err != nil {
+				Error.Println(err.Error())
 				return nil, err
 			}
 		}

--- a/pkg/client/devops/jenkins/request_test.go
+++ b/pkg/client/devops/jenkins/request_test.go
@@ -1,0 +1,38 @@
+package jenkins
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newFakeRequester() *Requester {
+	// init log
+	new(Jenkins).initLoggers()
+
+	return &Requester{
+		Base: "localhost",
+		Client: http.DefaultClient,
+	}
+}
+
+func newFakeAPIRequest() *APIRequest {
+	return NewAPIRequest("POST", "/test", nil)
+}
+
+func TestRequesterDo(t *testing.T) {
+	// test upload fail logic
+	requester := newFakeRequester()
+	fileNames := []string{"a.tmp", "b.tmp"}
+	_, err := requester.Do(newFakeAPIRequest(), nil, fileNames)
+	assert.NotNil(t, err)
+}
+
+func TestRequesterDoGet(t *testing.T) {
+	// test upload fail logic
+	requester := newFakeRequester()
+	fileNames := []string{"a.tmp", "b.tmp"}
+	_, err := requester.DoGet(newFakeAPIRequest(), nil, fileNames)
+	assert.NotNil(t, err)	
+}

--- a/pkg/client/devops/jenkins/utils.go
+++ b/pkg/client/devops/jenkins/utils.go
@@ -19,8 +19,11 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -98,6 +101,23 @@ func ParseJenkinsQuery(query string) (result url.Values, err error) {
 		}
 	}
 	return
+}
+
+func UploadFunc(fileName string, writer *multipart.Writer) error {
+	fileData, err := os.Open(fileName)
+	if err != nil {
+		return err
+	}
+	defer fileData.Close()
+
+	part, err := writer.CreateFormFile("file", filepath.Base(fileName))
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(part, fileData); err != nil {
+		return err
+	}
+	return nil
 }
 
 type JenkinsBlueTime time.Time

--- a/pkg/client/devops/jenkins/utils_test.go
+++ b/pkg/client/devops/jenkins/utils_test.go
@@ -1,7 +1,10 @@
 package jenkins
 
 import (
+	"bytes"
+	"mime/multipart"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,18 +22,18 @@ func TestParseJenkinsQuery(t *testing.T) {
 		},
 		{
 			param: "branch=master", expected: url.Values{
-				"branch": []string{"master"},
-			}, err: false,
+			"branch": []string{"master"},
+		}, err: false,
 		},
 		{
 			param: "&branch=master", expected: url.Values{
-				"branch": []string{"master"},
-			}, err: false,
+			"branch": []string{"master"},
+		}, err: false,
 		},
 		{
 			param: "branch=master&", expected: url.Values{
-				"branch": []string{"master"},
-			}, err: false,
+			"branch": []string{"master"},
+		}, err: false,
 		},
 		{
 			param: "branch=%gg", expected: url.Values{}, err: true,
@@ -55,4 +58,19 @@ type testData struct {
 	param    string
 	expected interface{}
 	err      bool
+}
+
+func TestUploadFunc(t *testing.T) {
+	testFileName := "/tmp/upload.tmp"
+	_, err := os.Create(testFileName)
+	if err != nil {
+		t.Errorf("Can't create tmp file, err: %v", err)
+	}
+	defer os.Remove(testFileName)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	err = UploadFunc(testFileName, writer)
+	
+	assert.Nil(t, err, "uploadFunc has err: %v", err)
 }


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
may lead to resource leaks
1.  Using defer in loops
2. call fileData.Close() is too late


### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduce a user-facing change??

```release-note
None
```
/cc @LinuxSuRen 