### PR TITLE
Remove resource config due to non-existing fake CRD

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,7 +3,6 @@
 # It should be run by config/default
 resources:
 - bases/devops.kubesphere.io_pipelines.yaml
-- bases/devops.kubesphere.io_fakes.yaml
 - bases/devops.kubesphere.io_devopsprojects.yaml
 - bases/devops.kubesphere.io_s2ibinaries.yaml
 - bases/devops.kubesphere.io_s2ibuilders.yaml


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

This PR tries to resolve error below when we execute command `make install` or `make uninstall`:

```bash
/home/johnniang/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
kustomize build config/crd | kubectl apply -f -
Error: accumulating resources: accumulation err='accumulating resources from 'bases/devops.kubesphere.io_fakes.yaml': evalsymlink failure on '/home/johnniang/workspaces/kubesphere/ks-devops/config/crd/bases/devops.kubesphere.io_fakes.yaml' : lstat /home/johnniang/workspaces/kubesphere/ks-devops/config/crd/bases/devops.kubesphere.io_fakes.yaml: no such file or directory': evalsymlink failure on '/home/johnniang/workspaces/kubesphere/ks-devops/config/crd/bases/devops.kubesphere.io_fakes.yaml' : lstat /home/johnniang/workspaces/kubesphere/ks-devops/config/crd/bases/devops.kubesphere.io_fakes.yaml: no such file or directory
error: no objects passed to apply
make: *** [Makefile:40: install] Error 1
```

After that, we could install and uninstall CRDs by executing `make install` and `make uninstall`:

```bash
    ~/workspaces/kubesphere/ks-devops    bug/make-install  make install                                                                                  ✔  4s  
/home/johnniang/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
kustomize build config/crd | kubectl apply -f -
customresourcedefinition.apiextensions.k8s.io/clustertemplates.devops.kubesphere.io configured
customresourcedefinition.apiextensions.k8s.io/devopsprojects.devops.kubesphere.io configured
customresourcedefinition.apiextensions.k8s.io/pipelineruns.devops.kubesphere.io configured
customresourcedefinition.apiextensions.k8s.io/pipelines.devops.kubesphere.io configured
customresourcedefinition.apiextensions.k8s.io/s2ibinaries.devops.kubesphere.io configured
customresourcedefinition.apiextensions.k8s.io/s2ibuilders.devops.kubesphere.io configured
customresourcedefinition.apiextensions.k8s.io/s2ibuildertemplates.devops.kubesphere.io configured
customresourcedefinition.apiextensions.k8s.io/s2iruns.devops.kubesphere.io configured
customresourcedefinition.apiextensions.k8s.io/templates.devops.kubesphere.io configured
    ~/workspaces/kubesphere/ks-devops    bug/make-install  make uninstall                                                                                                                                                                                                                                                                                 ✔ 
/home/johnniang/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
kustomize build config/crd | kubectl delete -f -
customresourcedefinition.apiextensions.k8s.io "clustertemplates.devops.kubesphere.io" deleted
customresourcedefinition.apiextensions.k8s.io "devopsprojects.devops.kubesphere.io" deleted
customresourcedefinition.apiextensions.k8s.io "pipelineruns.devops.kubesphere.io" deleted
customresourcedefinition.apiextensions.k8s.io "pipelines.devops.kubesphere.io" deleted
customresourcedefinition.apiextensions.k8s.io "s2ibinaries.devops.kubesphere.io" deleted
customresourcedefinition.apiextensions.k8s.io "s2ibuilders.devops.kubesphere.io" deleted
customresourcedefinition.apiextensions.k8s.io "s2ibuildertemplates.devops.kubesphere.io" deleted
customresourcedefinition.apiextensions.k8s.io "s2iruns.devops.kubesphere.io" deleted
customresourcedefinition.apiextensions.k8s.io "templates.devops.kubesphere.io" deleted

```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [x] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [x] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
