### PR TITLE
Create a new API to download artifacts from a PipelineRun

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/h2non/gock v1.0.9
-	github.com/jenkins-zh/jenkins-client v0.0.8
+	github.com/jenkins-zh/jenkins-client v0.0.9
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jenkins-zh/jenkins-cli v0.0.32/go.mod h1:uE1mH9PNITrg0sugv6HXuM/CSddg0zxXoYu3w57I3JY=
-github.com/jenkins-zh/jenkins-client v0.0.8 h1:leaVU9pYvWcAhpG4VkX7KUFIcvNp1qxwnnGVjkhSfMU=
-github.com/jenkins-zh/jenkins-client v0.0.8/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
+github.com/jenkins-zh/jenkins-client v0.0.9 h1:yqWtjLifYWbVxR+wFdExh/cHSQ54i/Cdco2MYkc/5vI=
+github.com/jenkins-zh/jenkins-client v0.0.9/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
 github.com/jenkins-zh/jenkins-formulas v0.0.5/go.mod h1:zS8fm8u5L6FcjZM0QznXsLV9T2UtSVK+hT6Sm76iUZ4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/pkg/client/devops/fake/fakedevops.go
+++ b/pkg/client/devops/fake/fakedevops.go
@@ -18,6 +18,7 @@ package fake
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -189,6 +190,10 @@ func (d *Devops) RunPipeline(projectName, pipelineName string, httpParameters *d
 func (d *Devops) GetArtifacts(projectName, pipelineName, runId string, httpParameters *devops.HttpParameters) ([]devops.Artifacts, error) {
 	return nil, nil
 }
+func (d *Devops) DownloadArtifact(projectName, pipelineName, runId, filename string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
 func (d *Devops) GetRunLog(projectName, pipelineName, runId string, httpParameters *devops.HttpParameters) ([]byte, error) {
 	return nil, nil
 }

--- a/pkg/client/devops/jclient/pipeline.go
+++ b/pkg/client/devops/jclient/pipeline.go
@@ -17,7 +17,12 @@ limitations under the License.
 package jclient
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"strconv"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/artifact"
 
 	"kubesphere.io/devops/pkg/client/devops"
 )
@@ -60,6 +65,16 @@ func (j *JenkinsClient) RunPipeline(projectName, pipelineName string, httpParame
 // GetArtifacts returns the artifacts of a pipeline run
 func (j *JenkinsClient) GetArtifacts(projectName, pipelineName, runID string, httpParameters *devops.HttpParameters) ([]devops.Artifacts, error) {
 	return j.jenkins.GetArtifacts(projectName, pipelineName, runID, httpParameters)
+}
+
+// DownloadArtifact download an artifact
+func (j *JenkinsClient) DownloadArtifact(projectName, pipelineName, runID, filename string) (io.ReadCloser, error) {
+	jobRunID, err := strconv.Atoi(runID)
+	if err != nil {
+		return nil, fmt.Errorf("runId error, not a number: %v", err)
+	}
+	c := artifact.Client{JenkinsCore: j.Core}
+	return c.GetArtifact(projectName, pipelineName, jobRunID, filename)
 }
 
 // GetRunLog returns the log output of a pipeline run

--- a/pkg/client/devops/pipeline.go
+++ b/pkg/client/devops/pipeline.go
@@ -1135,6 +1135,7 @@ type PipelineOperator interface {
 	ReplayPipeline(projectName, pipelineName, runId string, httpParameters *HttpParameters) (*ReplayPipeline, error)
 	RunPipeline(projectName, pipelineName string, httpParameters *HttpParameters) (*RunPipeline, error)
 	GetArtifacts(projectName, pipelineName, runId string, httpParameters *HttpParameters) ([]Artifacts, error)
+	DownloadArtifact(projectName, pipelineName, runId, filename string) (io.ReadCloser, error)
 	GetRunLog(projectName, pipelineName, runId string, httpParameters *HttpParameters) ([]byte, error)
 	GetStepLog(projectName, pipelineName, runId, nodeId, stepId string, httpParameters *HttpParameters) ([]byte, http.Header, error)
 	GetNodeSteps(projectName, pipelineName, runId, nodeId string, httpParameters *HttpParameters) ([]NodeSteps, error)

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -907,3 +907,33 @@ func parseErr(err error, resp *restful.Response) {
 	}
 	return
 }
+
+// downloadArtifact API to download artifacts from Jenkins
+func (h *ProjectPipelineHandler) downloadArtifact(request *restful.Request, response *restful.Response) {
+	projectName := request.PathParameter("devops")
+	pipelineName := request.PathParameter("pipeline")
+	runId := request.PathParameter("run")
+	fileName := request.QueryParameter("filename")
+
+	artifactUrl := fmt.Sprintf("/job/%s/job/%s/%s/artifact/%s", projectName, pipelineName, runId, fileName)
+	statusCode, body, err := h.jenkinsClient.Request(http.MethodGet, artifactUrl, nil, nil)
+	if err != nil {
+		kapis.HandleError(request, response, err)
+		return
+	}
+
+	if statusCode != http.StatusOK {
+		err := fmt.Errorf("failed to get artifact. The HTTP status code is %d", statusCode)
+		kapis.HandleError(request, response, err)
+		return
+	}
+
+	// add download header
+	response.AddHeader("Content-Type", "application/octet-stream")
+	response.AddHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
+	_, err = response.Write(body)
+	if err != nil {
+		kapis.HandleError(request, response, err)
+		return
+	}
+}

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -956,33 +956,3 @@ func parseErr(err error, resp *restful.Response) {
 	}
 	return
 }
-
-// downloadArtifact API to download artifacts from Jenkins
-func (h *ProjectPipelineHandler) downloadArtifact(request *restful.Request, response *restful.Response) {
-	projectName := request.PathParameter("devops")
-	pipelineName := request.PathParameter("pipeline")
-	runId := request.PathParameter("run")
-	fileName := request.QueryParameter("filename")
-
-	artifactUrl := fmt.Sprintf("/job/%s/job/%s/%s/artifact/%s", projectName, pipelineName, runId, fileName)
-	statusCode, body, err := h.jenkinsClient.Request(http.MethodGet, artifactUrl, nil, nil)
-	if err != nil {
-		kapis.HandleError(request, response, err)
-		return
-	}
-
-	if statusCode != http.StatusOK {
-		err := fmt.Errorf("failed to get artifact. The HTTP status code is %d", statusCode)
-		kapis.HandleError(request, response, err)
-		return
-	}
-
-	// add download header
-	response.AddHeader("Content-Type", "application/octet-stream")
-	response.AddHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
-	_, err = response.Write(body)
-	if err != nil {
-		kapis.HandleError(request, response, err)
-		return
-	}
-}

--- a/pkg/kapis/devops/v1alpha2/handler.go
+++ b/pkg/kapis/devops/v1alpha2/handler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"kubesphere.io/devops/pkg/client/clientset/versioned"
 	devopsClient "kubesphere.io/devops/pkg/client/devops"
 	"kubesphere.io/devops/pkg/client/informers/externalversions"
@@ -31,7 +30,6 @@ type ProjectPipelineHandler struct {
 	k8sClient               k8s.Client
 	devopsOperator          devops.DevopsOperator
 	projectCredentialGetter devops.ProjectCredentialGetter
-	jenkinsClient           core.JenkinsCore
 }
 
 type PipelineSonarHandler struct {
@@ -39,12 +37,11 @@ type PipelineSonarHandler struct {
 	pipelineSonarGetter devops.PipelineSonarGetter
 }
 
-func NewProjectPipelineHandler(devopsClient devopsClient.Interface, k8sClient k8s.Client, jenkinsClient core.JenkinsCore) ProjectPipelineHandler {
+func NewProjectPipelineHandler(devopsClient devopsClient.Interface, k8sClient k8s.Client) ProjectPipelineHandler {
 	return ProjectPipelineHandler{
 		devopsOperator:          devops.NewDevopsOperator(devopsClient, k8sClient.Kubernetes(), k8sClient.KubeSphere()),
 		projectCredentialGetter: devops.NewProjectCredentialOperator(devopsClient),
 		k8sClient:               k8sClient,
-		jenkinsClient:           jenkinsClient,
 	}
 }
 

--- a/pkg/kapis/devops/v1alpha2/handler.go
+++ b/pkg/kapis/devops/v1alpha2/handler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"kubesphere.io/devops/pkg/client/clientset/versioned"
 	devopsClient "kubesphere.io/devops/pkg/client/devops"
 	"kubesphere.io/devops/pkg/client/informers/externalversions"
@@ -30,6 +31,7 @@ type ProjectPipelineHandler struct {
 	k8sClient               k8s.Client
 	devopsOperator          devops.DevopsOperator
 	projectCredentialGetter devops.ProjectCredentialGetter
+	jenkinsClient           core.JenkinsCore
 }
 
 type PipelineSonarHandler struct {
@@ -37,11 +39,12 @@ type PipelineSonarHandler struct {
 	pipelineSonarGetter devops.PipelineSonarGetter
 }
 
-func NewProjectPipelineHandler(devopsClient devopsClient.Interface, k8sClient k8s.Client) ProjectPipelineHandler {
+func NewProjectPipelineHandler(devopsClient devopsClient.Interface, k8sClient k8s.Client, jenkinsClient core.JenkinsCore) ProjectPipelineHandler {
 	return ProjectPipelineHandler{
 		devopsOperator:          devops.NewDevopsOperator(devopsClient, k8sClient.Kubernetes(), k8sClient.KubeSphere()),
 		projectCredentialGetter: devops.NewProjectCredentialOperator(devopsClient),
 		k8sClient:               k8sClient,
+		jenkinsClient:           jenkinsClient,
 	}
 }
 

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -654,16 +654,6 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Returns(http.StatusOK, api.StatusOK, map[string]interface{}{}).
 			Writes(map[string]interface{}{}))
 
-		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}").
-			To(projectPipelineHandler.GetPipelineRun).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}).
-			Doc("Get details in the specified pipeline activity.").
-			Param(webservice.PathParameter("devops", "the name of devops project")).
-			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
-			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).
-			Returns(http.StatusOK, api.StatusOK, devops.PipelineRun{}).
-			Writes(devops.PipelineRun{}))
-
 		// download PipelineRun artifact
 		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/artifact/runs/{run}").
 			Param(webservice.PathParameter("devops", "DevOps project's ID, e.g. project-RRRRAzLBlLEm")).

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -664,16 +664,6 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Returns(http.StatusOK, api.StatusOK, map[string]interface{}{}).
 			Writes(map[string]interface{}{}))
 
-		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}").
-			To(projectPipelineHandler.GetPipelineRun).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}).
-			Doc("Get details in the specified pipeline activity.").
-			Param(webservice.PathParameter("devops", "the name of devops project")).
-			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
-			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).
-			Returns(http.StatusOK, api.StatusOK, devops.PipelineRun{}).
-			Writes(devops.PipelineRun{}))
-
 		// download PipelineRun artifact
 		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/artifact/runs/{run}").
 			Param(webservice.PathParameter("devops", "DevOps project's ID, e.g. project-RRRRAzLBlLEm")).

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -19,11 +19,12 @@ package v1alpha2
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"kubesphere.io/devops/pkg/apiserver/runtime"
 	"kubesphere.io/devops/pkg/client/k8s"
-	"net/url"
-	"strings"
 
 	"github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
@@ -225,16 +226,6 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 				DataFormat("limit=%d")).
 			Returns(http.StatusOK, "The filed of \"Url\" in response can download artifacts", []devops.Artifacts{}).
 			Writes([]devops.Artifacts{}))
-
-		// download PipelineRun artifact
-		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}/artifacts/download").
-			Param(webservice.PathParameter("devops", "DevOps project's ID, e.g. project-RRRRAzLBlLEm")).
-			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
-			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).
-			Param(webservice.QueryParameter("filename", "artifact filename. e.g. artifact:v1.0.1")).
-			To(projectPipelineHandler.downloadArtifact).
-			Returns(http.StatusOK, api.StatusOK, nil).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
 
 		// match /blue/rest/organizations/jenkins/pipelines/{devops}/{pipeline}/runs/{run}/log/?start=0
 		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}/log").

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -663,16 +663,6 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Reads(devops.ReqJenkinsfile{}).
 			Returns(http.StatusOK, api.StatusOK, map[string]interface{}{}).
 			Writes(map[string]interface{}{}))
-
-		// download PipelineRun artifact
-		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}/artifacts").
-			Param(webservice.PathParameter("devops", "DevOps project's ID, e.g. project-RRRRAzLBlLEm")).
-			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
-			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).
-			Param(webservice.QueryParameter("filename", "artifact filename. e.g. artifact:v1.0.1")).
-			To(projectPipelineHandler.downloadArtifact).
-			Returns(http.StatusOK, api.StatusOK, nil).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
 	}
 	return nil
 }

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -226,6 +226,16 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Returns(http.StatusOK, "The filed of \"Url\" in response can download artifacts", []devops.Artifacts{}).
 			Writes([]devops.Artifacts{}))
 
+		// download PipelineRun artifact
+		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}/artifacts/download").
+			Param(webservice.PathParameter("devops", "DevOps project's ID, e.g. project-RRRRAzLBlLEm")).
+			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
+			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).
+			Param(webservice.QueryParameter("filename", "artifact filename. e.g. artifact:v1.0.1")).
+			To(projectPipelineHandler.downloadArtifact).
+			Returns(http.StatusOK, api.StatusOK, nil).
+			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
+
 		// match /blue/rest/organizations/jenkins/pipelines/{devops}/{pipeline}/runs/{run}/log/?start=0
 		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}/log").
 			To(projectPipelineHandler.GetRunLog).
@@ -653,16 +663,6 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Reads(devops.ReqJenkinsfile{}).
 			Returns(http.StatusOK, api.StatusOK, map[string]interface{}{}).
 			Writes(map[string]interface{}{}))
-
-		// download PipelineRun artifact
-		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}/artifacts").
-			Param(webservice.PathParameter("devops", "DevOps project's ID, e.g. project-RRRRAzLBlLEm")).
-			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
-			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).
-			Param(webservice.QueryParameter("filename", "artifact filename. e.g. artifact:v1.0.1")).
-			To(projectPipelineHandler.downloadArtifact).
-			Returns(http.StatusOK, api.StatusOK, nil).
-			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
 	}
 	return nil
 }

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -663,6 +663,26 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Reads(devops.ReqJenkinsfile{}).
 			Returns(http.StatusOK, api.StatusOK, map[string]interface{}{}).
 			Writes(map[string]interface{}{}))
+
+		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}").
+			To(projectPipelineHandler.GetPipelineRun).
+			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}).
+			Doc("Get details in the specified pipeline activity.").
+			Param(webservice.PathParameter("devops", "the name of devops project")).
+			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
+			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).
+			Returns(http.StatusOK, api.StatusOK, devops.PipelineRun{}).
+			Writes(devops.PipelineRun{}))
+
+		// download PipelineRun artifact
+		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/artifact/runs/{run}").
+			Param(webservice.PathParameter("devops", "DevOps project's ID, e.g. project-RRRRAzLBlLEm")).
+			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
+			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).
+			Param(webservice.QueryParameter("filename", "artifact filename. e.g. artifact:v1.0.1")).
+			To(projectPipelineHandler.downloadArtifact).
+			Returns(http.StatusOK, api.StatusOK, nil).
+			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
 	}
 	return nil
 }

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -71,7 +71,7 @@ func AddToContainer(container *restful.Container, ksInformers externalversions.S
 func addToContainerWithWebService(container *restful.Container, ksInformers externalversions.SharedInformerFactory,
 	devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface,
 	s3Client s3.Interface, endpoint string, k8sClient k8s.Client, jenkinsClient core.JenkinsCore, ws *restful.WebService) error {
-	err := AddPipelineToWebService(ws, devopsClient, k8sClient, jenkinsClient)
+	err := AddPipelineToWebService(ws, devopsClient, k8sClient)
 	if err != nil {
 		return err
 	}
@@ -95,11 +95,11 @@ func addToContainerWithWebService(container *restful.Container, ksInformers exte
 	return nil
 }
 
-func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops.Interface, k8sClient k8s.Client, jenkinsClient core.JenkinsCore) error {
+func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops.Interface, k8sClient k8s.Client) error {
 	projectPipelineEnable := devopsClient != nil
 
 	if projectPipelineEnable {
-		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, k8sClient, jenkinsClient)
+		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, k8sClient)
 
 		webservice.Route(webservice.GET("/devops/{devops}/credentials/{credential}/usage").
 			To(projectPipelineHandler.GetProjectCredentialUsage).

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -665,7 +665,7 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Writes(map[string]interface{}{}))
 
 		// download PipelineRun artifact
-		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/artifact/runs/{run}").
+		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}/artifacts").
 			Param(webservice.PathParameter("devops", "DevOps project's ID, e.g. project-RRRRAzLBlLEm")).
 			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
 			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -655,7 +655,7 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Writes(map[string]interface{}{}))
 
 		// download PipelineRun artifact
-		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/artifact/runs/{run}").
+		webservice.Route(webservice.GET("/devops/{devops}/pipelines/{pipeline}/runs/{run}/artifacts").
 			Param(webservice.PathParameter("devops", "DevOps project's ID, e.g. project-RRRRAzLBlLEm")).
 			Param(webservice.PathParameter("pipeline", "the name of the CI/CD pipeline")).
 			Param(webservice.PathParameter("run", "pipeline run ID, the unique ID for a pipeline once build.")).

--- a/pkg/kapis/devops/v1alpha2/register_test.go
+++ b/pkg/kapis/devops/v1alpha2/register_test.go
@@ -213,7 +213,7 @@ func TestAPIsExist(t *testing.T) {
 		name: "artifact download",
 		args: args{
 			method: http.MethodGet,
-			uri:    "/devops/fake/pipelines/fake/runs/fake/artifacts",
+			uri:    "/devops/fake/pipelines/fake/runs/fake/artifacts/download",
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/kapis/devops/v1alpha2/register_test.go
+++ b/pkg/kapis/devops/v1alpha2/register_test.go
@@ -213,7 +213,7 @@ func TestAPIsExist(t *testing.T) {
 		name: "artifact download",
 		args: args{
 			method: http.MethodGet,
-			uri:    "/devops/fake/pipelines/fake/artifact/runs/fake",
+			uri:    "/devops/fake/pipelines/fake/runs/fake/artifacts",
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/kapis/devops/v1alpha2/register_test.go
+++ b/pkg/kapis/devops/v1alpha2/register_test.go
@@ -209,6 +209,12 @@ func TestAPIsExist(t *testing.T) {
 			method: http.MethodPost,
 			uri:    "/tojenkinsfile",
 		},
+	}, {
+		name: "artifact download",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/devops/fake/pipelines/fake/artifact/runs/fake",
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/kapis/devops/v1alpha2/register_test.go
+++ b/pkg/kapis/devops/v1alpha2/register_test.go
@@ -18,6 +18,10 @@ package v1alpha2
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/emicklei/go-restful"
 	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"github.com/stretchr/testify/assert"
@@ -28,9 +32,6 @@ import (
 	fakedevops "kubesphere.io/devops/pkg/client/devops/fake"
 	"kubesphere.io/devops/pkg/client/k8s"
 	"kubesphere.io/devops/pkg/constants"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestAPIsExist(t *testing.T) {
@@ -208,12 +209,6 @@ func TestAPIsExist(t *testing.T) {
 		args: args{
 			method: http.MethodPost,
 			uri:    "/tojenkinsfile",
-		},
-	}, {
-		name: "artifact download",
-		args: args{
-			method: http.MethodGet,
-			uri:    "/devops/fake/pipelines/fake/runs/fake/artifacts/download",
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/register.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/register.go
@@ -19,19 +19,24 @@ package pipelinerun
 import (
 	"net/http"
 
+	restfulspec "github.com/emicklei/go-restful-openapi"
+	"kubesphere.io/devops/pkg/constants"
+
 	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
 	"kubesphere.io/devops/pkg/models/pipelinerun"
 
 	"github.com/emicklei/go-restful"
 	"kubesphere.io/devops/pkg/api"
 	"kubesphere.io/devops/pkg/client/devops"
+	devopsClient "kubesphere.io/devops/pkg/client/devops"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // RegisterRoutes register routes into web service.
-func RegisterRoutes(ws *restful.WebService, c client.Client) {
+func RegisterRoutes(ws *restful.WebService, devopsClient devopsClient.Interface, c client.Client) {
 	handler := newAPIHandler(apiHandlerOption{
-		client: c,
+		devopsClient: devopsClient,
+		client:       c,
 	})
 
 	ws.Route(ws.GET("/namespaces/{namespace}/pipelines/{pipeline}/pipelineruns").
@@ -69,4 +74,13 @@ func RegisterRoutes(ws *restful.WebService, c client.Client) {
 		Param(ws.PathParameter("namespace", "Namespace of the PipelineRun")).
 		Param(ws.PathParameter("pipelinerun", "Name of the PipelineRun")).
 		Returns(http.StatusOK, api.StatusOK, []pipelinerun.NodeDetail{}))
+
+	// download PipelineRun artifact
+	ws.Route(ws.GET("/namespaces/{namespace}/pipelineruns/{pipelinerun}/artifacts/download").
+		Param(ws.PathParameter("namespace", "Namespace of the PipelineRun")).
+		Param(ws.PathParameter("pipelinerun", "Name of the PipelineRun")).
+		Param(ws.QueryParameter("filename", "artifact filename. e.g. artifact:v1.0.1")).
+		To(handler.downloadArtifact).
+		Returns(http.StatusOK, api.StatusOK, nil).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
 }

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/register_test.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/register_test.go
@@ -17,14 +17,16 @@ limitations under the License.
 package pipelinerun
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/emicklei/go-restful"
 	"github.com/stretchr/testify/assert"
 	"kubesphere.io/devops/pkg/api/devops/v1alpha1"
 	"kubesphere.io/devops/pkg/apiserver/runtime"
-	"net/http"
-	"net/http/httptest"
+	fakedevops "kubesphere.io/devops/pkg/client/devops/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 func TestAPIsExist(t *testing.T) {
@@ -34,7 +36,7 @@ func TestAPIsExist(t *testing.T) {
 	schema, err := v1alpha1.SchemeBuilder.Register().Build()
 	assert.Nil(t, err)
 
-	RegisterRoutes(wsWithGroup, fake.NewFakeClientWithScheme(schema))
+	RegisterRoutes(wsWithGroup, fakedevops.NewFakeDevops(nil), fake.NewFakeClientWithScheme(schema))
 	restful.DefaultContainer.Add(wsWithGroup)
 
 	type args struct {
@@ -67,6 +69,12 @@ func TestAPIsExist(t *testing.T) {
 		args: args{
 			method: http.MethodGet,
 			uri:    "/namespaces/fake/pipelineruns/fake/nodedetails",
+		},
+	}, {
+		name: "download artifact",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/namespaces/fake/pipelineruns/fake/artifacts/download",
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -19,10 +19,11 @@
 package v1alpha3
 
 import (
+	"net/http"
+
 	"kubesphere.io/devops/pkg/kapis/devops/v1alpha3/common"
 	"kubesphere.io/devops/pkg/kapis/devops/v1alpha3/scm"
 	"kubesphere.io/devops/pkg/kapis/devops/v1alpha3/template"
-	"net/http"
 
 	restful "github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
@@ -56,7 +57,7 @@ func AddToContainer(container *restful.Container, devopsClient devopsClient.Inte
 
 	for _, service := range services {
 		registerRoutes(devopsClient, k8sClient, client, service)
-		pipelinerun.RegisterRoutes(service, client)
+		pipelinerun.RegisterRoutes(service, devopsClient, client)
 		pipeline.RegisterRoutes(service, client)
 		template.RegisterRoutes(service, &common.Options{
 			GenericClient: client,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
### What this PR does / why we need it:
Please refer to: https://github.com/kubesphere/ks-devops/issues/449
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:
An API was created in v1aplha2 : https://github.com/mzmuer/ks-devops/blob/bcdd8765ade8743f65de170238f1e989b92c4955/pkg/kapis/devops/v1alpha2/register.go#L668

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
