### PR TITLE
Auto amend the Gitlab URL

### DIFF
--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -113,18 +113,11 @@ func getAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 		Client:        mgr.GetClient(),
 		ArgoNamespace: s.ArgoCDOption.Namespace,
 	}
+	gitRepoReconcilers := gitrepository.GetReconcilers()
 
 	return map[string]func(mgr manager.Manager) error{
-		"gitrepository": func(mgr manager.Manager) error {
-			err := (&gitrepository.Reconciler{
-				Client: mgr.GetClient(),
-			}).SetupWithManager(mgr)
-			if err == nil {
-				err = (&gitrepository.WebhookReconciler{
-					Client: mgr.GetClient(),
-				}).SetupWithManager(mgr)
-			}
-			return err
+		gitRepoReconcilers.GetName(): func(mgr manager.Manager) error {
+			return gitRepoReconcilers.SetupWithManager(mgr)
 		},
 		"addon": func(mgr manager.Manager) error {
 			err := (&addon.OperatorCRDReconciler{

--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -113,7 +113,7 @@ func getAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 		Client:        mgr.GetClient(),
 		ArgoNamespace: s.ArgoCDOption.Namespace,
 	}
-	gitRepoReconcilers := gitrepository.GetReconcilers()
+	gitRepoReconcilers := gitrepository.GetReconcilers(mgr.GetClient())
 
 	return map[string]func(mgr manager.Manager) error{
 		gitRepoReconcilers.GetName(): func(mgr manager.Manager) error {

--- a/cmd/controller/app/options/feature.go
+++ b/cmd/controller/app/options/feature.go
@@ -35,6 +35,7 @@ func (o *FeatureOptions) GetControllers() map[string]bool {
 	defaultMap := map[string]bool{
 		"jenkins":       true,
 		"jenkinsconfig": true,
+		"gitrepository": true,
 	}
 
 	// support to only enable the specific controllers

--- a/cmd/controller/app/options/feature_test.go
+++ b/cmd/controller/app/options/feature_test.go
@@ -37,6 +37,7 @@ func TestFeatureOptions_GetControllers(t *testing.T) {
 		want: map[string]bool{
 			"jenkins":       true,
 			"jenkinsconfig": true,
+			"gitrepository": true,
 		},
 	}, {
 		name: "no input (be nil) from users",
@@ -46,6 +47,7 @@ func TestFeatureOptions_GetControllers(t *testing.T) {
 		want: map[string]bool{
 			"jenkins":       true,
 			"jenkinsconfig": true,
+			"gitrepository": true,
 		},
 	}, {
 		name: "merge with the input from users",
@@ -57,6 +59,7 @@ func TestFeatureOptions_GetControllers(t *testing.T) {
 		want: map[string]bool{
 			"jenkins":       true,
 			"jenkinsconfig": true,
+			"gitrepository": true,
 			"fake":          true,
 		},
 	}, {

--- a/controllers/core/fake.go
+++ b/controllers/core/fake.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// FakeGroupedReconciler is a fake GroupedReconciler which is for the test purpose
+type FakeGroupedReconciler struct {
+	HasError bool
+}
+
+// GetName returns the name
+func (f *FakeGroupedReconciler) GetName() string {
+	return "fake"
+}
+
+// GetGroupName returns the group name
+func (f *FakeGroupedReconciler) GetGroupName() string {
+	return "fake"
+}
+
+// Reconcile is fake reconcile process
+func (f *FakeGroupedReconciler) Reconcile(reconcile.Request) (result reconcile.Result, err error) {
+	return
+}
+
+// SetupWithManager setups the reconciler
+func (f *FakeGroupedReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if f.HasError {
+		return errors.New("fake")
+	}
+	return nil
+}

--- a/controllers/core/named.go
+++ b/controllers/core/named.go
@@ -16,8 +16,15 @@ limitations under the License.
 
 package core
 
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
 // NamedReconciler is an interface with allow a reconciler has a name
 type NamedReconciler interface {
+	reconcile.Reconciler
 	// GetName returns the name of the reconciler
 	GetName() string
 }
@@ -25,6 +32,48 @@ type NamedReconciler interface {
 // GroupReconciler is an interface with the group name
 // a group means a set of some reconcilers that have a particular feature
 type GroupReconciler interface {
+	reconcile.Reconciler
 	// GetGroupName returns the group name
 	GetGroupName() string
+}
+
+// GroupedReconciler is an interface for grouping reconciler purpose
+type GroupedReconciler interface {
+	NamedReconciler
+	GroupReconciler
+
+	SetupWithManager(mgr ctrl.Manager) error
+}
+
+// GroupedReconcilers is an alias of the slice of GroupedReconciler
+type GroupedReconcilers []GroupedReconciler
+
+// Append is a similar function to the original slice append
+func (g GroupedReconcilers) Append(reconciler GroupedReconciler) GroupedReconcilers {
+	g = append(g, reconciler)
+	return g
+}
+
+// Size returns the size of the slice
+func (g GroupedReconcilers) Size() int {
+	return len(g)
+}
+
+// GetName returns the name of the group
+func (g GroupedReconcilers) GetName() (name string) {
+	if len(g) > 0 {
+		name = g[0].GetGroupName()
+	}
+	return
+}
+
+// SetupWithManager setups with a group of reconcilers
+func (g GroupedReconcilers) SetupWithManager(mgr manager.Manager) (err error) {
+	for i := range g {
+		item := g[i]
+		if err = item.SetupWithManager(mgr); err != nil {
+			break
+		}
+	}
+	return
 }

--- a/controllers/core/named_test.go
+++ b/controllers/core/named_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package core
 
 import (

--- a/controllers/core/named_test.go
+++ b/controllers/core/named_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+)
+
+func TestGroupedReconcilers_SetupWithManager(t *testing.T) {
+	type args struct {
+		mgr manager.Manager
+	}
+	tests := []struct {
+		name    string
+		g       GroupedReconcilers
+		args    args
+		wantErr bool
+	}{{
+		name:    "empty",
+		g:       GroupedReconcilers{},
+		wantErr: false,
+	}, {
+		name:    "no errors",
+		g:       []GroupedReconciler{&FakeGroupedReconciler{}},
+		wantErr: false,
+	}, {
+		name:    "have errors",
+		g:       []GroupedReconciler{&FakeGroupedReconciler{HasError: true}},
+		wantErr: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.g.SetupWithManager(tt.args.mgr); (err != nil) != tt.wantErr {
+				t.Errorf("SetupWithManager() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGroupedFakeReconciler(t *testing.T) {
+	fakeReconciler := &FakeGroupedReconciler{}
+	assert.Equal(t, "fake", fakeReconciler.GetName())
+	result, err := fakeReconciler.Reconcile(reconcile.Request{})
+	assert.True(t, result.IsZero())
+	assert.Nil(t, err)
+
+	var group GroupedReconcilers
+	group = group.Append(fakeReconciler)
+	assert.Equal(t, 1, group.Size())
+	assert.Equal(t, "fake", group.GetName())
+}

--- a/controllers/gitrepository/constants.go
+++ b/controllers/gitrepository/constants.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitrepository
+
+const (
+	groupName = "gitrepository"
+)

--- a/controllers/gitrepository/gitrepository_amend_controller.go
+++ b/controllers/gitrepository/gitrepository_amend_controller.go
@@ -15,6 +15,7 @@ package gitrepository
 
 import (
 	"context"
+	"fmt"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/tools/record"
 	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
@@ -36,6 +37,7 @@ type AmendReconciler struct {
 
 func (r *AmendReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error) {
 	ctx := context.Background()
+	r.log.Info(fmt.Sprintf("start to AmendReconciler: %s", req.String()))
 
 	repo := &v1alpha3.GitRepository{}
 	if err = r.Get(ctx, req.NamespacedName, repo); err != nil {

--- a/controllers/gitrepository/gitrepository_amend_controller.go
+++ b/controllers/gitrepository/gitrepository_amend_controller.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitrepository
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/record"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"strings"
+)
+
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=gitrepositories,verbs=get;list;watch;update
+
+// AmendReconciler reconciles a GitRepository object
+// See the main reason for this controller, https://github.com/kubesphere/ks-devops/issues/567
+type AmendReconciler struct {
+	client.Client
+	log      logr.Logger
+	recorder record.EventRecorder
+}
+
+func (r *AmendReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error) {
+	ctx := context.Background()
+
+	repo := &v1alpha3.GitRepository{}
+	if err = r.Get(ctx, req.NamespacedName, repo); err != nil {
+		err = client.IgnoreNotFound(err)
+		return
+	}
+
+	if amendGitlabURL(repo) {
+		err = r.Update(ctx, repo)
+	}
+	return
+}
+
+func amendGitlabURL(repo *v1alpha3.GitRepository) (changed bool) {
+	if strings.ToLower(repo.Spec.Provider) != "gitlab" {
+		return
+	}
+
+	if !strings.HasSuffix(repo.Spec.URL, ".git") {
+		repo.Spec.URL += ".git"
+		changed = true
+	}
+	return
+}
+
+func (r *AmendReconciler) GetName() string {
+	return "git-repository-amend"
+}
+
+func (r *AmendReconciler) GetGroupName() string {
+	return groupName
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *AmendReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.recorder = mgr.GetEventRecorderFor(r.GetName())
+	r.log = ctrl.Log.WithName(r.GetName())
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha3.GitRepository{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		Complete(r)
+}

--- a/controllers/gitrepository/gitrepository_amend_controller_test.go
+++ b/controllers/gitrepository/gitrepository_amend_controller_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package gitrepository
 
 import (

--- a/controllers/gitrepository/gitrepository_amend_controller_test.go
+++ b/controllers/gitrepository/gitrepository_amend_controller_test.go
@@ -1,0 +1,49 @@
+package gitrepository
+
+import (
+	"github.com/stretchr/testify/assert"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"testing"
+)
+
+func Test_amendGitlabURL(t *testing.T) {
+	type args struct {
+		repo *v1alpha3.GitRepository
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantChanged bool
+		verify      func(t *testing.T, repo *v1alpha3.GitRepository)
+	}{{
+		name: "not gitlab",
+		args: args{
+			repo: &v1alpha3.GitRepository{},
+		},
+		wantChanged: false,
+	}, {
+		name: "gitlab, URL without suffix .git",
+		args: args{
+			repo: &v1alpha3.GitRepository{
+				Spec: v1alpha3.GitRepositorySpec{
+					Provider: "Gitlab",
+					URL:      "https://gitlab.com/linuxsuren/test",
+				},
+			},
+		},
+		wantChanged: true,
+		verify: func(t *testing.T, repo *v1alpha3.GitRepository) {
+			assert.Equal(t, "https://gitlab.com/linuxsuren/test.git", repo.Spec.URL)
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.verify == nil {
+				tt.verify = func(t *testing.T, repo *v1alpha3.GitRepository) {
+				}
+			}
+			assert.Equalf(t, tt.wantChanged, amendGitlabURL(tt.args.repo), "amendGitlabURL(%v)", tt.args.repo)
+			tt.verify(t, tt.args.repo)
+		})
+	}
+}

--- a/controllers/gitrepository/gitrepository_webhook_controller.go
+++ b/controllers/gitrepository/gitrepository_webhook_controller.go
@@ -43,9 +43,6 @@ type Reconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO currently, this controller only can add a new webhook to a git repository. It might be
-//   possible to add more and more wenhooks, and there's no way to clean them.
-//   Second problem is that this controller cannot update the webhook when a webhook changed.
 func (r *Reconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error) {
 	ctx := context.Background()
 	log := r.log.WithValues("GitRepository", req.NamespacedName)
@@ -252,11 +249,19 @@ func addToArrayInAnnotations(array map[string]string, key, value string) map[str
 	return array
 }
 
+func (r *Reconciler) GetName() string {
+	return "gitrepository-controller"
+}
+
+func (r *Reconciler) GetGroupName() string {
+	return groupName
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// the server should obey Kubernetes naming convention: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
-	r.recorder = mgr.GetEventRecorderFor("gitrepository-controller")
-	r.log = ctrl.Log.WithName("gitrepository-controller")
+	r.recorder = mgr.GetEventRecorderFor(r.GetName())
+	r.log = ctrl.Log.WithName(r.GetName())
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha3.GitRepository{}).
 		Complete(r)

--- a/controllers/gitrepository/register.go
+++ b/controllers/gitrepository/register.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitrepository
+
+import (
+	"kubesphere.io/devops/controllers/core"
+)
+
+func GetReconcilers() core.GroupedReconcilers {
+	return []core.GroupedReconciler{
+		&Reconciler{},
+		&AmendReconciler{},
+		&WebhookReconciler{},
+	}
+}

--- a/controllers/gitrepository/register.go
+++ b/controllers/gitrepository/register.go
@@ -15,10 +15,13 @@ package gitrepository
 
 import (
 	"kubesphere.io/devops/controllers/core"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetReconcilers() core.GroupedReconcilers {
+func GetReconcilers(k8s client.Client) core.GroupedReconcilers {
 	return []core.GroupedReconciler{
-		&AmendReconciler{},
+		&AmendReconciler{
+			Client: k8s,
+		},
 	}
 }

--- a/controllers/gitrepository/register.go
+++ b/controllers/gitrepository/register.go
@@ -19,8 +19,6 @@ import (
 
 func GetReconcilers() core.GroupedReconcilers {
 	return []core.GroupedReconciler{
-		&Reconciler{},
 		&AmendReconciler{},
-		&WebhookReconciler{},
 	}
 }

--- a/controllers/gitrepository/register_test.go
+++ b/controllers/gitrepository/register_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestGetReconcilers(t *testing.T) {
-	reconcilers := GetReconcilers()
+	reconcilers := GetReconcilers(nil)
 	for i := range reconcilers {
 		item := reconcilers[i]
 		assert.Equal(t, groupName, item.GetGroupName())

--- a/controllers/gitrepository/register_test.go
+++ b/controllers/gitrepository/register_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitrepository
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetReconcilers(t *testing.T) {
+	reconcilers := GetReconcilers()
+	for i := range reconcilers {
+		item := reconcilers[i]
+		assert.Equal(t, groupName, item.GetGroupName())
+	}
+}

--- a/controllers/gitrepository/webhook_notify.go
+++ b/controllers/gitrepository/webhook_notify.go
@@ -98,9 +98,17 @@ func (r *WebhookReconciler) notifyGitRepo(ns, name string) (err error) {
 	return
 }
 
+func (r *WebhookReconciler) GetName() string {
+	return "webhook-notify"
+}
+
+func (r *WebhookReconciler) GetGroupName() string {
+	return groupName
+}
+
 func (r *WebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.recorder = mgr.GetEventRecorderFor("webhook-notify")
-	r.log = ctrl.Log.WithName("webhook-notify")
+	r.recorder = mgr.GetEventRecorderFor(r.GetName())
+	r.log = ctrl.Log.WithName(r.GetName())
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha3.Webhook{}).
 		Complete(r)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #567

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
