### PR TITLE
Fix an issue where the application status subresource was not updated

### DIFF
--- a/controllers/argocd/application_controller.go
+++ b/controllers/argocd/application_controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
@@ -61,9 +60,7 @@ func (r *ApplicationReconciler) Reconcile(req ctrl.Request) (result ctrl.Result,
 func (r *ApplicationReconciler) reconcileArgoApplication(app *v1alpha1.Application) (err error) {
 	ctx := context.Background()
 
-	argoApp := &unstructured.Unstructured{}
-	argoApp.SetKind("Application")
-	argoApp.SetAPIVersion("argoproj.io/v1alpha1")
+	argoApp := createBareArgoCDApplicationObject()
 
 	if err = r.Get(ctx, types.NamespacedName{
 		Namespace: app.GetNamespace(),
@@ -105,12 +102,7 @@ func createUnstructuredApplication(app *v1alpha1.Application) (result *unstructu
 		argoApp.Spec.Destination.Server = ""
 	}
 
-	newArgoApp := &unstructured.Unstructured{}
-	newArgoApp.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "argoproj.io",
-		Version: "v1alpha1",
-		Kind:    "Application",
-	})
+	newArgoApp := createBareArgoCDApplicationObject()
 	newArgoApp.SetName(app.GetName())
 	newArgoApp.SetNamespace(app.GetNamespace())
 

--- a/controllers/argocd/argocd-application-status-controller.go
+++ b/controllers/argocd/argocd-application-status-controller.go
@@ -21,9 +21,11 @@ import (
 	"encoding/json"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
+	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -57,8 +59,8 @@ func (r *ApplicationStatusReconciler) Reconcile(req ctrl.Request) (result ctrl.R
 	var status map[string]interface{}
 	if status, _, err = unstructured.NestedMap(argoCDApp.Object, "status"); err == nil {
 		var statusData []byte
-		if statusData, err = json.Marshal(status); err == nil {
-			app = app.DeepCopy()
+		if statusData, err = json.Marshal(status); err == nil && !reflect.DeepEqual([]byte(app.Status.ArgoApp), statusData) {
+			//app = app.DeepCopy()
 			if app.GetLabels() == nil {
 				// make sure the labels are not nil
 				app.SetLabels(map[string]string{})
@@ -71,15 +73,20 @@ func (r *ApplicationStatusReconciler) Reconcile(req ctrl.Request) (result ctrl.R
 			if healthStatus, found, _ := unstructured.NestedString(status, "health", "status"); found {
 				app.GetLabels()[v1alpha1.HealthStatusLabelKey] = healthStatus
 			}
-			app.Status.ArgoApp = string(statusData)
+
+			// update labels
 			err = r.Update(ctx, app)
+
+			// update status subresource
+			app.Status.ArgoApp = string(statusData)
+			err = r.Status().Update(ctx, app)
 		}
 	}
 	return
 }
 
 func getArgoCDApplication(client client.Reader, namespacedName types.NamespacedName) (app *unstructured.Unstructured, err error) {
-	app = getArgoCDApplicationObject()
+	app = createBareArgoCDApplicationObject()
 
 	if err = client.Get(context.Background(), namespacedName, app); err != nil {
 		app = nil
@@ -97,19 +104,22 @@ func (r *ApplicationStatusReconciler) GetGroupName() string {
 	return controllerGroupName
 }
 
-func getArgoCDApplicationObject() *unstructured.Unstructured {
-	cluster := &unstructured.Unstructured{}
-	cluster.SetKind("Application")
-	cluster.SetAPIVersion("argoproj.io/v1alpha1")
-	return cluster.DeepCopy()
+func createBareArgoCDApplicationObject() *unstructured.Unstructured {
+	argoApp := &unstructured.Unstructured{}
+	argoApp.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+	return argoApp
 }
 
 // SetupWithManager init the logger, recorder and filters
 func (r *ApplicationStatusReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	cluster := getArgoCDApplicationObject()
+	argoApp := createBareArgoCDApplicationObject()
 	r.log = ctrl.Log.WithName(r.GetName())
 	r.recorder = mgr.GetEventRecorderFor(r.GetName())
 	return ctrl.NewControllerManagedBy(mgr).
-		For(cluster).
+		For(argoApp).
 		Complete(r)
 }

--- a/controllers/argocd/argocd-application-status-controller.go
+++ b/controllers/argocd/argocd-application-status-controller.go
@@ -74,8 +74,17 @@ func (r *ApplicationStatusReconciler) Reconcile(req ctrl.Request) (result ctrl.R
 				app.GetLabels()[v1alpha1.HealthStatusLabelKey] = healthStatus
 			}
 
+			// unset operation field if it was absent
+			if _, found, err := unstructured.NestedMap(argoCDApp.Object, "operation"); err != nil {
+				return ctrl.Result{}, err
+			} else if !found && app.Spec.ArgoApp != nil {
+				app.Spec.ArgoApp.Operation = nil
+			}
+
 			// update labels
-			err = r.Update(ctx, app)
+			if err = r.Update(ctx, app); err != nil {
+				return
+			}
 
 			// update status subresource
 			app.Status.ArgoApp = string(statusData)

--- a/controllers/argocd/argocd-application-status-controller_test.go
+++ b/controllers/argocd/argocd-application-status-controller_test.go
@@ -99,7 +99,7 @@ func Test_getArgoCDApplicationObject(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.verify(t, getArgoCDApplicationObject())
+			tt.verify(t, createBareArgoCDApplicationObject())
 		})
 	}
 }


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Fix an issue where the application status subresource was not updated. 

This issue was produced by https://github.com/kubesphere/ks-devops/pull/506.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??

```release-note
None
```

/cc @kubesphere/sig-devops 
