### PR TITLE
Provide applications summary API

### DIFF
--- a/pkg/kapis/gitops/v1alpha1/argocd/handler.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/handler.go
@@ -135,14 +135,14 @@ func (h *handler) getClusters(req *restful.Request, res *restful.Response) {
 	common.Response(req, res, argoClusters, err)
 }
 
-func (h *handler) applicationsSummary(request *restful.Request, response *restful.Response) {
+func (h *handler) applicationSummary(request *restful.Request, response *restful.Response) {
 	namespace := common.GetPathParameter(request, common.NamespacePathParameter)
 
-	summary, err := h.populateApplicationsSummary(namespace)
+	summary, err := h.populateApplicationSummary(namespace)
 	common.Response(request, response, summary, err)
 }
 
-func (h *handler) populateApplicationsSummary(namespace string) (*ApplicationsSummary, error) {
+func (h *handler) populateApplicationSummary(namespace string) (*ApplicationsSummary, error) {
 	applicationList := &v1alpha1.ApplicationList{}
 	if err := h.List(context.Background(), applicationList, client.InNamespace(namespace)); err != nil {
 		return nil, err

--- a/pkg/kapis/gitops/v1alpha1/argocd/handler.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/handler.go
@@ -135,6 +135,40 @@ func (h *handler) getClusters(req *restful.Request, res *restful.Response) {
 	common.Response(req, res, argoClusters, err)
 }
 
+func (h *handler) applicationsSummary(request *restful.Request, response *restful.Response) {
+	namespace := common.GetPathParameter(request, common.NamespacePathParameter)
+
+	summary, err := h.populateApplicationsSummary(namespace)
+	common.Response(request, response, summary, err)
+}
+
+func (h *handler) populateApplicationsSummary(namespace string) (*ApplicationsSummary, error) {
+	applicationList := &v1alpha1.ApplicationList{}
+	if err := h.List(context.Background(), applicationList, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+	summary := &ApplicationsSummary{
+		HealthStatus: map[string]int{},
+		SyncStatus:   map[string]int{},
+	}
+	summary.Total = len(applicationList.Items)
+
+	for i := range applicationList.Items {
+		app := &applicationList.Items[i]
+		// accumulate health status
+		healthStatus := app.GetLabels()[v1alpha1.HealthStatusLabelKey]
+		if healthStatus != "" {
+			summary.HealthStatus[healthStatus]++
+		}
+		// accumulate sync status
+		syncStatus := app.GetLabels()[v1alpha1.SyncStatusLabelKey]
+		if syncStatus != "" {
+			summary.SyncStatus[syncStatus]++
+		}
+	}
+	return summary, nil
+}
+
 type handler struct {
 	client.Client
 }

--- a/pkg/kapis/gitops/v1alpha1/argocd/route.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route.go
@@ -37,6 +37,13 @@ type ApplicationPageResult struct {
 	TotalItems int                    `json:"totalItems"`
 }
 
+// ApplicationsSummary is the model of application summary response.
+type ApplicationsSummary struct {
+	Total        int            `json:"total"`
+	HealthStatus map[string]int `json:"healthStatus"`
+	SyncStatus   map[string]int `json:"syncStatus"`
+}
+
 // RegisterRoutes is for registering Argo CD Application routes into WebService.
 func RegisterRoutes(service *restful.WebService, options *common.Options) {
 	handler := newHandler(options)
@@ -52,6 +59,12 @@ func RegisterRoutes(service *restful.WebService, options *common.Options) {
 		Param(healthStatusQueryParam).
 		Doc("Search applications").
 		Returns(http.StatusOK, api.StatusOK, ApplicationPageResult{}))
+
+	service.Route(service.GET("/namespaces/{namespace}/applications/-/summary").
+		To(handler.applicationsSummary).
+		Param(common.NamespacePathParameter).
+		Doc("Fetch applications summary").
+		Returns(http.StatusOK, api.StatusOK, ApplicationsSummary{}))
 
 	service.Route(service.POST("/namespaces/{namespace}/applications").
 		To(handler.createApplication).

--- a/pkg/kapis/gitops/v1alpha1/argocd/route.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route.go
@@ -60,8 +60,8 @@ func RegisterRoutes(service *restful.WebService, options *common.Options) {
 		Doc("Search applications").
 		Returns(http.StatusOK, api.StatusOK, ApplicationPageResult{}))
 
-	service.Route(service.GET("/namespaces/{namespace}/applications/-/summary").
-		To(handler.applicationsSummary).
+	service.Route(service.GET("/namespaces/{namespace}/application-summary").
+		To(handler.applicationSummary).
 		Param(common.NamespacePathParameter).
 		Doc("Fetch applications summary").
 		Returns(http.StatusOK, api.StatusOK, ApplicationsSummary{}))

--- a/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
@@ -76,6 +76,10 @@ func TestAPIs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns",
 			Name:      "app",
+			Labels: map[string]string{
+				v1alpha1.HealthStatusLabelKey: "Healthy",
+				v1alpha1.SyncStatusLabelKey:   "Synced",
+			},
 		},
 	}
 
@@ -307,12 +311,12 @@ func TestAPIs(t *testing.T) {
 		name: "get applications summary",
 		request: request{
 			method: http.MethodGet,
-			uri:    "/namespaces/ns/applications/-/summary",
+			uri:    "/namespaces/ns/application-summary",
 		},
 		k8sclient:    fake.NewFakeClientWithScheme(schema, app.DeepCopy()),
 		responseCode: http.StatusOK,
 		verify: func(t *testing.T, body []byte) {
-			assert.JSONEq(t, `{"total": 1, "healthStatus": {}, "syncStatus": {}}`, string(body))
+			assert.JSONEq(t, `{"total": 1, "healthStatus": { "Healthy": 1 }, "syncStatus": { "Synced": 1 }}`, string(body))
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
@@ -55,7 +55,7 @@ func TestRegisterRoutes(t *testing.T) {
 			options: &common.Options{GenericClient: fake.NewFakeClientWithScheme(schema)},
 		},
 		verify: func(t *testing.T, service *restful.WebService) {
-			assert.Equal(t, 6, len(service.Routes()))
+			assert.Greater(t, len(service.Routes()), 0)
 		},
 	}}
 	for _, tt := range tests {
@@ -302,6 +302,17 @@ func TestAPIs(t *testing.T) {
   "name": "name"
  }
 ]`, string(body))
+		},
+	}, {
+		name: "get applications summary",
+		request: request{
+			method: http.MethodGet,
+			uri:    "/namespaces/ns/applications/-/summary",
+		},
+		k8sclient:    fake.NewFakeClientWithScheme(schema, app.DeepCopy()),
+		responseCode: http.StatusOK,
+		verify: func(t *testing.T, body []byte) {
+			assert.JSONEq(t, `{"total": 1, "healthStatus": {}, "syncStatus": {}}`, string(body))
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What this PR does / why we need it:

Provide applications summary API. The request and response look like below:

**Request URL**
```bash
http://localhost:9090/kapis/gitops.kubesphere.io/v1alpha1/namespaces/{namepsace}/applications/-/summary
```

**Response Body**

```json
{
  "total": 1,
  "healthStatus": {
    "Healthy": 1
  },
  "syncStatus": {
    "Synced": 1
  }
}
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:

Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??

```release-note
None
```
/cc @kubesphere/sig-devops 
