### PR TITLE
Replace it with the new Jenkins client

### DIFF
--- a/cmd/apiserver/app/options/options.go
+++ b/cmd/apiserver/app/options/options.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	v1 "k8s.io/api/core/v1"
 	"kubesphere.io/devops/pkg/client/cache"
+	"kubesphere.io/devops/pkg/client/devops/jclient"
 	"kubesphere.io/devops/pkg/client/sonarqube"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -37,7 +38,6 @@ import (
 	"net/http"
 	"strings"
 
-	"kubesphere.io/devops/pkg/client/devops/jenkins"
 	"kubesphere.io/devops/pkg/client/k8s"
 	"kubesphere.io/devops/pkg/client/s3"
 	fakes3 "kubesphere.io/devops/pkg/client/s3/fake"
@@ -111,7 +111,7 @@ func (s *ServerRunOptions) NewAPIServer(stopCh <-chan struct{}) (*apiserver.APIS
 	}
 
 	if s.JenkinsOptions.Host != "" {
-		devopsClient, err := jenkins.NewDevopsClient(s.JenkinsOptions)
+		devopsClient, err := jclient.NewJenkinsClient(s.JenkinsOptions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to jenkins, please check jenkins status, error: %v", err)
 		}

--- a/pkg/client/devops/jclient/jenkins.go
+++ b/pkg/client/devops/jclient/jenkins.go
@@ -26,7 +26,7 @@ import (
 // JenkinsClient represents a client of Jenkins
 type JenkinsClient struct {
 	Core    core.JenkinsCore
-	jenkins devops.Interface // For refactor purpose only
+	jenkins *jenkins.Jenkins // For refactor purpose only
 }
 
 // ApplyNewSource apply a new source

--- a/pkg/client/devops/jenkins/devops.go
+++ b/pkg/client/devops/jenkins/devops.go
@@ -14,11 +14,10 @@ limitations under the License.
 package jenkins
 
 import (
-	"kubesphere.io/devops/pkg/client/devops"
 	"net/http"
 )
 
-func NewDevopsClient(options *Options) (devops.Interface, error) {
+func NewDevopsClient(options *Options) (*Jenkins, error) {
 	// we have to create http client with no redirection
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake
### What this PR does / why we need it:
Please refer to: #496 

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
https://github.com/kubesphere/ks-devops/blob/14ea1b04b27be835c1d8f399c057fdfb4bb027cc/pkg/client/devops/jclient/jenkins.go#L27-L30
IMO, the structure as a whole should be a `devopsClient.Interface` . this makes it easy to add lines to the API, or to rewrite the old API

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
