### PR TITLE
Fix the restful doc of the v1alpha3

### DIFF
--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -97,8 +97,9 @@ func registerRoutersForCredentials(handler *devopsHandler, ws *restful.WebServic
 	ws.Route(ws.POST("/devops/{devops}/credentials").
 		To(handler.CreateCredential).
 		Param(ws.PathParameter("devops", "devops name")).
+		Reads(v1.Secret{}).
 		Doc("create the credential of the specified devops for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Returns(http.StatusOK, api.StatusOK, v1.Secret{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
 	ws.Route(ws.GET("/devops/{devops}/credentials/{credential}").
@@ -106,15 +107,16 @@ func registerRoutersForCredentials(handler *devopsHandler, ws *restful.WebServic
 		Param(ws.PathParameter("devops", "project name")).
 		Param(ws.PathParameter("credential", "pipeline name")).
 		Doc("get the credential of the specified devops for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1.Secret{}).
+		Returns(http.StatusOK, api.StatusOK, v1.Secret{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
 	ws.Route(ws.PUT("/devops/{devops}/credentials/{credential}").
 		To(handler.UpdateCredential).
 		Param(ws.PathParameter("devops", "project name")).
 		Param(ws.PathParameter("credential", "credential name")).
+		Reads(v1.Secret{}).
 		Doc("put the credential of the specified devops for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1.Secret{}).
+		Returns(http.StatusOK, api.StatusOK, v1.Secret{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
 	ws.Route(ws.DELETE("/devops/{devops}/credentials/{credential}").
@@ -122,7 +124,7 @@ func registerRoutersForCredentials(handler *devopsHandler, ws *restful.WebServic
 		Param(ws.PathParameter("devops", "project name")).
 		Param(ws.PathParameter("credential", "credential name")).
 		Doc("delete the credential of the specified devops for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1.Secret{}).
+		Returns(http.StatusOK, api.StatusOK, v1.Secret{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
 }
 
@@ -141,8 +143,9 @@ func registerRoutersForPipelines(handler *devopsHandler, ws *restful.WebService)
 	ws.Route(ws.POST("/devops/{devops}/pipelines").
 		To(handler.CreatePipeline).
 		Param(ws.PathParameter("devops", "devops name")).
+		Reads(v1alpha3.Pipeline{}).
 		Doc("create the pipeline of the specified devops for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Returns(http.StatusOK, api.StatusOK, v1alpha3.Pipeline{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
 	ws.Route(ws.GET("/devops/{devops}/pipelines/{pipeline}").
@@ -151,7 +154,7 @@ func registerRoutersForPipelines(handler *devopsHandler, ws *restful.WebService)
 		Param(ws.PathParameter("devops", "project name")).
 		Param(ws.PathParameter("pipeline", "pipeline name")).
 		Doc("get the pipeline of the specified devops for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Returns(http.StatusOK, api.StatusOK, v1alpha3.Pipeline{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
 	ws.Route(ws.PUT("/devops/{devops}/pipelines/{pipeline}").
@@ -159,7 +162,7 @@ func registerRoutersForPipelines(handler *devopsHandler, ws *restful.WebService)
 		Param(ws.PathParameter("devops", "project name")).
 		Param(ws.PathParameter("pipeline", "pipeline name")).
 		Doc("put the pipeline of the specified devops for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Returns(http.StatusOK, api.StatusOK, v1alpha3.Pipeline{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
 	ws.Route(ws.DELETE("/devops/{devops}/pipelines/{pipeline}").
@@ -167,7 +170,7 @@ func registerRoutersForPipelines(handler *devopsHandler, ws *restful.WebService)
 		Param(ws.PathParameter("devops", "project name")).
 		Param(ws.PathParameter("pipeline", "pipeline name")).
 		Doc("delete the pipeline of the specified devops for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1alpha3.Pipeline{}).
+		Returns(http.StatusOK, api.StatusOK, v1alpha3.Pipeline{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsPipelineTag}))
 }
 
@@ -185,8 +188,9 @@ func registerRoutersForWorkspace(handler *devopsHandler, ws *restful.WebService)
 	ws.Route(ws.POST("/workspaces/{workspace}/devops").
 		To(handler.CreateDevOpsProject).
 		Param(ws.PathParameter("workspace", "workspace name")).
+		Reads(v1alpha3.DevOpsProject{}).
 		Doc("Create the devopsproject of the specified workspace for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
+		Returns(http.StatusOK, api.StatusOK, v1alpha3.DevOpsProject{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
 	ws.Route(ws.GET("/workspaces/{workspace}/devops/{devops}").
@@ -202,8 +206,9 @@ func registerRoutersForWorkspace(handler *devopsHandler, ws *restful.WebService)
 		To(handler.UpdateDevOpsProject).
 		Param(ws.PathParameter("workspace", "workspace name")).
 		Param(ws.PathParameter("devops", "project name")).
+		Reads(v1alpha3.DevOpsProject{}).
 		Doc("Put the devopsproject of the specified workspace for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
+		Returns(http.StatusOK, api.StatusOK, v1alpha3.DevOpsProject{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
 	ws.Route(ws.DELETE("/workspaces/{workspace}/devops/{devops}").
@@ -211,6 +216,6 @@ func registerRoutersForWorkspace(handler *devopsHandler, ws *restful.WebService)
 		Param(ws.PathParameter("workspace", "workspace name")).
 		Param(ws.PathParameter("devops", "project name")).
 		Doc("Get the devopsproject of the specified workspace for the current user").
-		Returns(http.StatusOK, api.StatusOK, []v1alpha3.DevOpsProject{}).
+		Returns(http.StatusOK, api.StatusOK, v1alpha3.DevOpsProject{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Please feel free to use the following image if you want to test it:
```
kubespheredev/devops-apiserver:dev-v3.2.1-e166ee9
```

screenshot:
![image](https://user-images.githubusercontent.com/1450685/160996007-61ba7eb5-bd8b-4839-be90-000935809737.png)


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
