### PR TITLE
Redefine template delimiters to "$( )"

### DIFF
--- a/config/samples/devops_v1alpha1_clustertemplate.yaml
+++ b/config/samples/devops_v1alpha1_clustertemplate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clustertemplate-sample
 spec:
   parameters:
-    - name: gitCloneURL
+    - name: cloneURL
       description: What is your repository URL you want to clone?
       type: string # ignorable
       validation:
@@ -17,11 +17,6 @@ spec:
       description: Do we really need build stage only?
       default: false # Valid JSON value
       type: bool
-    - name: matrix
-      description: Matrix versions of gradle
-      type: string-array
-      default: ["6.9.1-jdk11", "7.0.0-jdk11", "7.3.3-jdk11"]
-
   template: | # Go template
     pipeline {
         agent {
@@ -36,7 +31,7 @@ spec:
         stages {
             stage('Checkout') {
                 steps {
-                    git branch: '{{.params.revision}}', url: '{{.params.cloneURL}}'
+                    git branch: '$(.params.revision)', url: '$(.params.cloneURL)'
                 }
             }
             stage('Gradle Check') {
@@ -53,12 +48,12 @@ spec:
                     }
                 }
             }
-            {{if ne .params.buildOnly "true"}}
+            $(if ne .params.buildOnly "true")
             stage('Archive Assets') {
                 steps {
                     archiveArtifacts '**/build/libs/*.jar'
                 }
             }
-            {{end}}
+            $(end)
         }
     }

--- a/pkg/kapis/devops/v1alpha3/template/render.go
+++ b/pkg/kapis/devops/v1alpha3/template/render.go
@@ -41,6 +41,8 @@ func render(templateObject v1alpha3.TemplateObject, parameters []Parameter) (v1a
 		Namespace: templateObject.GetNamespace(),
 	}.String()
 	template := tmpl.New(templateName)
+	//TODO Make delimiters configurable
+	template.Delims("$(", ")")
 	if _, err := template.Parse(rawTemplate); err != nil {
 		klog.Errorf("failed to parse template: %s, and err = %v", templateName, err)
 		return nil, errors.NewBadRequest("Failed to render template, please check the pipeline template for syntax error.")


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What this PR does / why we need it:

As mentioned in the title.

By default, Helm is using go template to render its templates. If we using the same template delimiters as Helm, they will have conflicts. See error below when I tried to add a ClusterTemplate into Helm charts at [here](https://github.com/kubesphere-sigs/ks-devops-helm-chart/pull/62/commits/235e3e1cbaa4e347339ccb7954075e389d3161be):

```bash
helm lint charts/ks-devops
Error: 1 chart(s) linted, 1 chart(s) failed
==> Linting charts/ks-devops
[INFO] Chart.yaml: icon is recommended
Error:  templates/: template: ks-devops/templates/cluster-template-nodejs.yaml:44:[6](https://github.com/kubesphere-sigs/ks-devops-helm-chart/runs/5476016572?check_suite_focus=true#step:4:6)[8](https://github.com/kubesphere-sigs/ks-devops-helm-chart/runs/5476016572?check_suite_focus=true#step:4:8): executing "ks-devops/templates/cluster-template-nodejs.yaml" at <.params.CloneRevision>: nil pointer evaluating interface {}.CloneRevision

make: *** [Makefile:2: lint-chart] Error 1
Error: Process completed with exit code 2.
```

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??

```release-note
None
```

/cc @kubesphere/sig-devops 