### PR TITLE
Fix the wrong paging of the organization list API

### DIFF
--- a/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
+++ b/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
@@ -63,20 +63,29 @@ func (h *handler) getOrganizations(scm, secret, namespace string, page, size int
 	var c *goscm.Client
 	if c, err = factory.GetClient(); err == nil {
 		var resp *goscm.Response
-
-		if orgs, resp, err = c.Organizations.List(ctx, goscm.ListOptions{Size: size, Page: page}); err == nil {
-			code = resp.Status
-		} else {
-			code = 101
-		}
-
 		if includeUser {
 			var user string
 			if user, err = h.getCurrentUsername(c); err == nil {
-				orgs = append(orgs, &goscm.Organization{
+				orgs = []*goscm.Organization{{
 					Name:   user,
 					Avatar: fmt.Sprintf("https://avatars.githubusercontent.com/%s", user),
-				})
+				}}
+			}
+
+			if size > 1 {
+				size--
+			}
+		} else {
+			orgs = []*goscm.Organization{}
+		}
+
+		if size > 0 {
+			var tmpOrgs []*goscm.Organization
+			if tmpOrgs, resp, err = c.Organizations.List(ctx, goscm.ListOptions{Size: size, Page: page}); err == nil {
+				code = resp.Status
+				orgs = append(orgs, tmpOrgs...)
+			} else {
+				code = 101
 			}
 		}
 	} else {

--- a/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
+++ b/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
@@ -64,16 +64,18 @@ func (h *handler) getOrganizations(scm, secret, namespace string, page, size int
 	if c, err = factory.GetClient(); err == nil {
 		var resp *goscm.Response
 		if includeUser {
-			var user string
-			if user, err = h.getCurrentUsername(c); err == nil {
-				orgs = []*goscm.Organization{{
-					Name:   user,
-					Avatar: fmt.Sprintf("https://avatars.githubusercontent.com/%s", user),
-				}}
-			}
+			if page == 1 {
+				var user string
+				if user, err = h.getCurrentUsername(c); err == nil {
+					orgs = []*goscm.Organization{{
+						Name:   user,
+						Avatar: fmt.Sprintf("https://avatars.githubusercontent.com/%s", user),
+					}}
+				}
 
-			if size > 1 {
-				size--
+				if size >= 1 {
+					size--
+				}
 			}
 		} else {
 			orgs = []*goscm.Organization{}

--- a/pkg/kapis/devops/v1alpha3/scm/scmhandler_test.go
+++ b/pkg/kapis/devops/v1alpha3/scm/scmhandler_test.go
@@ -206,6 +206,32 @@ func TestSCMAPI(t *testing.T) {
 			assert.Equal(t, "github", orgs[1].Name)
 		},
 	}, {
+		name: "get the organization list (real size is 1) include current user",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/scms/github/organizations?secret=token&secretNamespace=default&includeUser=true&pageNumber=1&pageSize=1",
+		},
+		prepare: func() {
+			gock.New("https://api.github.com").
+				Get("/user").
+				Reply(200).
+				Type("application/json").
+				SetHeader("X-GitHub-Request-Id", "DD0E:6011:12F21A8:1926790:5A2064E2").
+				SetHeader("X-RateLimit-Limit", "60").
+				SetHeader("X-RateLimit-Remaining", "59").
+				SetHeader("X-RateLimit-Reset", "1512076018").
+				File("testdata/user.json")
+		},
+		verify: func(code int, response []byte, t *testing.T) {
+			assert.Equal(t, 200, code)
+
+			var orgs []organization
+			err := json.Unmarshal(response, &orgs)
+			assert.Nil(t, err)
+			assert.Equal(t, 1, len(orgs))
+			assert.Equal(t, "octocat", orgs[0].Name)
+		},
+	}, {
 		name: "get the organization list include current user",
 		args: args{
 			method: http.MethodGet,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
