### PR TITLE
Bump golangci lint action to v3

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,7 +49,7 @@ jobs:
             exit 1
           fi
       - name: golint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.41.1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,9 +49,8 @@ jobs:
             exit 1
           fi
       - name: golint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.41.1
-          skip-build-cache: true
-          skip-pkg-cache: true
+          skip-cache: true


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

This may resolve the lint errors like below:

![image](https://user-images.githubusercontent.com/16865714/162408642-eb441464-7a69-48ae-a231-becec7cf7ad1.png)

The result is as below:

![image](https://user-images.githubusercontent.com/16865714/162409020-db4f3ca7-4af5-475c-a2af-ce01b9caa44b.png)

### Which issue(s) this PR fixes:

Fixes https://github.com/kubesphere/ks-devops/actions/runs/2114131090

### Special notes for reviewers:

/cc @kubesphere/sig-devops 

Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??

```release-note
None
```
