### PR TITLE
Refine Swagger config to access Swagger UI in development environment

### DIFF
--- a/config/dockerfiles/apiserver/Dockerfile
+++ b/config/dockerfiles/apiserver/Dockerfile
@@ -4,28 +4,24 @@ FROM golang:1.16 as builder
 ARG GOPROXY
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
+COPY go.mod go.sum Makefile ./
 COPY cmd cmd/
 COPY pkg pkg/
 
-# Build
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o apiserver cmd/apiserver/apiserver.go
-
-# download Swagger UI files
-RUN git clone https://github.com/swagger-api/swagger-ui -b v2.2.10 --depth 1
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download && \
+    # Build
+    CGO_ENABLED=0 GO111MODULE=on go build -a -o apiserver cmd/apiserver/apiserver.go && \
+    # download Swagger UI files
+    make swagger-ui
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/apiserver .
-COPY --from=builder /workspace/swagger-ui/dist bin/swagger-ui
+COPY --from=builder /workspace/bin/swagger-ui/dist bin/swagger-ui/dist
 USER nonroot:nonroot
 
 ENTRYPOINT ["/apiserver"]

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -1,3 +1,10 @@
-You can explore all APIs via the Swagger UI:
+Before starting the APIServer, execute the following one command to clone Swagger UI:
 
-* The URL is `ip:port/apidocs/`
+```bash
+make swagger-ui
+```
+
+Then, start the APIServer and explore all API documentation via the Swagger UI: <http://localhost:9090/apidocs/?url=http://localhost:9090/apidocs.json>.
+ 
+
+* The URL pattern is like `http://ip:port/apidocs/?url=http://ip:port/apidocs.json`

--- a/pkg/kapis/doc/registry.go
+++ b/pkg/kapis/doc/registry.go
@@ -27,6 +27,6 @@ func AddSwaggerService(wss []*restful.WebService, c *restful.Container) {
 		WebServices:     wss,
 		ApiPath:         "/apidocs.json",
 		SwaggerPath:     "/apidocs/",
-		SwaggerFilePath: "bin/swagger-ui"}
+		SwaggerFilePath: "bin/swagger-ui/dist"}
 	swagger.RegisterSwaggerService(config, c)
 }


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

According to https://github.com/emicklei/go-restful-swagger12#how-to-use-swagger-ui-with-go-restful, I refined the swagger config when registering Swagger service.

```go
config := swagger.Config{
	WebServices:    restful.RegisteredWebServices(),
	ApiPath:        "/apidocs.json",
	SwaggerPath:     "/apidocs/",
	SwaggerFilePath: "/Users/emicklei/Projects/swagger-ui/dist"}
swagger.InstallSwaggerService(config)		
```

In `config/apiserver/Dockerfile`, the swagger config is suitable for that, but when we develop in local environment we cannot access the Swagger UI  properly via <http://localhost:9090/apidocs/?url=http://localhost:9090/apidocs.json>.

In this PR, I correct the SwaggerFilePath config and refine `config/apiserver/Dockerfile`. This fix has no impact on how APIServer that are already deployed can access API documentation.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:

Docker image for test:

```
johnniang/devops-apiserver:dev-v3.2.1-cd84037
```

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
