### PR TITLE
Add missing git secret support which belong to ks type

### DIFF
--- a/config/samples/devops_v1alpha1_application.yaml
+++ b/config/samples/devops_v1alpha1_application.yaml
@@ -1,4 +1,4 @@
-apiVersion: devops.kubesphere.io/v1alpha1
+apiVersion: gitops.kubesphere.io/v1alpha1
 kind: Application
 metadata:
   name: app
@@ -6,14 +6,14 @@ spec:
   argoApp:
     project: default
     source:
-      repoURL: https://github.com/kubesphere-sigs/ks-versions
+      repoURL: https://gitlab.com/LinuxSuRen1/argocd
       targetRevision: HEAD
-      path: .
+      path: test
       directory:
         recurse: true
     destination:
       server: https://kubernetes.default.svc
-      namespace: ks-version
+      namespace: default
     syncPolicy:
       automated:
         prune: true

--- a/pkg/client/git/client.go
+++ b/pkg/client/git/client.go
@@ -82,10 +82,12 @@ func (c *ClientFactory) getTokenFromSecret(secretRef *v1.SecretReference) (token
 	}
 
 	switch gitSecret.Type {
-	case v1.SecretTypeBasicAuth:
+	case v1.SecretTypeBasicAuth, "credential.devops.kubesphere.io/basic-auth":
 		token = string(gitSecret.Data[v1.BasicAuthPasswordKey])
 	case v1.SecretTypeOpaque:
 		token = string(gitSecret.Data[v1.ServiceAccountTokenKey])
+	case "credential.devops.kubesphere.io/secret-text":
+		token = string(gitSecret.Data["secret"])
 	}
 	return
 }

--- a/pkg/client/git/client_test.go
+++ b/pkg/client/git/client_test.go
@@ -56,6 +56,26 @@ func TestGetClient(t *testing.T) {
 			v1.ServiceAccountTokenKey: []byte("token"),
 		},
 	}
+	textSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "opaqueSecret",
+			Namespace: "ns",
+		},
+		Type: "credential.devops.kubesphere.io/secret-text",
+		Data: map[string][]byte{
+			v1.ServiceAccountTokenKey: []byte("token"),
+		},
+	}
+	ksBasicAuthSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "opaqueSecret",
+			Namespace: "ns",
+		},
+		Type: "credential.devops.kubesphere.io/basic-auth",
+		Data: map[string][]byte{
+			v1.BasicAuthPasswordKey: []byte("token"),
+		},
+	}
 	type fields struct {
 		provider  string
 		secretRef *v1.SecretReference
@@ -111,6 +131,28 @@ func TestGetClient(t *testing.T) {
 		name: "gitlab provider",
 		fields: fields{
 			k8sClient: fake.NewFakeClientWithScheme(schema, opaqueSecret.DeepCopy()),
+			provider:  "gitlab",
+			secretRef: &v1.SecretReference{Namespace: "ns", Name: "opaqueSecret"},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.Nil(t, err, i)
+			return false
+		},
+	}, {
+		name: "gitlab provider - text secret",
+		fields: fields{
+			k8sClient: fake.NewFakeClientWithScheme(schema, textSecret.DeepCopy()),
+			provider:  "gitlab",
+			secretRef: &v1.SecretReference{Namespace: "ns", Name: "opaqueSecret"},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.Nil(t, err, i)
+			return false
+		},
+	}, {
+		name: "gitlab provider - ks basic auth secret",
+		fields: fields{
+			k8sClient: fake.NewFakeClientWithScheme(schema, ksBasicAuthSecret.DeepCopy()),
 			provider:  "gitlab",
 			secretRef: &v1.SecretReference{Namespace: "ns", Name: "opaqueSecret"},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:
/kind bug

See the following screenshot:

![image](https://user-images.githubusercontent.com/1450685/156958166-9c6f7cd3-4dc5-4492-99be-4d71a04077b1.png)
![image](https://user-images.githubusercontent.com/1450685/156958465-27dab154-667a-44e2-af92-850cfef4dd98.png)

Currently, this project does not use the original secret type.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

this is the upstream of https://github.com/kubesphere/console/pull/2943

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
