### PR TITLE
Add Argo CD application cascade deletion support

### DIFF
--- a/controllers/argocd/application_controller.go
+++ b/controllers/argocd/application_controller.go
@@ -25,11 +25,15 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
 	"kubesphere.io/devops/pkg/utils/k8sutil"
+	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"strings"
 )
 
 //+kubebuilder:rbac:groups=gitops.kubesphere.io,resources=applications,verbs=get;list;update
@@ -95,6 +99,7 @@ func (r *ApplicationReconciler) reconcileArgoApplication(app *v1alpha1.Applicati
 
 		if err == nil {
 			k8sutil.RemoveFinalizer(&app.ObjectMeta, v1alpha1.ApplicationFinalizerName)
+			k8sutil.RemoveFinalizer(&app.ObjectMeta, v1alpha1.ArgoCDResourcesFinalizer)
 			err = r.Update(context.TODO(), app)
 		}
 		return
@@ -149,7 +154,20 @@ func (r *ApplicationReconciler) reconcileArgoApplication(app *v1alpha1.Applicati
 			var newArgoApp *unstructured.Unstructured
 			if newArgoApp, err = createUnstructuredApplication(app); err == nil {
 				argoApp.Object["spec"] = newArgoApp.Object["spec"]
-				err = r.Update(ctx, argoApp)
+				argoApp.SetFinalizers(newArgoApp.GetFinalizers())
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
+					latestArgoApp := createBareArgoCDApplicationObject()
+					if err = r.Get(context.Background(), types.NamespacedName{
+						Namespace: argoApp.GetNamespace(),
+						Name:      argoApp.GetName(),
+					}, latestArgoApp); err != nil {
+						return
+					}
+
+					argoApp.SetResourceVersion(latestArgoApp.GetResourceVersion())
+					err = r.Update(ctx, argoApp)
+					return
+				})
 			}
 		}
 	}
@@ -180,6 +198,17 @@ func createUnstructuredApplication(app *v1alpha1.Application) (result *unstructu
 	})
 	newArgoApp.SetName(app.GetName())
 	newArgoApp.SetNamespace(app.GetNamespace())
+
+	// copy all potential finalizers
+	finalizers := app.GetFinalizers()
+	targetFinalizers := make([]string, 0)
+	for i := range finalizers {
+		finalizer := finalizers[i]
+		if strings.HasSuffix(finalizer, "argocd.argoproj.io") {
+			targetFinalizers = append(targetFinalizers, finalizer)
+		}
+	}
+	newArgoApp.SetFinalizers(targetFinalizers)
 
 	if err := SetNestedField(newArgoApp.Object, argoApp.Spec, "spec"); err != nil {
 		return nil, err
@@ -219,13 +248,34 @@ func (r *ApplicationReconciler) GetGroupName() string {
 	return controllerGroupName
 }
 
+type finalizersChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements default UpdateEvent filter for validating finalizers change
+func (finalizersChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.MetaOld == nil {
+		return false
+	}
+	if e.ObjectOld == nil {
+		return false
+	}
+	if e.ObjectNew == nil {
+		return false
+	}
+	if e.MetaNew == nil {
+		return false
+	}
+	return !reflect.DeepEqual(e.MetaNew.GetFinalizers(), e.MetaOld.GetFinalizers())
+}
+
 // SetupWithManager setups the reconciler with a manager
 // setup the logger, recorder
 func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.log = ctrl.Log.WithName(r.GetName())
 	r.recorder = mgr.GetEventRecorderFor(r.GetName())
 	return ctrl.NewControllerManagedBy(mgr).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, finalizersChangedPredicate{})).
 		For(&v1alpha1.Application{}).
 		Complete(r)
 }

--- a/pkg/api/gitops/v1alpha1/constants.go
+++ b/pkg/api/gitops/v1alpha1/constants.go
@@ -28,3 +28,6 @@ const (
 
 // ApplicationFinalizerName is the name of PipelineRun finalizer
 const ApplicationFinalizerName = "application." + GroupName
+
+// ArgoCDResourcesFinalizer is the name of Argo CD resource finalizer
+const ArgoCDResourcesFinalizer = "resources-finalizer.argocd.argoproj.io"

--- a/pkg/kapis/gitops/v1alpha1/argocd/route.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route.go
@@ -29,6 +29,9 @@ var (
 	pathParameterApplication = restful.PathParameter("application", "The application name")
 	syncStatusQueryParam     = restful.QueryParameter("syncStatus", `Filter by sync status. Available values: "Unknown", "Synced" and "OutOfSync"`)
 	healthStatusQueryParam   = restful.QueryParameter("healthStatus", `Filter by health status. Available values: "Unknown", "Progressing", "Healthy", "Suspended", "Degraded" and "Missing"`)
+	cascadeQueryParam        = restful.QueryParameter("cascade",
+		"Delete both the app and its resources, rather than only the application if cascade is true").
+		DefaultValue("false").DataType("bool")
 )
 
 // ApplicationPageResult is the model of page result of Applications.
@@ -105,6 +108,7 @@ func RegisterRoutes(service *restful.WebService, options *common.Options, argoOp
 		To(handler.delApplication).
 		Param(common.NamespacePathParameter).
 		Param(pathParameterApplication).
+		Param(cascadeQueryParam).
 		Doc("Delete a particular application").
 		Returns(http.StatusOK, api.StatusOK, v1alpha1.Application{}))
 

--- a/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
@@ -193,6 +193,25 @@ func TestAPIs(t *testing.T) {
 			assert.Nil(t, err)
 		},
 	}, {
+		name: "delete an application by cascade",
+		request: request{
+			method: http.MethodDelete,
+			uri:    "/namespaces/ns/applications/app?cascade=true",
+		},
+		k8sclient:    fake.NewFakeClientWithScheme(schema, app.DeepCopy()),
+		responseCode: http.StatusOK,
+		verify: func(t *testing.T, body []byte) {
+			list := &unstructured.Unstructured{}
+			err := yaml.Unmarshal(body, list)
+			assert.Nil(t, err)
+
+			name, _, err := unstructured.NestedString(list.Object, "metadata", "name")
+			assert.Equal(t, "app", name)
+			finalizers, _, err := unstructured.NestedSlice(list.Object, "metadata", "finalizers")
+			assert.Equal(t, []interface{}{"resources-finalizer.argocd.argoproj.io"}, finalizers)
+			assert.Nil(t, err)
+		},
+	}, {
 		name: "create an application",
 		request: request{
 			method: http.MethodPost,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
