### PR TITLE
Sort by creationTimestamp in descending order by default

### DIFF
--- a/pkg/kapis/gitops/v1alpha1/argocd/handler_test.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/handler_test.go
@@ -290,6 +290,24 @@ func Test_handler_applicationList(t *testing.T) {
 			},
 			TotalItems: 3,
 		},
+	}, {
+		name: "Should sort by creationTimestamp in descending order by default",
+		args: args{
+			req: createRequest("/applications", "fake-namespace"),
+			apps: []v1alpha1.Application{
+				*createAppWithCreationTime("fake-app-2", "fake-namespace", current),
+				*createAppWithCreationTime("fake-app-1", "fake-namespace", yesterday),
+				*createAppWithCreationTime("fake-app-3", "fake-namespace", tomorrow),
+			},
+		},
+		wantResponse: api.ListResult{
+			Items: []interface{}{
+				*createAppWithCreationTime("fake-app-3", "fake-namespace", tomorrow),
+				*createAppWithCreationTime("fake-app-2", "fake-namespace", current),
+				*createAppWithCreationTime("fake-app-1", "fake-namespace", yesterday),
+			},
+			TotalItems: 3,
+		},
 	},
 	}
 	for _, tt := range tests {

--- a/pkg/models/resources/v1alpha3/interface.go
+++ b/pkg/models/resources/v1alpha3/interface.go
@@ -184,10 +184,8 @@ func DefaultObjectMetaCompare(left, right metav1.Object, sortBy query.Field) boo
 	case query.FieldName:
 		// sort the name in ascending order
 		return strings.Compare(left.GetName(), right.GetName()) > 0
-	//	?sortBy=creationTimestamp
+	// Sort by creationTimestamp in descending order by default
 	default:
-		fallthrough
-	case query.FieldCreationTimeStamp:
 		// compare by name if creation timestamp is equal
 		leftTime := left.GetCreationTimestamp()
 		rightTime := right.GetCreationTimestamp()

--- a/pkg/models/resources/v1alpha3/interface_test.go
+++ b/pkg/models/resources/v1alpha3/interface_test.go
@@ -236,6 +236,46 @@ func TestDefaultObjectMetaCompare(t *testing.T) {
 		},
 		field:             query.FieldUID,
 		expectedCmpResult: false,
+	}, {
+		name: "Should sort by creation timestamp in descending order by default#1",
+		left: v1.ObjectMeta{
+			CreationTimestamp: now,
+		},
+		right: v1.ObjectMeta{
+			CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+		},
+		expectedCmpResult: false,
+	}, {
+		name: "Should sort by creation timestamp in descending order by default#2",
+		left: v1.ObjectMeta{
+			CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+		},
+		right: v1.ObjectMeta{
+			CreationTimestamp: now,
+		},
+		expectedCmpResult: true,
+	}, {
+		name: "Should sort by name in ascending order by default when creation timestamps are the same#1",
+		left: v1.ObjectMeta{
+			CreationTimestamp: now,
+			Name:              "a",
+		},
+		right: v1.ObjectMeta{
+			CreationTimestamp: now,
+			Name:              "b",
+		},
+		expectedCmpResult: false,
+	}, {
+		name: "Should sort by name in ascending order by default when creation timestamps are the same#2",
+		left: v1.ObjectMeta{
+			CreationTimestamp: now,
+			Name:              "b",
+		},
+		right: v1.ObjectMeta{
+			CreationTimestamp: now,
+			Name:              "a",
+		},
+		expectedCmpResult: true,
 	},
 	}
 


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Sort by creationTimestamp in descending order by default while using default comparison function. Or it will produce messy sort of result when searching a lot of resources.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??

```release-note
None
```

/cc @kubesphere/sig-devops 
