### PR TITLE
Fix the wrong YAML parse of the Argo Cluster

### DIFF
--- a/controllers/argocd/multi-cluster-controller.go
+++ b/controllers/argocd/multi-cluster-controller.go
@@ -165,6 +165,10 @@ func getArgoClusterConfigObject(configText string) (object *ClusterConfig) {
 	cluster := kubeconfig.Clusters[0]
 	user := kubeconfig.Users[0]
 
+	cluster.Cluster.CA = base64DecodeWithoutErrorCheck(cluster.Cluster.CA)
+	user.Auth.ClientCert = base64DecodeWithoutErrorCheck(user.Auth.ClientCert)
+	user.Auth.ClientKey = base64DecodeWithoutErrorCheck(user.Auth.ClientKey)
+
 	object = &ClusterConfig{
 		BearerToken: user.Auth.Token,
 		TLSClientConfig: TLSClientConfig{
@@ -175,6 +179,11 @@ func getArgoClusterConfigObject(configText string) (object *ClusterConfig) {
 		},
 	}
 	return
+}
+
+func base64DecodeWithoutErrorCheck(str string) string {
+	data, _ := base64.StdEncoding.DecodeString(str)
+	return string(data)
 }
 
 func getCluster(client client.Reader, namespacedName types.NamespacedName) (cluster *unstructured.Unstructured, err error) {

--- a/controllers/argocd/multi-cluster-controller_test.go
+++ b/controllers/argocd/multi-cluster-controller_test.go
@@ -451,11 +451,14 @@ func Test_getArgoClusterConfigFormat(t *testing.T) {
 	configData := base64.StdEncoding.EncodeToString([]byte(`clusters:
 - cluster:
     insecure-skip-tls-verify: true
+    certificate-authority-data: LeRuIGZha2UK
     server: server
   name: name
 users:
 - name: name
   user:
+    client-certificate-data: LeRuIGZha2UK
+    client-key-data: LeRuIGZha2UK
     token: token`))
 	type args struct {
 		config string
@@ -469,7 +472,7 @@ users:
 		args: args{
 			config: configData,
 		},
-		want: []byte(`{"bearerToken":"token","tlsClientConfig":{"insecure":true}}`),
+		want: []byte(`{"bearerToken":"token","tlsClientConfig":{"insecure":true,"certData":"LeRuIGZha2UK","keyData":"LeRuIGZha2UK","caData":"LeRuIGZha2UK"}}`),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/argocd/types.go
+++ b/controllers/argocd/types.go
@@ -78,7 +78,7 @@ type clusterConfig struct {
 type clusterConfigConnection struct {
 	SkipTLS bool   `yaml:"insecure-skip-tls-verify,omitempty"`
 	Server  string `yaml:"server,omitempty"`
-	CA      string `yaml:"certificate-authority-data:,omitempty"`
+	CA      string `yaml:"certificate-authority-data,omitempty"`
 }
 
 type clusterConfigUser struct {

--- a/controllers/argocd/types_test.go
+++ b/controllers/argocd/types_test.go
@@ -36,6 +36,7 @@ func Test_parseKubeConfig(t *testing.T) {
 clusters:
 - cluster:
     insecure-skip-tls-verify: true
+    certificate-authority-data: ca-data
     server: server
   name: name
 users:
@@ -49,6 +50,7 @@ users:
 				Cluster: clusterConfigConnection{
 					SkipTLS: true,
 					Server:  "server",
+					CA:      "ca-data",
 				},
 			}},
 			Users: []clusterConfigUser{{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
As I mentioned in the title.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #561

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
