### PR TITLE
Fix the CD manual sync not work

### DIFF
--- a/controllers/argocd/application_controller.go
+++ b/controllers/argocd/application_controller.go
@@ -153,6 +153,7 @@ func (r *ApplicationReconciler) reconcileArgoApplication(app *v1alpha1.Applicati
 			var newArgoApp *unstructured.Unstructured
 			if newArgoApp, err = createUnstructuredApplication(app); err == nil {
 				argoApp.Object["spec"] = newArgoApp.Object["spec"]
+				argoApp.Object["operation"] = newArgoApp.Object["operation"]
 				argoApp.SetFinalizers(newArgoApp.GetFinalizers())
 				err = retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
 					latestArgoApp := createBareArgoCDApplicationObject()

--- a/controllers/argocd/application_controller_test.go
+++ b/controllers/argocd/application_controller_test.go
@@ -72,6 +72,17 @@ func Test_createUnstructuredApplication(t *testing.T) {
 								Namespace: "namespace",
 							},
 						},
+						Operation: &v1alpha1.Operation{
+							Sync: &v1alpha1.SyncOperation{
+								Revision:    "master",
+								Prune:       true,
+								DryRun:      true,
+								SyncOptions: []string{"a=b"},
+							},
+							InitiatedBy: v1alpha1.OperationInitiator{
+								Username: "admin",
+							},
+						},
 					},
 				},
 			},
@@ -85,6 +96,16 @@ func Test_createUnstructuredApplication(t *testing.T) {
 			assert.Equal(t, "server", destServer)
 			destNs, _, _ := unstructured.NestedString(gotResult.Object, "spec", "destination", "namespace")
 			assert.Equal(t, "namespace", destNs)
+			revision, _, _ := unstructured.NestedString(gotResult.Object, "operation", "sync", "revision")
+			assert.Equal(t, "master", revision)
+			syncOptions, _, _ := unstructured.NestedStringSlice(gotResult.Object, "operation", "sync", "syncOptions")
+			assert.Equal(t, []string{"a=b"}, syncOptions)
+			prune, _, _ := unstructured.NestedBool(gotResult.Object, "operation", "sync", "prune")
+			assert.Equal(t, true, prune)
+			dryRun, _, _ := unstructured.NestedBool(gotResult.Object, "operation", "sync", "dryRun")
+			assert.Equal(t, true, dryRun)
+			initiatedBy, _, _ := unstructured.NestedString(gotResult.Object, "operation", "initiatedBy", "username")
+			assert.Equal(t, "admin", initiatedBy)
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #572

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
