### PR TITLE
Provide a flag to set the namespace of the ArgoCD instance

### DIFF
--- a/cmd/apiserver/app/options/options.go
+++ b/cmd/apiserver/app/options/options.go
@@ -68,6 +68,7 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	s.JenkinsOptions.AddFlags(fss.FlagSet("devops"), s.JenkinsOptions)
 	s.SonarQubeOptions.AddFlags(fss.FlagSet("sonarqube"), s.SonarQubeOptions)
 	s.S3Options.AddFlags(fss.FlagSet("s3"), s.S3Options)
+	s.ArgoCDOption.AddFlags(fss.FlagSet("argocd"))
 
 	fs = fss.FlagSet("klog")
 	local := flag.NewFlagSet("klog", flag.ExitOnError)

--- a/cmd/apiserver/app/server.go
+++ b/cmd/apiserver/app/server.go
@@ -35,6 +35,9 @@ func NewAPIServerCommand() (cmd *cobra.Command) {
 	// Load configuration from file
 	conf, err := config.TryLoadFromDisk()
 	if err == nil {
+		if conf.ArgoCDOption == nil {
+			conf.ArgoCDOption = &config.ArgoCDOption{}
+		}
 		s = &options.ServerRunOptions{
 			GenericServerRunOptions: s.GenericServerRunOptions,
 			Config:                  conf,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,7 @@ rules:
   resources:
   - events
   verbs:
+  - create
   - patch
 - apiGroups:
   - ""

--- a/controllers/argocd/application_controller.go
+++ b/controllers/argocd/application_controller.go
@@ -29,6 +29,7 @@ import (
 	"kubesphere.io/devops/pkg/utils/k8sutil"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 //+kubebuilder:rbac:groups=gitops.kubesphere.io,resources=applications,verbs=get;list;update
@@ -224,6 +225,7 @@ func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.log = ctrl.Log.WithName(r.GetName())
 	r.recorder = mgr.GetEventRecorderFor(r.GetName())
 	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		For(&v1alpha1.Application{}).
 		Complete(r)
 }

--- a/controllers/argocd/application_controller_test.go
+++ b/controllers/argocd/application_controller_test.go
@@ -57,11 +57,6 @@ func Test_createUnstructuredApplication(t *testing.T) {
 		},
 		verify: func(t *testing.T, gotResult *unstructured.Unstructured, gotErr error) {
 			assert.Nil(t, gotErr)
-
-			// make sure it has the ownerReference
-			refs, _, _ := unstructured.NestedSlice(gotResult.Object, "metadata", "ownerReferences")
-			assert.NotNil(t, refs)
-			assert.Equal(t, 1, len(refs))
 		},
 	}, {
 		name: "with some specific fields, with default values",

--- a/controllers/argocd/application_controller_test.go
+++ b/controllers/argocd/application_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -100,13 +99,16 @@ func Test_createUnstructuredApplication(t *testing.T) {
 }
 
 func TestApplicationReconciler_reconcileArgoApplication(t *testing.T) {
-	schema, err := v1alpha3.SchemeBuilder.Register().Build()
+	schema, err := v1alpha1.SchemeBuilder.Register().Build()
 	assert.Nil(t, err)
 
 	app := &v1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "fake",
 			Namespace: "fake",
+			Labels: map[string]string{
+				v1alpha1.ArgoCDLocationLabelKey: "fake",
+			},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			ArgoApp: &v1alpha1.ArgoApplication{
@@ -129,9 +131,8 @@ func TestApplicationReconciler_reconcileArgoApplication(t *testing.T) {
 	argoApp.SetNamespace("fake")
 
 	type fields struct {
-		Client   client.Client
-		log      logr.Logger
-		recorder record.EventRecorder
+		Client client.Client
+		log    logr.Logger
 	}
 	type args struct {
 		app *v1alpha1.Application
@@ -144,7 +145,7 @@ func TestApplicationReconciler_reconcileArgoApplication(t *testing.T) {
 	}{{
 		name: "without Argo Application",
 		fields: fields{
-			Client: fake.NewFakeClientWithScheme(schema),
+			Client: fake.NewFakeClientWithScheme(schema, app.DeepCopy()),
 		},
 		args: args{
 			app: app.DeepCopy(),
@@ -167,7 +168,7 @@ func TestApplicationReconciler_reconcileArgoApplication(t *testing.T) {
 	}, {
 		name: "with Argo Application",
 		fields: fields{
-			Client: fake.NewFakeClientWithScheme(schema, argoApp.DeepCopy()),
+			Client: fake.NewFakeClientWithScheme(schema, app.DeepCopy()),
 		},
 		args: args{
 			app: app.DeepCopy(),
@@ -191,7 +192,7 @@ func TestApplicationReconciler_reconcileArgoApplication(t *testing.T) {
 			r := &ApplicationReconciler{
 				Client:   tt.fields.Client,
 				log:      tt.fields.log,
-				recorder: tt.fields.recorder,
+				recorder: &record.FakeRecorder{},
 			}
 			err := r.reconcileArgoApplication(tt.args.app)
 			tt.verify(t, tt.fields.Client, err)

--- a/controllers/argocd/argocd-application-status-controller.go
+++ b/controllers/argocd/argocd-application-status-controller.go
@@ -67,7 +67,7 @@ func (r *ApplicationStatusReconciler) Reconcile(req ctrl.Request) (result ctrl.R
 		Namespace: appNs,
 		Name:      appName,
 	}, app); err != nil {
-		r.log.Error(err, "cannot found application with namespace: %s, name: %s", appNs, appName)
+		r.log.Error(err, "cannot find application with namespace: %s, name: %s", appNs, appName)
 		err = nil
 		return
 	}

--- a/controllers/argocd/argocd-application-status-controller.go
+++ b/controllers/argocd/argocd-application-status-controller.go
@@ -19,8 +19,11 @@ package argocd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -28,6 +31,7 @@ import (
 	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 //+kubebuilder:rbac:groups=gitops.kubesphere.io,resources=applications,verbs=get;update
@@ -44,14 +48,26 @@ type ApplicationStatusReconciler struct {
 // Reconcile is the entrypoint of the controller
 func (r *ApplicationStatusReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error) {
 	var argoCDApp *unstructured.Unstructured
+	r.log.Info(fmt.Sprintf("start to reconcile ArgoCD application: %s", req.String()))
+
 	if argoCDApp, err = getArgoCDApplication(r.Client, req.NamespacedName); err != nil {
 		err = client.IgnoreNotFound(err)
 		return
 	}
 
+	appNs := argoCDApp.GetLabels()[v1alpha1.AppNamespaceLabelKey]
+	appName := argoCDApp.GetLabels()[v1alpha1.AppNameLabelKey]
+	if appName == "" || appNs == "" {
+		return
+	}
+
 	ctx := context.Background()
 	app := &v1alpha1.Application{}
-	if err = r.Get(ctx, req.NamespacedName, app); err != nil {
+	if err = r.Get(ctx, types.NamespacedName{
+		Namespace: appNs,
+		Name:      appName,
+	}, app); err != nil {
+		r.log.Error(err, "cannot found application with namespace: %s, name: %s", appNs, appName)
 		err = nil
 		return
 	}
@@ -86,7 +102,6 @@ func (r *ApplicationStatusReconciler) Reconcile(req ctrl.Request) (result ctrl.R
 				return
 			}
 
-			// update status subresource
 			app.Status.ArgoApp = string(statusData)
 			err = r.Status().Update(ctx, app)
 		}
@@ -128,7 +143,12 @@ func (r *ApplicationStatusReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	argoApp := createBareArgoCDApplicationObject()
 	r.log = ctrl.Log.WithName(r.GetName())
 	r.recorder = mgr.GetEventRecorderFor(r.GetName())
+	var withLabelPredicate = predicate.NewPredicateFuncs(func(meta metav1.Object, object runtime.Object) (ok bool) {
+		_, ok = meta.GetLabels()[v1alpha1.ArgoCDAppControlByLabelKey]
+		return
+	})
 	return ctrl.NewControllerManagedBy(mgr).
 		For(argoApp).
+		WithEventFilter(withLabelPredicate).
 		Complete(r)
 }

--- a/controllers/argocd/argocd-application-status-controller_test.go
+++ b/controllers/argocd/argocd-application-status-controller_test.go
@@ -18,7 +18,6 @@ package argocd
 
 import (
 	"fmt"
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,6 +28,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"testing"
 )
 
@@ -123,9 +123,7 @@ func TestArgoCDApplicationStatusReconciler_Reconcile(t *testing.T) {
 	defaultArgoCDApp.SetNamespace("ns")
 
 	type fields struct {
-		Client   client.Client
-		log      logr.Logger
-		recorder record.EventRecorder
+		Client client.Client
 	}
 	type args struct {
 		req controllerruntime.Request
@@ -192,8 +190,8 @@ func TestArgoCDApplicationStatusReconciler_Reconcile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &ApplicationStatusReconciler{
 				Client:   tt.fields.Client,
-				log:      tt.fields.log,
-				recorder: tt.fields.recorder,
+				log:      log.NullLogger{},
+				recorder: &record.FakeRecorder{},
 			}
 			gotResult, err := r.Reconcile(tt.args.req)
 			if !tt.wantErr(t, err, fmt.Sprintf("Reconcile(%v)", tt.args.req)) {

--- a/pkg/api/gitops/v1alpha1/constants.go
+++ b/pkg/api/gitops/v1alpha1/constants.go
@@ -25,3 +25,6 @@ const (
 	AppNamespaceLabelKey       = GroupName + "/application-namespace"
 	AppNameLabelKey            = GroupName + "/application-name"
 )
+
+// ApplicationFinalizerName is the name of PipelineRun finalizer
+const ApplicationFinalizerName = "application." + GroupName

--- a/pkg/api/gitops/v1alpha1/constants.go
+++ b/pkg/api/gitops/v1alpha1/constants.go
@@ -16,7 +16,12 @@
 package v1alpha1
 
 const (
-	GroupName            = "gitops.kubesphere.io"
-	HealthStatusLabelKey = GroupName + "/health-status"
-	SyncStatusLabelKey   = GroupName + "/sync-status"
+	GroupName                  = "gitops.kubesphere.io"
+	HealthStatusLabelKey       = GroupName + "/health-status"
+	SyncStatusLabelKey         = GroupName + "/sync-status"
+	ArgoCDLocationLabelKey     = GroupName + "/argocd-location"
+	ArgoCDAppNameLabelKey      = GroupName + "/argocd-application"
+	ArgoCDAppControlByLabelKey = GroupName + "/argocd-application-control-by"
+	AppNamespaceLabelKey       = GroupName + "/application-namespace"
+	AppNameLabelKey            = GroupName + "/application-name"
 )

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -161,7 +161,7 @@ func (s *APIServer) installKubeSphereAPIs() {
 	))
 	wss = append(wss, gitops.AddToContainer(s.container, &common.Options{
 		GenericClient: s.Client,
-	})...)
+	}, s.Config.ArgoCDOption)...)
 	doc.AddSwaggerService(wss, s.container)
 }
 

--- a/pkg/config/argocd.go
+++ b/pkg/config/argocd.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/spf13/pflag"
+
+// ArgoCDOption as the ArgoCD integration configuration
+type ArgoCDOption struct {
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty" description:"Which namespace the ArgoCD located"`
+}
+
+// AddFlags adds the flags which related to argocd
+func (o *ArgoCDOption) AddFlags(fs *pflag.FlagSet) {
+	// see also https://argo-cd.readthedocs.io/en/stable/getting_started/
+	fs.StringVarP(&o.Namespace, "argocd-namespace", o.Namespace, "argocd", "Which namespace the ArgoCD located")
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,12 +84,13 @@ type Config struct {
 	RedisOptions          *cache.Options                     `json:"redis,omitempty" yaml:"redis,omitempty" mapstructure:"redis"`
 	S3Options             *s3.Options                        `json:"s3,omitempty" yaml:"s3,omitempty" mapstructure:"s3"`
 	SonarQubeOptions      *sonarqube.Options                 `json:"sonarqube,omitempty" yaml:"sonarQube,omitempty" mapstructure:"sonarqube"`
+	ArgoCDOption          *ArgoCDOption                      `json:"argocd,omitempty" yaml:"argocd,omitempty" mapstructure:"argocd"`
 	AuthenticationOptions *authoptions.AuthenticationOptions `json:"authentication,omitempty" yaml:"authentication,omitempty" mapstructure:"authentication"`
 	AuthMode              AuthMode                           `json:"authMode,omitempty" yaml:"authMode,omitempty" mapstructure:"authMode"`
 	JWTSecret             string                             `json:"jwtSecret,omitempty" yaml:"jwtSecret,omitempty" mapstructure:"jwtSecret"`
 }
 
-// newConfig creates a default non-empty Config
+// New creates a default non-empty Config
 func New() *Config {
 	return &Config{
 		SonarQubeOptions:  sonarqube.NewSonarQubeOptions(),
@@ -126,7 +127,7 @@ func TryLoadFromDisk() (*Config, error) {
 	return conf, nil
 }
 
-// convertToMap simply converts config to map[string]bool
+// ToMap simply converts config to map[string]bool
 // to hide sensitive information
 func (conf *Config) ToMap() map[string]bool {
 	conf.stripEmptyOptions()

--- a/pkg/kapis/gitops/v1alpha1/argocd/handler.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/handler.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
 	"kubesphere.io/devops/pkg/apiserver/query"
+	"kubesphere.io/devops/pkg/config"
 	"kubesphere.io/devops/pkg/kapis/common"
 	"kubesphere.io/devops/pkg/models/resources/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -85,6 +86,10 @@ func (h *handler) createApplication(req *restful.Request, res *restful.Response)
 	application := &v1alpha1.Application{}
 	if err = req.ReadEntity(application); err == nil {
 		application.Namespace = namespace
+		if application.Labels == nil {
+			application.Labels = make(map[string]string)
+		}
+		application.Labels[v1alpha1.ArgoCDLocationLabelKey] = h.ArgoCDNamespace
 		err = h.Create(context.Background(), application)
 	}
 
@@ -137,10 +142,12 @@ func (h *handler) getClusters(req *restful.Request, res *restful.Response) {
 
 type handler struct {
 	client.Client
+	ArgoCDNamespace string
 }
 
-func newHandler(options *common.Options) *handler {
+func newHandler(options *common.Options, argoOption *config.ArgoCDOption) *handler {
 	return &handler{
-		Client: options.GenericClient,
+		Client:          options.GenericClient,
+		ArgoCDNamespace: argoOption.Namespace,
 	}
 }

--- a/pkg/kapis/gitops/v1alpha1/argocd/route.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route.go
@@ -20,6 +20,7 @@ import (
 	"kubesphere.io/devops/pkg/api"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
 	"kubesphere.io/devops/pkg/apiserver/query"
+	"kubesphere.io/devops/pkg/config"
 	"kubesphere.io/devops/pkg/kapis/common"
 	"net/http"
 )
@@ -38,8 +39,8 @@ type ApplicationPageResult struct {
 }
 
 // RegisterRoutes is for registering Argo CD Application routes into WebService.
-func RegisterRoutes(service *restful.WebService, options *common.Options) {
-	handler := newHandler(options)
+func RegisterRoutes(service *restful.WebService, options *common.Options, argoOption *config.ArgoCDOption) {
+	handler := newHandler(options, argoOption)
 	service.Route(service.GET("/namespaces/{namespace}/applications").
 		To(handler.applicationList).
 		Param(common.NamespacePathParameter).

--- a/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
@@ -27,6 +27,7 @@ import (
 	"kubesphere.io/devops/pkg/api"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
 	"kubesphere.io/devops/pkg/apiserver/runtime"
+	"kubesphere.io/devops/pkg/config"
 	"kubesphere.io/devops/pkg/kapis/common"
 	"net/http"
 	"net/http/httptest"
@@ -60,7 +61,7 @@ func TestRegisterRoutes(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			RegisterRoutes(tt.args.service, tt.args.options)
+			RegisterRoutes(tt.args.service, tt.args.options, &config.ArgoCDOption{})
 			tt.verify(t, tt.args.service)
 		})
 	}
@@ -307,7 +308,7 @@ func TestAPIs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			wsWithGroup := runtime.NewWebService(v1alpha1.GroupVersion)
-			RegisterRoutes(wsWithGroup, &common.Options{GenericClient: tt.k8sclient})
+			RegisterRoutes(wsWithGroup, &common.Options{GenericClient: tt.k8sclient}, &config.ArgoCDOption{})
 
 			container := restful.NewContainer()
 			container.Add(wsWithGroup)

--- a/pkg/kapis/gitops/v1alpha1/registery.go
+++ b/pkg/kapis/gitops/v1alpha1/registery.go
@@ -20,6 +20,7 @@ import (
 	"github.com/emicklei/go-restful"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
 	"kubesphere.io/devops/pkg/apiserver/runtime"
+	"kubesphere.io/devops/pkg/config"
 	"kubesphere.io/devops/pkg/kapis/common"
 	"kubesphere.io/devops/pkg/kapis/gitops/v1alpha1/argocd"
 )
@@ -28,13 +29,13 @@ import (
 //+kubebuilder:rbac:groups=gitops.kubesphere.io,resources=applications,verbs=get;list;update;delete;create;watch
 
 // AddToContainer adds web services into web service container.
-func AddToContainer(container *restful.Container, options *common.Options) []*restful.WebService {
+func AddToContainer(container *restful.Container, options *common.Options, argoOption *config.ArgoCDOption) []*restful.WebService {
 	services := []*restful.WebService{
 		runtime.NewWebService(v1alpha1.GroupVersion),
 		runtime.NewWebServiceWithoutGroup(v1alpha1.GroupVersion),
 	}
 	for _, service := range services {
-		argocd.RegisterRoutes(service, options)
+		argocd.RegisterRoutes(service, options, argoOption)
 		container.Add(service)
 	}
 	return services

--- a/pkg/utils/k8sutil/objectmeta.go
+++ b/pkg/utils/k8sutil/objectmeta.go
@@ -22,8 +22,11 @@ import (
 )
 
 // AddFinalizer adds an finalizer
-func AddFinalizer(objectMeta *metav1.ObjectMeta, finalizer string) {
+func AddFinalizer(objectMeta *metav1.ObjectMeta, finalizer string) (added bool) {
+	count := len(objectMeta.Finalizers)
 	objectMeta.Finalizers = sliceutil.AddToSlice(finalizer, objectMeta.Finalizers)
+	added = len(objectMeta.Finalizers) > count
+	return
 }
 
 // RemoveFinalizer removes an finalizer


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:
This PR provides a flag to set the namespace of the Argo CD instance: `--argocd-namespace=xxx`. Users need to use this flag if they install Argo CD to other namespaces instead of `argocd`.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

```
kubespheredev/devops-apiserver:dev-v3.2.1-48fbb49
```

```
kubespheredev/devops-controller:dev-v3.2.1-48fbb49
```

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
