### PR TITLE
Fix the problem that PipelineRun is always in "Not Running" state

### DIFF
--- a/controllers/jenkins/pipelinerun/utils.go
+++ b/controllers/jenkins/pipelinerun/utils.go
@@ -151,7 +151,7 @@ type parameterConverter struct {
 }
 
 func (converter parameterConverter) convert() []job.Parameter {
-	var params []job.Parameter
+	params := make([]job.Parameter, 0, len(converter.parameters))
 	for _, param := range converter.parameters {
 		params = append(params, job.Parameter{
 			Name:  param.Name,

--- a/controllers/jenkins/pipelinerun/utils_test.go
+++ b/controllers/jenkins/pipelinerun/utils_test.go
@@ -344,11 +344,11 @@ func Test_parameterConverter_convert(t *testing.T) {
 		fields fields
 		want   []job.Parameter
 	}{{
-		name: "Nil parameters",
+		name: "Should return empty parameters when 'parameters' is nil",
 		fields: fields{
 			parameters: nil,
 		},
-		want: nil,
+		want: []job.Parameter{},
 	}, {
 		name: "Single parameter",
 		fields: fields{


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Always trigger Jenkins Pipeline with non-nil parameters. This will prevent `DevOps Controller` and `Jenkins` with the following errors if we trigger a Pipeline which needs parameters without parameters.

The error in `devops-controller`:

```go
devops-controller-76c4868fb6-567pk E0316 14:30:00.446693       1 pipelinerun_controller.go:184] pipelinerun-controller "msg"="unable to run pipeline" "error"="unexpected status code: 500" "Pipeline"="empty-parameter-demo" "PipelineRun"={"Namespace":"my-devops-projectdq8jj","Name":"empty-parameter-demo-4x75t"} "namespace"="my-devops-projectdq8jj" "pipeline"="empty-parameter-demo"
devops-controller-76c4868fb6-567pk E0316 14:30:00.446798       1 controller.go:246] controller "msg"="Reconciler error" "error"="unexpected status code: 500" "controller"="pipelinerun" "name"="empty-parameter-demo-4x75t" "namespace"="my-devops-projectdq8jj" "reconcilerGroup"="devops.kubesphere.io" "reconcilerKind"="PipelineRun" 
devops-controller-76c4868fb6-567pk E0316 14:30:01.611307       1 pipelinerun_controller.go:184] pipelinerun-controller "msg"="unable to run pipeline" "error"="unexpected status code: 500" "Pipeline"="empty-parameter-demo" "PipelineRun"={"Namespace":"my-devops-projectdq8jj","Name":"empty-parameter-demo-4x75t"} "namespace"="my-devops-projectdq8jj" "pipeline"="empty-parameter-demo"
devops-controller-76c4868fb6-567pk E0316 14:30:01.611405       1 controller.go:246] controller "msg"="Reconciler error" "error"="unexpected status code: 500" "controller"="pipelinerun" "name"="empty-parameter-demo-4x75t" "namespace"="my-devops-projectdq8jj" "reconcilerGroup"="devops.kubesphere.io" "reconcilerKind"="PipelineRun" 
```

The error in `Jenkins`:

```java

Mar 16, 2022 2:30:00 PM WARNING hudson.init.impl.InstallUncaughtExceptionHandler handleException
Caught unhandled exception with ID bfc04e5a-1149-41c9-8413-57197d97f128
net.sf.json.JSONException: A JSONObject text must begin with '{' at character 0 of 
	at net.sf.json.util.JSONTokener.syntaxError(JSONTokener.java:499)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:919)
	at net.sf.json.JSONObject._fromString(JSONObject.java:1145)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:162)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:132)
	at io.jenkins.blueocean.service.embedded.rest.RunContainerImpl.getParameterValue(RunContainerImpl.java:157)
	at io.jenkins.blueocean.service.embedded.rest.RunContainerImpl.create(RunContainerImpl.java:118)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:710)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:393)
	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:405)
	at org.kohsuke.stapler.ForwardingFunction.invoke(ForwardingFunction.java:83)
```

### Which issue(s) this PR fixes:

Fixes #485 

### Special notes for reviewers:

Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??

```release-note
Fix the problem that PipelineRun is always in "Not Running" state
```

/cc @kubesphere/sig-devops 
