### PR TITLE
Fix the multi-branch pipeline creating

### DIFF
--- a/pkg/client/devops/jclient/projectPipeline.go
+++ b/pkg/client/devops/jclient/projectPipeline.go
@@ -51,7 +51,7 @@ func (j *JenkinsClient) CreateProjectPipeline(projectID string, pipeline *v1alph
 		}
 		return pipeline.Name, nil
 	case devopsv1alpha3.MultiBranchPipelineType:
-		createPayload, err := getCreateMultiBranchPipelinePayload(pipeline.Spec.Pipeline)
+		createPayload, err := getCreateMultiBranchPipelinePayload(pipeline.Spec.MultiBranchPipeline)
 		if err != nil {
 			return "", restful.NewError(http.StatusInternalServerError, err.Error())
 		}
@@ -101,7 +101,7 @@ func getCreatePayload(pipeline *devopsv1alpha3.NoScmPipeline) (jobPayload *job.C
 	return
 }
 
-func getCreateMultiBranchPipelinePayload(pipeline *devopsv1alpha3.NoScmPipeline) (jobPayload *job.CreateJobPayload, err error) {
+func getCreateMultiBranchPipelinePayload(pipeline *devopsv1alpha3.MultiBranchPipeline) (jobPayload *job.CreateJobPayload, err error) {
 	// NoScmPipeline do not have copy mode to create a pipeline
 	jobPayload = &job.CreateJobPayload{
 		Mode: "org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject",

--- a/pkg/client/devops/jenkins/pipeline_internal.go
+++ b/pkg/client/devops/jenkins/pipeline_internal.go
@@ -421,7 +421,9 @@ func parseMultiBranchPipelineConfigXml(config string) (*devopsv1alpha3.MultiBran
 			pipeline.MultiBranchJobTrigger = getMultiBranchJobTriggerfromEtree(properties)
 		}
 	}
-	pipeline.Description = project.SelectElement("description").Text()
+	if project.SelectElement("description") != nil {
+		pipeline.Description = project.SelectElement("description").Text()
+	}
 
 	if discarder := project.SelectElement("orphanedItemStrategy"); discarder != nil {
 		pipeline.Discarder = &devopsv1alpha3.DiscarderProperty{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:
/kind bug

The controller manager panic once there is a multi-branch pipeline.

![033fdd80d348c551662bd67dfa9e9f6](https://user-images.githubusercontent.com/1450685/157193349-7597b7f5-25fa-4881-8dd4-a9e2b4b1c554.png)

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
