### PR TITLE
Fix error handle jclient.NewJenkinsClient()

### DIFF
--- a/pkg/client/devops/jclient/jenkins.go
+++ b/pkg/client/devops/jclient/jenkins.go
@@ -27,23 +27,22 @@ func (j *JenkinsClient) ApplyNewSource(s string) (err error) {
 var _ devops.Interface = &JenkinsClient{}
 
 // NewJenkinsClient creates a Jenkins client
-func NewJenkinsClient(options *jenkins.Options) (jenkinsClient *JenkinsClient, err error) {
+func NewJenkinsClient(options *jenkins.Options) (*JenkinsClient, error) {
 	jenkinsCore := core.JenkinsCore{
 		URL:      options.Host,
 		UserName: options.Username,
 		Token:    options.Password,
 	}
-	crumbIssuer, e := jenkinsCore.GetCrumb()
-	if e != nil {
-		return
+	crumbIssuer, err := jenkinsCore.GetCrumb()
+	if err != nil {
+		return nil, err
 	} else if crumbIssuer != nil {
 		jenkinsCore.JenkinsCrumb = *crumbIssuer
 	}
 
 	devopsClient, _ := jenkins.NewDevopsClient(options) // For refactor purpose only
-	jenkinsClient = &JenkinsClient{
+	return &JenkinsClient{
 		Core:    jenkinsCore,
 		jenkins: devopsClient, // For refactor purpose only
-	}
-	return
+	}, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
If jenkinsCore.GetCrumb() failed, error won't be return and JenkinsClient will be nil. 
This makes program panic and no error message showed up.
https://github.com/kubesphere/ks-devops/blob/6cb96cf0debdc4fc2fcc8af60ab324e5bf6c2102/pkg/client/devops/jclient/jenkins.go#L30-L40
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
```release-note
None
```

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note

```
