### PR TITLE
Fix the incorrect version of the addon

### DIFF
--- a/config/samples/addon/argocd.yaml
+++ b/config/samples/addon/argocd.yaml
@@ -1,8 +1,8 @@
-apiVersion: devops.kubesphere.io/v1alpha1
+apiVersion: devops.kubesphere.io/v1alpha3
 kind: Addon
 metadata:
   name: argocd
 spec:
-  version: v2.2.3
+  version: v2.3.1
   strategy:
     name: simple-operator-argocd

--- a/config/samples/addon/argocd_simple_operator.yaml
+++ b/config/samples/addon/argocd_simple_operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: devops.kubesphere.io/v1alpha1
+apiVersion: devops.kubesphere.io/v1alpha3
 kind: AddonStrategy
 metadata:
   name: simple-operator-argocd

--- a/config/samples/addon/ks_releaser.yaml
+++ b/config/samples/addon/ks_releaser.yaml
@@ -1,4 +1,4 @@
-apiVersion: devops.kubesphere.io/v1alpha1
+apiVersion: devops.kubesphere.io/v1alpha3
 kind: Addon
 metadata:
   name: ks-releaser

--- a/config/samples/addon/ks_releaser_simple_operator.yaml
+++ b/config/samples/addon/ks_releaser_simple_operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: devops.kubesphere.io/v1alpha1
+apiVersion: devops.kubesphere.io/v1alpha3
 kind: AddonStrategy
 metadata:
   name: ks-releaser-simple-operator

--- a/docs/addon.md
+++ b/docs/addon.md
@@ -21,7 +21,7 @@ For instance:
 ```yaml
 spec:
   containers:
-    - args
+    - args:
       - --enabled-controllers
       - addon=true
       image: ghcr.io/kubesphere/devops-controller
@@ -38,7 +38,7 @@ kubectl apply -f https://github.com/kubesphere-sigs/ks-releaser-operator/release
 finally, you can install `ks-releaser` by adding the following resource:
 
 ```yaml
-apiVersion: devops.kubesphere.io/v1alpha1
+apiVersion: devops.kubesphere.io/v1alpha3
 kind: Addon
 metadata:
   name: ks-releaser


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

### What this PR does / why we need it:
See [the upstream PR](https://github.com/kubesphere/ks-devops/pull/495/files#diff-79fcb5a70b9ca0287b27c25750baa58b11e94689aa017be09c355fbb9ae517c0). I have changed the version of CRD `addon`, but forget to change the document as well.


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
