### PR TITLE
Add a flag to support skip Jenkins connection in the controller cmd

### DIFF
--- a/cmd/controller/app/server.go
+++ b/cmd/controller/app/server.go
@@ -121,8 +121,13 @@ func Run(s *options.DevOpsControllerManagerOptions, stopCh <-chan struct{}) erro
 	if s.JenkinsOptions != nil && len(s.JenkinsOptions.Host) != 0 {
 		// Make sure that Jenkins host is not empty
 		devopsClient, err = jclient.NewJenkinsClient(s.JenkinsOptions)
-		if err != nil {
-			return fmt.Errorf("failed to connect jenkins, please check jenkins status, error: %v", err)
+		if !s.JenkinsOptions.SkipVerify && err != nil {
+			errMsg := fmt.Sprintf("failed to connect jenkins, please check jenkins status, error: %v", err)
+			if s.JenkinsOptions.SkipVerify {
+				fmt.Println(errMsg)
+			} else {
+				return fmt.Errorf(errMsg)
+			}
 		}
 	}
 

--- a/pkg/client/devops/jclient/jenkins.go
+++ b/pkg/client/devops/jclient/jenkins.go
@@ -31,8 +31,9 @@ type JenkinsClient struct {
 
 // ApplyNewSource apply a new source
 func (j *JenkinsClient) ApplyNewSource(s string) (err error) {
-	client := casc.Manager{
-		JenkinsCore: j.Core,
+	client := casc.Manager{}
+	if j != nil {
+		client.JenkinsCore = j.Core
 	}
 	if err = client.CheckNewSource(s); err == nil {
 		err = client.Replace(s)

--- a/pkg/client/devops/jenkins/options.go
+++ b/pkg/client/devops/jenkins/options.go
@@ -32,6 +32,7 @@ type Options struct {
 	Namespace       string        `json:"namespace,omitempty" yaml:"namespace"`
 	WorkerNamespace string        `json:"workerNamespace,omitempty" yaml:"workerNamespace"`
 	ReloadCasCDelay time.Duration `json:"reloadCasCDelay,omitempty" yaml:"reloadCasCDelay"`
+	SkipVerify      bool
 }
 
 // NewJenkinsOptions returns a `zero` instance
@@ -90,6 +91,8 @@ func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 
 	fs.IntVar(&s.MaxConnections, "jenkins-max-connections", c.MaxConnections, ""+
 		"Maximum allowed connections to Jenkins. ")
+	fs.BoolVar(&s.SkipVerify, "jenkins-skip-verify", false,
+		"Indicate if you want to skip the Jenkins connection verify")
 
 	fs.StringVar(&s.Namespace, "namespace", c.Namespace, "Namespace where devops system is in.")
 	fs.StringVar(&s.WorkerNamespace, "worker-namespace", c.WorkerNamespace, "Namespace where Jenkins agent workers are in.")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
In some cases, a developer might only want to test a particular feature instead of the full features. So, it would be better if we can ignore the unnecessary feature.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
