### PR TITLE
Fix the conflicts with duplicated PipelineRuns

### DIFF
--- a/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_synchronizer_test.go
@@ -433,3 +433,43 @@ func Test_createBarePipelineRunsIfNotPresent(t *testing.T) {
 		})
 	}
 }
+
+func Test_hasPendingPipelineRuns(t *testing.T) {
+	type args struct {
+		items []v1alpha3.PipelineRun
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{{
+		name: "have pending PipelineRuns",
+		args: args{
+			items: []v1alpha3.PipelineRun{{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"a": "1",
+					},
+				},
+			}},
+		},
+		want: true,
+	}, {
+		name: "not have pending PipelineRuns",
+		args: args{
+			items: []v1alpha3.PipelineRun{{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						v1alpha3.JenkinsPipelineRunIDAnnoKey: "1",
+					},
+				},
+			}},
+		},
+		want: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, hasPendingPipelineRuns(tt.args.items), "hasPendingPipelineRuns(%v)", tt.args.items)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

Please feel free to use the following images to test:
```
kubespheredev/devops-controller:dev-v3.2.1-ce8fbda
```

```
kubespheredev/devops-apiserver:dev-v3.2.1-ce8fbda
```

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note

```
