### PR TITLE
Maintains the Argo CD git repository secrets against to the GitRepository

### DIFF
--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -108,6 +108,10 @@ func getAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 	argocdAppStatusReconciler := &argocd.ApplicationStatusReconciler{
 		Client: mgr.GetClient(),
 	}
+	argocdGitRepoReconciler := &argocd.GitRepositoryController{
+		Client:        mgr.GetClient(),
+		ArgoNamespace: s.ArgoCDOption.Namespace,
+	}
 
 	return map[string]func(mgr manager.Manager) error{
 		"gitrepository": func(mgr manager.Manager) error {
@@ -173,6 +177,9 @@ func getAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 				return
 			}
 			if err = argocdAppStatusReconciler.SetupWithManager(mgr); err != nil {
+				return
+			}
+			if err = argocdGitRepoReconciler.SetupWithManager(mgr); err != nil {
 				return
 			}
 			return argocdAppReconciler.SetupWithManager(mgr)

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"flag"
+	"kubesphere.io/devops/pkg/config"
 	"strings"
 	"time"
 
@@ -42,6 +43,7 @@ type DevOpsControllerManagerOptions struct {
 	S3Options         *s3.Options
 	FeatureOptions    *FeatureOptions
 	JWTOptions        *JWTOptions
+	ArgoCDOption      *config.ArgoCDOption
 
 	// KubeSphere is using sigs.k8s.io/application as fundamental object to implement Application Management.
 	// There are other projects also built on sigs.k8s.io/application, when KubeSphere installed along side
@@ -76,6 +78,7 @@ func (s *DevOpsControllerManagerOptions) Flags() cliflag.NamedFlagSets {
 	s.KubernetesOptions.AddFlags(fss.FlagSet("kubernetes"), s.KubernetesOptions)
 	s.JenkinsOptions.AddFlags(fss.FlagSet("devops"), s.JenkinsOptions)
 	s.FeatureOptions.AddFlags(fss.FlagSet("feature"), s.FeatureOptions)
+	s.ArgoCDOption.AddFlags(fss.FlagSet("argocd"))
 
 	fs := fss.FlagSet("leaderelection")
 	s.bindLeaderElectionFlags(s.LeaderElection, fs)

--- a/cmd/controller/app/server.go
+++ b/cmd/controller/app/server.go
@@ -47,6 +47,9 @@ func NewControllerManagerCommand() *cobra.Command {
 	// Load configuration from disk via viper, /etc/kubesphere/kubesphere.[yaml,json,xxx]
 	conf, err := config.TryLoadFromDisk()
 	if err == nil {
+		if conf.ArgoCDOption == nil {
+			conf.ArgoCDOption = &config.ArgoCDOption{}
+		}
 		// make sure LeaderElection is not nil
 		// override devops controller manager options
 		s = &options.DevOpsControllerManagerOptions{
@@ -57,6 +60,7 @@ func NewControllerManagerCommand() *cobra.Command {
 				Secret:           conf.AuthenticationOptions.JwtSecret,
 				MaximumClockSkew: conf.AuthenticationOptions.MaximumClockSkew,
 			},
+			ArgoCDOption:   conf.ArgoCDOption,
 			FeatureOptions: s.FeatureOptions,
 			LeaderElection: s.LeaderElection,
 			LeaderElect:    s.LeaderElect,

--- a/controllers/argocd/git-repository-controller.go
+++ b/controllers/argocd/git-repository-controller.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package argocd
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"kubesphere.io/devops/pkg/utils/k8sutil"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=gitrepositories,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
+// GitRepositoryController is the reconciler of the GitRepository
+type GitRepositoryController struct {
+	client.Client
+	log      logr.Logger
+	recorder record.EventRecorder
+
+	// ArgoNamespace is the namespace of the ArgoCD instance
+	ArgoNamespace string
+}
+
+// Reconcile maintains the Argo CD git repository secrets against to the GitRepository
+func (c *GitRepositoryController) Reconcile(req ctrl.Request) (result ctrl.Result, err error) {
+	ctx := context.Background()
+	c.log.Info(fmt.Sprintf("start to git repository: %s", req.String()))
+
+	repo := &v1alpha3.GitRepository{}
+	if err = c.Get(ctx, req.NamespacedName, repo); err != nil {
+		err = client.IgnoreNotFound(err)
+		return
+	}
+
+	var deleted bool
+	if deleted, err = c.handleFinalizer(repo); deleted || err != nil {
+		return
+	}
+
+	err = c.handleArgoGitRepo(repo)
+	return
+}
+
+func (c *GitRepositoryController) handleFinalizer(repo *v1alpha3.GitRepository) (deleted bool, err error) {
+	if repo.ObjectMeta.DeletionTimestamp.IsZero() {
+		if k8sutil.AddFinalizer(&repo.ObjectMeta, v1alpha3.GitRepoFinalizerName) {
+			err = c.Update(context.TODO(), repo)
+		}
+		return
+	}
+
+	// finalize the Argo Git Repositories aka the special secrets
+	deleted = true
+	ctx := context.Background()
+	ns, name := c.ArgoNamespace, getSecretName(repo.Name)
+
+	secret := &v1.Secret{}
+	if err = c.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}, secret); err != nil {
+		err = client.IgnoreNotFound(err)
+	} else {
+		err = c.Delete(ctx, secret)
+	}
+	return
+}
+
+func (c *GitRepositoryController) handleArgoGitRepo(repo *v1alpha3.GitRepository) (err error) {
+	ctx := context.Background()
+	ns, name := c.ArgoNamespace, getSecretName(repo.Name)
+
+	secret := &v1.Secret{}
+	if err = c.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}, secret); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return
+		}
+
+		// no existing secret, create a new one
+		secret.SetNamespace(ns)
+		secret.SetName(name)
+		c.setArgoGitRepoFields(repo, secret)
+		err = c.Create(ctx, secret)
+	} else {
+		c.setArgoGitRepoFields(repo, secret)
+		err = c.Update(ctx, secret)
+	}
+	return
+}
+
+func (c *GitRepositoryController) setArgoGitRepoFields(repo *v1alpha3.GitRepository, secret *v1.Secret) {
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels["argocd.argoproj.io/secret-type"] = "repository"
+
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+	secret.Data["type"] = []byte("git")
+	secret.Data["url"] = []byte(repo.Spec.URL)
+
+	c.setArgoGitRepoAuth(secret, repo.Spec.Secret)
+}
+
+func (c *GitRepositoryController) setArgoGitRepoAuth(secret *v1.Secret, ref *v1.SecretReference) {
+	if ref == nil {
+		return
+	}
+
+	authSecret := &v1.Secret{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+	}, authSecret); err == nil {
+		switch authSecret.Type {
+		case v1.SecretTypeBasicAuth:
+			secret.Data["username"] = authSecret.Data[v1.BasicAuthUsernameKey]
+			secret.Data["password"] = authSecret.Data[v1.BasicAuthPasswordKey]
+		default:
+			c.log.V(4).Info("not support auth secret", "type", authSecret.Type)
+		}
+	}
+}
+
+func getSecretName(name string) string {
+	return fmt.Sprintf("%s-repo", name)
+}
+
+// GetName returns the name of this reconciler
+func (c *GitRepositoryController) GetName() string {
+	return "GitRepositoryController"
+}
+
+// GetGroupName returns the group name of this reconciler
+func (c *GitRepositoryController) GetGroupName() string {
+	return controllerGroupName
+}
+
+// SetupWithManager setups the reconciler with a manager
+// setup the logger, recorder
+func (c *GitRepositoryController) SetupWithManager(mgr ctrl.Manager) error {
+	c.log = ctrl.Log.WithName(c.GetName())
+	c.recorder = mgr.GetEventRecorderFor(c.GetName())
+	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		For(&v1alpha3.GitRepository{}).
+		Complete(c)
+}

--- a/controllers/argocd/git-repository-controller_test.go
+++ b/controllers/argocd/git-repository-controller_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package argocd
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_getSecretName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{{
+		name: "normal case",
+		args: args{
+			name: "name",
+		},
+		want: "name-repo",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getSecretName(tt.args.name), "getSecretName(%v)", tt.args.name)
+		})
+	}
+}
+
+func TestGitRepositoryController_Reconcile(t *testing.T) {
+	schema, err := v1alpha3.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+	err = v1.SchemeBuilder.AddToScheme(schema)
+	assert.Nil(t, err)
+
+	repo := v1alpha3.GitRepository{}
+	repo.SetNamespace("ns")
+	repo.SetName("fake")
+
+	repoWithAuth := repo.DeepCopy()
+	repoWithAuth.Spec.Secret = &v1.SecretReference{
+		Namespace: "argocd",
+		Name:      "fake-repo",
+	}
+
+	now := metav1.Now()
+	repoWithDeletion := repo.DeepCopy()
+	repoWithDeletion.DeletionTimestamp = &now
+
+	secret := v1.Secret{}
+	secret.SetNamespace("argocd")
+	secret.SetName("fake-repo")
+	secret.Type = v1.SecretTypeBasicAuth
+
+	type fields struct {
+		Client client.Client
+	}
+	type args struct {
+		req controllerruntime.Request
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantResult controllerruntime.Result
+		wantErr    assert.ErrorAssertionFunc
+	}{{
+		name: "not found a git repository",
+		fields: fields{
+			Client: fake.NewFakeClientWithScheme(schema),
+		},
+		args: args{
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "ns",
+					Name:      "fake",
+				},
+			},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			return false
+		},
+	}, {
+		name: "create a git repository, without argo secret",
+		fields: fields{
+			Client: fake.NewFakeClientWithScheme(schema, repo.DeepCopy()),
+		},
+		args: args{
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "ns",
+					Name:      "fake",
+				},
+			},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			return false
+		},
+	}, {
+		name: "create a git repository, with an argo secret",
+		fields: fields{
+			Client: fake.NewFakeClientWithScheme(schema, repo.DeepCopy(), secret.DeepCopy()),
+		},
+		args: args{
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "ns",
+					Name:      "fake",
+				},
+			},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			return false
+		},
+	}, {
+		name: "create a git repository with auth secret, with an argo secret",
+		fields: fields{
+			Client: fake.NewFakeClientWithScheme(schema, repoWithAuth.DeepCopy(), secret.DeepCopy()),
+		},
+		args: args{
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "ns",
+					Name:      "fake",
+				},
+			},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			return false
+		},
+	}, {
+		name: "delete a git repository, without argo secret",
+		fields: fields{
+			Client: fake.NewFakeClientWithScheme(schema, repoWithDeletion.DeepCopy()),
+		},
+		args: args{
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "ns",
+					Name:      "fake",
+				},
+			},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			return false
+		},
+	}, {
+		name: "delete a git repository, with argo secret",
+		fields: fields{
+			Client: fake.NewFakeClientWithScheme(schema, repoWithDeletion.DeepCopy(), secret.DeepCopy()),
+		},
+		args: args{
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "ns",
+					Name:      "fake",
+				},
+			},
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			return false
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &GitRepositoryController{
+				Client:        tt.fields.Client,
+				log:           log.NullLogger{},
+				recorder:      &record.FakeRecorder{},
+				ArgoNamespace: "argocd",
+			}
+			gotResult, err := c.Reconcile(tt.args.req)
+			if !tt.wantErr(t, err, fmt.Sprintf("Reconcile(%v)", tt.args.req)) {
+				return
+			}
+			assert.Equalf(t, tt.wantResult, gotResult, "Reconcile(%v)", tt.args.req)
+		})
+	}
+}

--- a/controllers/argocd/interface_test.go
+++ b/controllers/argocd/interface_test.go
@@ -55,6 +55,12 @@ func TestInterfaceImplement(t *testing.T) {
 			NamedReconciler: &Reconciler{},
 			GroupReconciler: &Reconciler{},
 		},
+	}, {
+		name: "GitRepositoryReconciler",
+		instance: interInstance{
+			NamedReconciler: &GitRepositoryController{},
+			GroupReconciler: &GitRepositoryController{},
+		},
 	}}
 	for i := range tests {
 		tt := tests[i]

--- a/pkg/api/devops/v1alpha3/gitrepository.go
+++ b/pkg/api/devops/v1alpha3/gitrepository.go
@@ -24,6 +24,9 @@ import (
 // AnnotationKeyWebhookUpdates is a signal that should update the webhooks
 const AnnotationKeyWebhookUpdates = "devops.kubesphere.io/webhook-updates"
 
+// GitRepoFinalizerName is the finalizer name of the git repository
+const GitRepoFinalizerName = "finalizer.gitrepository.devops.kubesphere.io"
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
As I mentioned in the title. See more details from [the official document](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories).

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
