### PR TITLE
fix: ParameterReference apiGroup empty

### DIFF
--- a/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
+++ b/config/crd/bases/devops.kubesphere.io_pipelineruns.yaml
@@ -375,7 +375,6 @@ spec:
                             type:
                               type: string
                           required:
-                          - isQuoted
                           - name
                           - type
                           type: object

--- a/config/crd/bases/devops.kubesphere.io_pipelines.yaml
+++ b/config/crd/bases/devops.kubesphere.io_pipelines.yaml
@@ -314,7 +314,6 @@ spec:
                         type:
                           type: string
                       required:
-                      - isQuoted
                       - name
                       - type
                       type: object

--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,9 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
-	golang.org/x/net v0.0.0-20211029224645-99673261e6eb
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -607,8 +607,9 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
+golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -670,8 +671,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
-golang.org/x/net v0.0.0-20211029224645-99673261e6eb h1:pirldcYWx7rx7kE5r+9WsOXPXK0+WH5+uZ7uPmJ44uM=
-golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -727,8 +728,9 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/api/devops/v1alpha3/pipeline_types.go
+++ b/pkg/api/devops/v1alpha3/pipeline_types.go
@@ -225,7 +225,7 @@ type DiscarderProperty struct {
 type ParameterDefinition struct {
 	Name         string `json:"name" description:"name of param"`
 	DefaultValue string `json:"default_value,omitempty" yaml:"default_value" mapstructure:"default_value" description:"default value of param"`
-	IsQuoted     bool   `json:"isQuoted" yaml:"isQuoted" description:"whether this param is quoted to build dynamic"`
+	IsQuoted     bool   `json:"isQuoted,omitempty" yaml:"isQuoted" description:"whether this param is quoted to build dynamic"`
 	Type         string `json:"type" description:"type of param"`
 	Description  string `json:"description,omitempty" description:"description of pipeline"`
 }

--- a/pkg/client/clientset/versioned/typed/devops/v1alpha3/pipeline.go
+++ b/pkg/client/clientset/versioned/typed/devops/v1alpha3/pipeline.go
@@ -111,6 +111,7 @@ func (c *pipelines) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 
 // Create takes the representation of a pipeline and creates it.  Returns the server's representation of the pipeline, and an error, if there is any.
 func (c *pipelines) Create(ctx context.Context, pipeline *v1alpha3.Pipeline, opts v1.CreateOptions) (result *v1alpha3.Pipeline, err error) {
+	c.formatPipelineObj(ctx, pipeline)
 	result = &v1alpha3.Pipeline{}
 	err = c.client.Post().
 		Namespace(c.ns).
@@ -124,6 +125,7 @@ func (c *pipelines) Create(ctx context.Context, pipeline *v1alpha3.Pipeline, opt
 
 // Update takes the representation of a pipeline and updates it. Returns the server's representation of the pipeline, and an error, if there is any.
 func (c *pipelines) Update(ctx context.Context, pipeline *v1alpha3.Pipeline, opts v1.UpdateOptions) (result *v1alpha3.Pipeline, err error) {
+	c.formatPipelineObj(ctx, pipeline)
 	result = &v1alpha3.Pipeline{}
 	err = c.client.Put().
 		Namespace(c.ns).
@@ -134,6 +136,18 @@ func (c *pipelines) Update(ctx context.Context, pipeline *v1alpha3.Pipeline, opt
 		Do(ctx).
 		Into(result)
 	return
+}
+
+// workaround for TypedLocalObjectReference keys do not have omitempty
+// TODO: remove this func after https://github.com/kubernetes/kubernetes/issues/79354 got solution
+func (c *pipelines) formatPipelineObj(ctx context.Context, pipeline *v1alpha3.Pipeline)	{
+	if pipeline.Spec.Pipeline != nil {
+		for k, v := range pipeline.Spec.Pipeline.ParametersFrom {
+			if v.APIGroup == nil {
+				pipeline.Spec.Pipeline.ParametersFrom[k].APIGroup = new(string)
+			}
+		}
+	}
 }
 
 // UpdateStatus was generated because the type contains a Status member.


### PR DESCRIPTION
/kind bug

pipeline save will get a error when apiGroup is empty.

https://github.com/kubernetes/kubernetes/issues/79354

Although the comment says it's optional, we'll still get an error if we pass null because there's no omitempty 


### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
