### PR TITLE
Provide an RESTful API to sync Application manually

### DIFF
--- a/pkg/kapis/gitops/v1alpha1/argocd/handler.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/handler.go
@@ -20,13 +20,26 @@ import (
 	"github.com/emicklei/go-restful"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/authentication/user"
+	utilretry "k8s.io/client-go/util/retry"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
 	"kubesphere.io/devops/pkg/apiserver/query"
+	apiserverrequest "kubesphere.io/devops/pkg/apiserver/request"
 	"kubesphere.io/devops/pkg/config"
 	"kubesphere.io/devops/pkg/kapis/common"
 	"kubesphere.io/devops/pkg/models/resources/v1alpha3"
+	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var argoAppNotConfiguredError = restful.NewError(http.StatusBadRequest,
+	"application is not initialized, please confirm you have already configured it")
+var operationAlreadyInProgressError = restful.NewError(http.StatusBadRequest,
+	"another operation is already in progress")
+var invalidRequestBodyError = restful.NewError(http.StatusBadRequest,
+	"invalid application sync request")
+var unauthenticatedError = restful.NewError(http.StatusUnauthorized,
+	"unauthenticated request")
 
 func (h *handler) applicationList(req *restful.Request, res *restful.Response) {
 	namespace := common.GetPathParameter(req, common.NamespacePathParameter)
@@ -62,6 +75,97 @@ func (h *handler) getApplication(req *restful.Request, res *restful.Response) {
 		Name:      name,
 	}, application)
 	common.Response(req, res, application, err)
+}
+
+func (h *handler) handleSyncApplication(req *restful.Request, res *restful.Response) {
+	namespace := common.GetPathParameter(req, common.NamespacePathParameter)
+	name := common.GetPathParameter(req, pathParameterApplication)
+
+	syncRequest := &ApplicationSyncRequest{}
+	err := req.ReadEntity(syncRequest)
+	if err != nil {
+		common.Response(req, res, nil, invalidRequestBodyError)
+		return
+	}
+
+	currentUser, ok := apiserverrequest.UserFrom(req.Request.Context())
+	if !ok || currentUser == nil {
+		common.Response(req, res, nil, unauthenticatedError)
+		return
+	}
+
+	app, err := h.syncApplication(namespace, name, syncRequest, currentUser)
+	common.Response(req, res, app, err)
+}
+
+func (h *handler) syncApplication(namespace, name string, syncRequest *ApplicationSyncRequest, currentUser user.Info) (*v1alpha1.Application, error) {
+	app := &v1alpha1.Application{}
+	ctx := context.Background()
+	if err := h.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, app); err != nil {
+		return nil, err
+	}
+	if app.Spec.ArgoApp == nil {
+		return nil, argoAppNotConfiguredError
+	}
+
+	argoApp := app.Spec.ArgoApp
+
+	// concrete operation
+	var syncOptions v1alpha1.SyncOptions
+	var retry *v1alpha1.RetryStrategy
+	if argoApp.Spec.SyncPolicy != nil {
+		syncOptions = argoApp.Spec.SyncPolicy.SyncOptions
+		retry = argoApp.Spec.SyncPolicy.Retry
+	}
+	if syncRequest.RetryStrategy != nil {
+		retry = syncRequest.RetryStrategy
+	}
+	if syncRequest.SyncOptions != nil {
+		syncOptions = *syncRequest.SyncOptions
+	}
+
+	operation := &v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{
+			Revision:     syncRequest.Revision,
+			Prune:        syncRequest.Prune,
+			DryRun:       syncRequest.DryRun,
+			SyncOptions:  syncOptions,
+			SyncStrategy: syncRequest.Strategy,
+			Resources:    syncRequest.Resources,
+			Manifests:    syncRequest.Manifests,
+		},
+		InitiatedBy: v1alpha1.OperationInitiator{Username: currentUser.GetName()},
+		Info:        syncRequest.Infos,
+	}
+	if retry != nil {
+		operation.Retry = *retry
+	}
+
+	return h.updateOperation(namespace, name, operation)
+}
+
+func (h *handler) updateOperation(namespace, name string, operation *v1alpha1.Operation) (*v1alpha1.Application, error) {
+	var app *v1alpha1.Application
+	return app, utilretry.RetryOnConflict(utilretry.DefaultRetry, func() error {
+		app = &v1alpha1.Application{}
+		err := h.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, app)
+		if err != nil {
+			return err
+		}
+		if app.Spec.ArgoApp == nil {
+			return argoAppNotConfiguredError
+		}
+		if app.Spec.ArgoApp.Operation != nil {
+			return operationAlreadyInProgressError
+		}
+
+		app.Spec.ArgoApp.Operation = operation
+		if err := h.Update(context.Background(), app); err != nil {
+			return err
+		}
+		// updated successfully
+		return nil
+	})
 }
 
 func (h *handler) delApplication(req *restful.Request, res *restful.Response) {

--- a/pkg/kapis/gitops/v1alpha1/argocd/handler_test.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/handler_test.go
@@ -16,14 +16,18 @@
 package argocd
 
 import (
+	"bytes"
 	"encoding/json"
 	"github.com/emicklei/go-restful"
 	"github.com/stretchr/testify/assert"
+	"io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/kubernetes/scheme"
 	"kubesphere.io/devops/pkg/api"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
+	"kubesphere.io/devops/pkg/apiserver/request"
 	"kubesphere.io/devops/pkg/kapis/common"
 	"net/http"
 	"net/http/httptest"
@@ -308,6 +312,171 @@ func Test_handler_applicationList(t *testing.T) {
 			wantResponseBytes, err := json.Marshal(tt.wantResponse)
 			assert.Nil(t, err)
 			assert.JSONEq(t, string(wantResponseBytes), recorder.Body.String())
+		})
+	}
+}
+
+func Test_handler_handleSyncApplication(t *testing.T) {
+	createApp := func(name string, op *v1alpha1.Operation) *v1alpha1.Application {
+		return &v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "fake-namespace",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				ArgoApp: &v1alpha1.ArgoApplication{
+					Operation: op,
+				},
+			},
+		}
+	}
+	createRequest := func(name string, syncRequest *ApplicationSyncRequest, withUser bool) *restful.Request {
+		var body io.Reader
+		if syncRequest != nil {
+			bodyJSON, err := json.Marshal(syncRequest)
+			assert.NoError(t, err)
+			body = bytes.NewBuffer(bodyJSON)
+		}
+		testReq := httptest.NewRequest(http.MethodPost, "/applications/app/sync", body)
+		testReq.Header.Set(restful.HEADER_ContentType, restful.MIME_JSON)
+		if withUser {
+			ctx := request.WithUser(testReq.Context(), &user.DefaultInfo{
+				Name: "fake-user",
+			})
+			testReq = testReq.WithContext(ctx)
+		}
+		req := restful.NewRequest(testReq)
+		req.PathParameters()[common.NamespacePathParameter.Data().Name] = "fake-namespace"
+		req.PathParameters()[pathParameterApplication.Data().Name] = name
+		return req
+	}
+	type fields struct {
+		apps []v1alpha1.Application
+	}
+	type args struct {
+		req *restful.Request
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		args             args
+		wantResponseCode int
+		verifyResponse   func(t *testing.T, response string)
+	}{{
+		name: "Should return bad request error if sync request is nil",
+		fields: fields{
+			apps: []v1alpha1.Application{
+				*createApp("fake-app", nil),
+			},
+		},
+		args: args{
+			req: createRequest("fake-app", nil, true),
+		},
+		wantResponseCode: http.StatusBadRequest,
+		verifyResponse: func(t *testing.T, response string) {
+			assert.Contains(t, response, invalidRequestBodyError.Error())
+		},
+	}, {
+		name: "Should return 404 if app is not found",
+		fields: fields{
+			apps: []v1alpha1.Application{
+				*createApp("fake-app", nil),
+			},
+		},
+		args: args{
+			req: createRequest("another-fake-app", &ApplicationSyncRequest{}, true),
+		},
+		wantResponseCode: http.StatusNotFound,
+		verifyResponse: func(t *testing.T, response string) {
+			assert.Contains(t, response, "applications.gitops.kubesphere.io \"another-fake-app\" not found")
+		},
+	}, {
+		name: "Should return 401 if unauthenticated user requests this endpoint",
+		fields: fields{
+			apps: []v1alpha1.Application{
+				*createApp("fake-app", nil),
+			},
+		},
+		args: args{
+			req: createRequest("fake-app", &ApplicationSyncRequest{}, false),
+		},
+		wantResponseCode: http.StatusUnauthorized,
+		verifyResponse: func(t *testing.T, response string) {
+			assert.Contains(t, response, unauthenticatedError.Error())
+		},
+	}, {
+		name: "Should return 400 if argoApp is not initialized",
+		fields: fields{
+			apps: []v1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-app",
+						Namespace: "fake-namespace",
+					},
+					Spec: v1alpha1.ApplicationSpec{
+						ArgoApp: nil,
+					},
+				},
+			},
+		},
+		args: args{
+			req: createRequest("fake-app", &ApplicationSyncRequest{}, true),
+		},
+		wantResponseCode: http.StatusBadRequest,
+		verifyResponse: func(t *testing.T, response string) {
+			assert.Contains(t, response, argoAppNotConfiguredError.Error())
+		},
+	}, {
+		name: "Should update operation field if app has no operation field",
+		fields: fields{
+			apps: []v1alpha1.Application{
+				*createApp("fake-app", nil),
+			},
+		},
+		args: args{
+			req: createRequest("fake-app", &ApplicationSyncRequest{
+				Prune:  true,
+				DryRun: true,
+				RetryStrategy: &v1alpha1.RetryStrategy{
+					Limit: 10,
+				},
+				Strategy: &v1alpha1.SyncStrategy{
+					Apply: &v1alpha1.SyncStrategyApply{
+						Force: true,
+					},
+				},
+				SyncOptions: &v1alpha1.SyncOptions{"fake-option=true"},
+			}, true),
+		},
+		wantResponseCode: http.StatusOK,
+		verifyResponse: func(t *testing.T, response string) {
+			gotApp := &v1alpha1.Application{}
+			err := json.Unmarshal([]byte(response), gotApp)
+			assert.NoError(t, err)
+			assert.NotNil(t, gotApp.Spec.ArgoApp.Operation)
+			gotOp := gotApp.Spec.ArgoApp.Operation
+			assert.True(t, gotOp.Sync.Prune)
+			assert.True(t, gotOp.Sync.DryRun)
+			assert.Equal(t, int64(10), gotOp.Retry.Limit)
+			assert.True(t, gotOp.Sync.SyncStrategy.Apply.Force)
+			assert.Equal(t, v1alpha1.SyncOptions{"fake-option=true"}, gotOp.Sync.SyncOptions)
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			utilruntime.Must(v1alpha1.AddToScheme(scheme.Scheme))
+			fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, toObjects(tt.fields.apps)...)
+			h := &handler{
+				Client: fakeClient,
+			}
+
+			recorder := httptest.NewRecorder()
+			resp := restful.NewResponse(recorder)
+			resp.SetRequestAccepts(restful.MIME_JSON)
+			// test entrypoint
+			h.handleSyncApplication(tt.args.req, resp)
+			assert.Equal(t, tt.wantResponseCode, recorder.Code)
+			tt.verifyResponse(t, recorder.Body.String())
 		})
 	}
 }

--- a/pkg/kapis/gitops/v1alpha1/argocd/route.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route.go
@@ -45,6 +45,19 @@ type ApplicationsSummary struct {
 	SyncStatus   map[string]int `json:"syncStatus"`
 }
 
+// ApplicationSyncRequest is a request to apply an operation to change state.
+type ApplicationSyncRequest struct {
+	Revision      string                           `json:"revision"`
+	DryRun        bool                             `json:"dryRun"`
+	Prune         bool                             `json:"prune"`
+	Strategy      *v1alpha1.SyncStrategy           `json:"strategy,omitempty"`
+	Resources     []v1alpha1.SyncOperationResource `json:"resources"`
+	Manifests     []string                         `json:"manifests,omitempty"`
+	Infos         []*v1alpha1.Info                 `json:"infos,omitempty"`
+	RetryStrategy *v1alpha1.RetryStrategy          `json:"retryStrategy,omitempty"`
+	SyncOptions   *v1alpha1.SyncOptions            `json:"syncOptions,omitempty"`
+}
+
 // RegisterRoutes is for registering Argo CD Application routes into WebService.
 func RegisterRoutes(service *restful.WebService, options *common.Options, argoOption *config.ArgoCDOption) {
 	handler := newHandler(options, argoOption)
@@ -79,6 +92,14 @@ func RegisterRoutes(service *restful.WebService, options *common.Options, argoOp
 		Param(common.NamespacePathParameter).
 		Param(pathParameterApplication).
 		Doc("Get a particular application").
+		Returns(http.StatusOK, api.StatusOK, v1alpha1.Application{}))
+
+	service.Route(service.POST("/namespaces/{namespace}/applications/{application}/sync").
+		To(handler.handleSyncApplication).
+		Param(common.NamespacePathParameter).
+		Param(pathParameterApplication).
+		Reads(ApplicationSyncRequest{}).
+		Doc("Sync a particular application manually").
 		Returns(http.StatusOK, api.StatusOK, v1alpha1.Application{}))
 
 	service.Route(service.DELETE("/namespaces/{namespace}/applications/{application}").


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What this PR does / why we need it:

Provide an RESTful API to sync Application manually.

![image](https://user-images.githubusercontent.com/16865714/160547155-68863406-aa9f-492a-be73-216ef75fc240.png)

Request body example:

```json
{
  "revision": "string",
  "dryRun": true,
  "prune": true,
  "strategy": {
    "apply": {
      "force": true
    },
    "hook": {
      "force": true
    }
  },
  "resources": [
    {
      "group": "string",
      "kind": "string",
      "name": "string",
      "namespace": "string"
    }
  ],
  "manifests": [
    "string"
  ],
  "infos": [
    {
      "name": "string",
      "value": "string"
    }
  ],
  "retryStrategy": {
    "limit": 0,
    "backoff": {
      "duration": "string",
      "factor": 0,
      "maxDuration": "string"
    }
  },
  "syncOptions": [
    null
  ]
}
```

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

/cc @kubesphere/sig-devops 

Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??

```release-note
None
```
