### PR TITLE
Add missing RBAC permission claim

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,12 +9,28 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - create
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -24,6 +40,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -41,6 +58,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - argoproj.io
   resources:
@@ -58,6 +76,7 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
 - apiGroups:
   - cluster.kubesphere.io
@@ -76,6 +95,28 @@ rules:
   - delete
   - get
   - update
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - addons
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - addonstrategies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - devops.kubesphere.io
   resources:
@@ -104,6 +145,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - devops.kubesphere.io
   resources:
@@ -161,7 +203,48 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - s2ibinaries
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - s2ibuilders
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - s2ibuildertemplates
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - s2iruns
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - devops.kubesphere.io
   resources:
@@ -203,9 +286,12 @@ rules:
   resources:
   - applications
   verbs:
+  - create
+  - delete
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - gitops.kubesphere.io
   resources:

--- a/controllers/addon/addon_controller.go
+++ b/controllers/addon/addon_controller.go
@@ -34,6 +34,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=addons,verbs=get;delete;create;update;watch;list
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=addonstrategies,verbs=get;delete;create;update;watch;list
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=releasercontrollers,verbs=get;delete;create;update;list
+//+kubebuilder:rbac:groups=argoproj.io,resources=argocds,verbs=get;delete;create;update;list
+
 // Reconciler takes the responsible for addon lifecycle
 type Reconciler struct {
 	client.Client

--- a/controllers/argocd/application_controller.go
+++ b/controllers/argocd/application_controller.go
@@ -100,6 +100,11 @@ func createUnstructuredApplication(app *v1alpha1.Application) (result *unstructu
 		argoApp.Spec.Project = "default"
 	}
 
+	// application destination can't have both name and server defined
+	if argoApp.Spec.Destination.Name != "" && argoApp.Spec.Destination.Server != "" {
+		argoApp.Spec.Destination.Server = ""
+	}
+
 	newArgoApp := &unstructured.Unstructured{}
 	newArgoApp.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "argoproj.io",

--- a/controllers/argocd/argocd-application-status-controller.go
+++ b/controllers/argocd/argocd-application-status-controller.go
@@ -30,7 +30,7 @@ import (
 
 //+kubebuilder:rbac:groups=gitops.kubesphere.io,resources=applications,verbs=get;update
 //+kubebuilder:rbac:groups=gitops.kubesphere.io,resources=applications/status,verbs=get;update
-//+kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;list
+//+kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;list;watch
 
 // ApplicationStatusReconciler represents a controller to sync cluster to ArgoCD cluster
 type ApplicationStatusReconciler struct {

--- a/controllers/jenkins/config/jenkinsconfig_controller.go
+++ b/controllers/jenkins/config/jenkinsconfig_controller.go
@@ -38,6 +38,8 @@ import (
 	"time"
 )
 
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;update;watch
+
 // ControllerOptions is the option of Jenkins configuration controller
 type ControllerOptions struct {
 	LimitRangeClient    v1core.LimitRangesGetter

--- a/controllers/jenkins/devopscredential/devopscredential_controller.go
+++ b/controllers/jenkins/devopscredential/devopscredential_controller.go
@@ -49,9 +49,7 @@ import (
 	"kubesphere.io/devops/pkg/utils/sliceutil"
 )
 
-/**
-  DevOps project controller is used to maintain the state of the DevOps project.
-*/
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;update;watch
 
 // Controller is the controller for DevOpsProject
 type Controller struct {

--- a/controllers/jenkins/devopsproject/devopsproject_controller.go
+++ b/controllers/jenkins/devopsproject/devopsproject_controller.go
@@ -53,8 +53,8 @@ import (
 	devopslisters "kubesphere.io/devops/pkg/client/listers/devops/v1alpha3"
 )
 
-//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=devopsprojects,verbs=get;list;update
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;update;create
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=devopsprojects,verbs=get;list;update;watch
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;update;create;watch
 
 // Controller is the controller of the DevOpsProject
 type Controller struct {

--- a/controllers/jenkins/pipeline/pipeline_metadata_controller.go
+++ b/controllers/jenkins/pipeline/pipeline_metadata_controller.go
@@ -52,6 +52,7 @@ type Reconciler struct {
 
 //+kubebuilder:rbac:groups=devops.kubesphere.io,resources=pipelines,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=devops.kubesphere.io,resources=pipelines/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups="",resources=events,verbs=patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -46,6 +46,12 @@ import (
 	"kubesphere.io/devops/pkg/client/devops"
 )
 
+// TODO perhaps we can find a better way to declaim the permission needs of the apiserver
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=s2ibinaries,verbs=get;list;update;delete;watch
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=s2ibuildertemplates,verbs=get;list;update;delete;watch
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=s2ibuilders,verbs=get;list;update;delete;watch
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=s2iruns,verbs=get;list;update;delete;watch
+
 var GroupVersion = schema.GroupVersion{Group: api.GroupName, Version: "v1alpha2"}
 
 func AddToContainer(container *restful.Container, ksInformers externalversions.SharedInformerFactory,

--- a/pkg/kapis/gitops/v1alpha1/registery.go
+++ b/pkg/kapis/gitops/v1alpha1/registery.go
@@ -24,6 +24,9 @@ import (
 	"kubesphere.io/devops/pkg/kapis/gitops/v1alpha1/argocd"
 )
 
+// TODO perhaps we can find a better way to declaim the permission needs of the apiserver
+//+kubebuilder:rbac:groups=gitops.kubesphere.io,resources=applications,verbs=get;list;update;delete;create;watch
+
 // AddToContainer adds web services into web service container.
 func AddToContainer(container *restful.Container, options *common.Options) []*restful.WebService {
 	services := []*restful.WebService{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind chore

### What this PR does / why we need it:
As I mentioned in the title. And we should not give too open permission to ks-devops. So, the next step is to change the `cluster-role` of [this file](https://github.com/kubesphere-sigs/ks-devops-helm-chart/blob/master/charts/ks-devops/templates/serviceaccount.yaml).

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
