### PR TITLE
Avoid getting the Jenkins crumb when creating Jenkins client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ generate-listers:
 
 # Build the docker image of controller-manager
 docker-build-controller:
-	docker build --build-arg GOPROXY=https://goproxy.io . -f config/dockerfiles/controller-manager/Dockerfile -t ${CONTROLLER_IMG}
+	docker build . -f config/dockerfiles/controller-manager/Dockerfile -t ${CONTROLLER_IMG}
 
 # Push the docker image of controller-manager
 docker-push-controller:
@@ -96,7 +96,7 @@ run-apiserver:
 	go run cmd/apiserver/apiserver.go
 # Build the docker image of apiserver
 docker-build-apiserver:
-	docker build --build-arg GOPROXY=https://goproxy.io . -f config/dockerfiles/apiserver/Dockerfile -t ${APISERVER_IMG}
+	docker build . -f config/dockerfiles/apiserver/Dockerfile -t ${APISERVER_IMG}
 
 # Push the docker image of controller-manager
 docker-push-apiserver:

--- a/pkg/client/devops/jclient/jenkins.go
+++ b/pkg/client/devops/jclient/jenkins.go
@@ -50,12 +50,6 @@ func NewJenkinsClient(options *jenkins.Options) (*JenkinsClient, error) {
 		UserName: options.Username,
 		Token:    options.Password,
 	}
-	crumbIssuer, err := jenkinsCore.GetCrumb()
-	if err != nil {
-		return nil, err
-	} else if crumbIssuer != nil {
-		jenkinsCore.JenkinsCrumb = *crumbIssuer
-	}
 
 	devopsClient, _ := jenkins.NewDevopsClient(options) // For refactor purpose only
 	return &JenkinsClient{


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
The Jenkins client will get the crumb automatically when trying to send a POST request. So, it is totally not necessary to do it at the initial stage.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

Please feel free to help me to verify it using the following image:

```
kubespheredev/devops-apiserver:dev-v3.2.1-55c2fe3
```

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
