### PR TITLE
Support rendering Template with parameters

### DIFF
--- a/config/samples/devops_v1alpha1_clustertemplate.yaml
+++ b/config/samples/devops_v1alpha1_clustertemplate.yaml
@@ -1,4 +1,4 @@
-apiVersion: devops.kubesphere.io/v1alpha1
+apiVersion: devops.kubesphere.io/v1alpha3
 kind: ClusterTemplate
 metadata:
   name: clustertemplate-sample
@@ -36,10 +36,9 @@ spec:
         stages {
             stage('Checkout') {
                 steps {
-                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'CloneOption', depth: 1, noTags: true, reference: '', shallow: true], [$class: 'SubmoduleOption', depth: 1, disableSubmodules: false, parentCredentials: false, recursiveSubmodules: true, reference: '', shallow: true, trackingSubmodules: false]], userRemoteConfigs: [[url: '{{ .params.gitCloneURL }}']]]
+                    git branch: '{{.params.revision}}', url: '{{.params.cloneURL}}'
                 }
             }
-            {{if not .buildOnly}}
             stage('Gradle Check') {
                 steps {
                     container('gradle') {
@@ -54,10 +53,12 @@ spec:
                     }
                 }
             }
+            {{if ne .params.buildOnly "true"}}
             stage('Archive Assets') {
                 steps {
                     archiveArtifacts '**/build/libs/*.jar'
                 }
             }
+            {{end}}
         }
     }

--- a/pkg/kapis/devops/v1alpha3/template/cluster_template_handler_test.go
+++ b/pkg/kapis/devops/v1alpha3/template/cluster_template_handler_test.go
@@ -179,6 +179,7 @@ func Test_handler_handleRenderClusterTemplate(t *testing.T) {
 	}
 	createRequest := func(uri, templateName string) *restful.Request {
 		fakeRequest := httptest.NewRequest(http.MethodGet, uri, nil)
+		fakeRequest.Header.Add(restful.HEADER_ContentType, restful.MIME_JSON)
 		request := restful.NewRequest(fakeRequest)
 		request.PathParameters()[ClusterTemplatePathParameter.Data().Name] = templateName
 		return request

--- a/pkg/kapis/devops/v1alpha3/template/render_test.go
+++ b/pkg/kapis/devops/v1alpha3/template/render_test.go
@@ -16,6 +16,7 @@
 package template
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kubesphere.io/devops/pkg/api/devops"
@@ -24,38 +25,85 @@ import (
 )
 
 func Test_render(t *testing.T) {
+	createTemplate := func(name, template string) v1alpha3.TemplateObject {
+		return &v1alpha3.Template{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: v1alpha3.TemplateSpec{
+				Template: template,
+			},
+		}
+	}
 	type args struct {
-		templateObject v1alpha3.TemplateObject
+		template   v1alpha3.TemplateObject
+		parameters []Parameter
 	}
 	tests := []struct {
-		name   string
-		args   args
-		verify func(t *testing.T, object v1alpha3.TemplateObject)
+		name    string
+		args    args
+		wantErr assert.ErrorAssertionFunc
+		verify  func(*testing.T, v1alpha3.TemplateObject)
 	}{{
-		name: "Should render template into annotations",
+		name: "Should render template without parameters",
 		args: args{
-			templateObject: &v1alpha3.Template{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "fake-template",
-				},
-				Spec: v1alpha3.TemplateSpec{
-					Template: "fake-template-content",
-				},
-			},
+			template:   createTemplate("fake-name", "fake-template"),
+			parameters: nil,
 		},
-		verify: func(t *testing.T, object v1alpha3.TemplateObject) {
-			gotRenderResult := object.GetAnnotations()[devops.GroupName+devops.RenderResultAnnoKey]
-			wantRenderResult := object.TemplateSpec().Template
-			assert.Equal(t, wantRenderResult, gotRenderResult)
+		verify: func(t *testing.T, template v1alpha3.TemplateObject) {
+			got := template.GetAnnotations()[devops.GroupName+devops.RenderResultAnnoKey]
+			assert.Equal(t, "fake-template", got)
 		},
-	},
-	}
+		wantErr: assert.NoError,
+	}, {
+		name: "Should render template with parameters",
+		args: args{
+			template: createTemplate("fake-name", "The number should be {{ .params.number }}"),
+			parameters: []Parameter{{
+				Name:  "number",
+				Value: "233",
+			}},
+		},
+		verify: func(t *testing.T, template v1alpha3.TemplateObject) {
+			got := template.GetAnnotations()[devops.GroupName+devops.RenderResultAnnoKey]
+			assert.Equal(t, "The number should be 233", got)
+		},
+		wantErr: assert.NoError,
+	}, {
+		name: "Should render incorrectly without corresponding parameter",
+		args: args{
+			template: createTemplate("fake-name", "The number should be: {{ .params.number }}"),
+			parameters: []Parameter{{
+				Name:  "name",
+				Value: "fake-name",
+			}},
+		},
+		verify: func(t *testing.T, template v1alpha3.TemplateObject) {
+			got := template.GetAnnotations()[devops.GroupName+devops.RenderResultAnnoKey]
+			assert.Equal(t, "The number should be: <no value>", got)
+		},
+		wantErr: assert.NoError,
+	}, {
+		name: "Should return error if the template is invalid",
+		args: args{
+			template: createTemplate("fake-name", "{{}}"),
+			parameters: []Parameter{{
+				Name:  "name",
+				Value: "fake-name",
+			}},
+		},
+		verify: func(t *testing.T, template v1alpha3.TemplateObject) {
+			assert.Nil(t, template)
+		},
+		wantErr: assert.Error,
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			templateObject := render(tt.args.templateObject)
-			if tt.verify != nil {
-				tt.verify(t, templateObject)
+			template, err := render(tt.args.template, tt.args.parameters)
+			if !tt.wantErr(t, err, fmt.Sprintf("render(%v, %v)", tt.args.template, tt.args.parameters)) {
+				return
 			}
+			tt.verify(t, template)
 		})
 	}
 }

--- a/pkg/kapis/devops/v1alpha3/template/route.go
+++ b/pkg/kapis/devops/v1alpha3/template/route.go
@@ -40,6 +40,11 @@ type PageResult struct {
 	Total int                 `json:"total"`
 }
 
+// RenderBody is the model of request body of render API.
+type RenderBody struct {
+	Parameters []Parameter `json:"parameters"`
+}
+
 // RegisterRoutes is for registering template routes into WebService.
 func RegisterRoutes(service *restful.WebService, options *common.Options) {
 	handler := newHandler(options)
@@ -63,6 +68,7 @@ func RegisterRoutes(service *restful.WebService, options *common.Options) {
 		To(handler.handleRenderTemplate).
 		Param(common.DevopsPathParameter).
 		Param(TemplatePathParameter).
+		Reads(RenderBody{}).
 		Doc(fmt.Sprintf("Render template and return render result into annotations (%s/%s) inside template", devops.GroupName, devops.RenderResultAnnoKey)).
 		Returns(http.StatusOK, api.StatusOK, v1alpha3.Template{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsTemplateTag}))
@@ -77,6 +83,7 @@ func RegisterRoutes(service *restful.WebService, options *common.Options) {
 	service.Route(service.POST("/clustertemplates/{clustertemplate}/render").
 		To(handler.handleRenderClusterTemplate).
 		Param(ClusterTemplatePathParameter).
+		Reads(RenderBody{}).
 		Doc("Render cluster template.").
 		Returns(http.StatusOK, api.StatusOK, v1alpha3.ClusterTemplate{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsClusterTemplateTag}))

--- a/pkg/kapis/devops/v1alpha3/template/route_test.go
+++ b/pkg/kapis/devops/v1alpha3/template/route_test.go
@@ -83,7 +83,9 @@ func TestRegisterRoutes(t *testing.T) {
 			uri := fmt.Sprintf("/kapis/%s/%s%s",
 				v1alpha3.GroupVersion.Group, v1alpha3.GroupVersion.Version, tt.args.uri)
 			recorder := httptest.NewRecorder()
-			request, _ := http.NewRequest(tt.args.method, uri, nil)
+			request := httptest.NewRequest(tt.args.method, uri, nil)
+			request.Header.Add(restful.HEADER_ContentType, restful.MIME_JSON)
+
 			container.ServeHTTP(recorder, request)
 			if recorder.Code == 404 {
 				assert.NotContains(t, recorder.Body.String(), "Page Not Found")

--- a/pkg/kapis/devops/v1alpha3/template/template_handler_test.go
+++ b/pkg/kapis/devops/v1alpha3/template/template_handler_test.go
@@ -84,6 +84,7 @@ func Test_templatesToObjects(t *testing.T) {
 		})
 	}
 }
+
 func Test_handler_handleQueryTemplates(t *testing.T) {
 	createTemplate := func(name string) *v1alpha3.Template {
 		return &v1alpha3.Template{
@@ -251,6 +252,7 @@ func Test_handler_handleRenderTemplate(t *testing.T) {
 	}
 	createRequest := func(uri, devopsName, templateName string) *restful.Request {
 		fakeRequest := httptest.NewRequest(http.MethodGet, uri, nil)
+		fakeRequest.Header.Add(restful.HEADER_ContentType, restful.MIME_JSON)
 		request := restful.NewRequest(fakeRequest)
 		request.PathParameters()[common.DevopsPathParameter.Data().Name] = devopsName
 		request.PathParameters()[TemplatePathParameter.Data().Name] = templateName


### PR DESCRIPTION
### What type of PR is this?

/kind feature
/kind api-change

### What this PR does / why we need it:

Support rendering Template with parameters. So that we could pass parameters to the template render API:

```json
{
  "parameters": [
    {
      "name": "cloneURL",
      "value": "https://github.com/halo-dev/halo.git"
    },
    {
      "name": "buildOnly",
      "value": "false"
    }
  ]
}
```

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

About parameters validations and default parametrs, I will handle them in the future.

#### How to test?

> Docker image for test: `johnniang/devops-apiserver:dev-v3.2.1-6c40b47`

1. Create a cluster for test
2. Install all CRDs and ClusterTemplate sample
    ```bash
     kubectl apply -f config/crd/bases/
    kubectl apply -f config/samples/devops_v1alpha1_clustertemplate.yaml 
    ```
4. Run DevOps APIServer
5. Try to render the ClusterTemplate sample:
    ```bash
    curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{ \ 
       "parameters": [ \ 
         { \ 
           "name": "cloneURL", \ 
           "value": "https://github.com/halo-dev/halo.git" \ 
         }, \ 
         { \ 
           "name": "buildOnly", \ 
           "value": "false" \ 
         } \ 
       ] \ 
     }' 'http://localhost:9090/kapis/devops.kubesphere.io/v1alpha3/clustertemplates/clustertemplate-sample/render'
    ```

Please check the following list before waiting reviewers:

- [x] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [x] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```

/cc @kubesphere/sig-devops 
