### PR TITLE
Fix the gitrepository update API cannot change the annotations

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,8 +38,10 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -56,6 +58,7 @@ rules:
   - applications
   verbs:
   - create
+  - delete
   - get
   - list
   - update
@@ -154,8 +157,11 @@ rules:
   resources:
   - gitrepositories
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/pkg/kapis/devops/v1alpha3/scm/gitrepository_handler.go
+++ b/pkg/kapis/devops/v1alpha3/scm/gitrepository_handler.go
@@ -79,20 +79,19 @@ func (h *handler) updateGitRepositories(req *restful.Request, res *restful.Respo
 	ctx := context.Background()
 
 	patchRepo := &v1alpha3.GitRepository{}
-	repo := &v1alpha3.GitRepository{}
-
 	err := req.ReadEntity(patchRepo)
 	if err == nil {
+		repo := &v1alpha3.GitRepository{}
 		err = h.Get(ctx, types.NamespacedName{
 			Namespace: namespace,
 			Name:      repoName,
 		}, repo)
 		if err == nil {
-			repo.Spec = patchRepo.Spec
-			err = h.Update(ctx, repo)
+			patchRepo.ResourceVersion = repo.ResourceVersion
+			err = h.Update(ctx, patchRepo)
 		}
 	}
-	common.Response(req, res, repo, err)
+	common.Response(req, res, patchRepo, err)
 }
 
 func (h *handler) deleteGitRepositories(req *restful.Request, res *restful.Response) {

--- a/pkg/kapis/devops/v1alpha3/scm/route.go
+++ b/pkg/kapis/devops/v1alpha3/scm/route.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=gitrepositories,verbs=get;list;update;delete;create;watch;patch
+
 var (
 	pathParameterSCM          = restful.PathParameter("scm", "the SCM type")
 	pathParameterOrganization = restful.PathParameter("organization",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:
/kind bug

Please feel free to use the following image to test it:
```
kubespheredev/devops-apiserver:dev-v3.2.1-61652d9
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
