### PR TITLE
Fix the potential nil panic due to Jenkins job xml parsing

### DIFF
--- a/pkg/client/devops/jenkins/pipeline_internal.go
+++ b/pkg/client/devops/jenkins/pipeline_internal.go
@@ -138,8 +138,8 @@ func parsePipelineConfigXml(config string) (*devopsv1alpha3.NoScmPipeline, error
 			SelectElement("jenkins.model.BuildDiscarderProperty").
 			SelectElement("strategy")
 		pipeline.Discarder = &devopsv1alpha3.DiscarderProperty{
-			DaysToKeep: strategy.SelectElement("daysToKeep").Text(),
-			NumToKeep:  strategy.SelectElement("numToKeep").Text(),
+			DaysToKeep: getElementTextValueOrEmpty(strategy, "daysToKeep"),
+			NumToKeep:  getElementTextValueOrEmpty(strategy, "numToKeep"),
 		}
 	}
 
@@ -154,7 +154,7 @@ func parsePipelineConfigXml(config string) (*devopsv1alpha3.NoScmPipeline, error
 		triggersEle := triggerProperty.SelectElement("triggers")
 		if timerTrigger := triggersEle.SelectElement("hudson.triggers.TimerTrigger"); timerTrigger != nil {
 			pipeline.TimerTrigger = &devopsv1alpha3.TimerTrigger{
-				Cron: timerTrigger.SelectElement("spec").Text(),
+				Cron: getElementTextValueOrEmpty(timerTrigger, "spec"),
 			}
 		}
 
@@ -207,6 +207,14 @@ func appendParametersToEtree(properties *etree.Element, parameters []devopsv1alp
 	}
 }
 
+func getElementTextValueOrEmpty(element *etree.Element, name string) string {
+	subEle := element.SelectElement(name)
+	if subEle != nil {
+		return subEle.Text()
+	}
+	return ""
+}
+
 func getParametersfromEtree(properties *etree.Element) []devopsv1alpha3.ParameterDefinition {
 	var parameters []devopsv1alpha3.ParameterDefinition
 	if parametersProperty := properties.SelectElement("hudson.model.ParametersDefinitionProperty"); parametersProperty != nil {
@@ -215,42 +223,42 @@ func getParametersfromEtree(properties *etree.Element) []devopsv1alpha3.Paramete
 			switch param.Tag {
 			case "hudson.model.StringParameterDefinition":
 				parameters = append(parameters, devopsv1alpha3.ParameterDefinition{
-					Name:         param.SelectElement("name").Text(),
-					Description:  param.SelectElement("description").Text(),
-					DefaultValue: param.SelectElement("defaultValue").Text(),
+					Name:         getElementTextValueOrEmpty(param, "name"),
+					Description:  getElementTextValueOrEmpty(param, "description"),
+					DefaultValue: getElementTextValueOrEmpty(param, "defaultValue"),
 					Type:         ParameterTypeMap["hudson.model.StringParameterDefinition"],
 				})
 			case "hudson.model.BooleanParameterDefinition":
 				parameters = append(parameters, devopsv1alpha3.ParameterDefinition{
-					Name:         param.SelectElement("name").Text(),
-					Description:  param.SelectElement("description").Text(),
-					DefaultValue: param.SelectElement("defaultValue").Text(),
+					Name:         getElementTextValueOrEmpty(param, "name"),
+					Description:  getElementTextValueOrEmpty(param, "description"),
+					DefaultValue: getElementTextValueOrEmpty(param, "defaultValue"),
 					Type:         ParameterTypeMap["hudson.model.BooleanParameterDefinition"],
 				})
 			case "hudson.model.TextParameterDefinition":
 				parameters = append(parameters, devopsv1alpha3.ParameterDefinition{
-					Name:         param.SelectElement("name").Text(),
-					Description:  param.SelectElement("description").Text(),
-					DefaultValue: param.SelectElement("defaultValue").Text(),
+					Name:         getElementTextValueOrEmpty(param, "name"),
+					Description:  getElementTextValueOrEmpty(param, "description"),
+					DefaultValue: getElementTextValueOrEmpty(param, "defaultValue"),
 					Type:         ParameterTypeMap["hudson.model.TextParameterDefinition"],
 				})
 			case "hudson.model.FileParameterDefinition":
 				parameters = append(parameters, devopsv1alpha3.ParameterDefinition{
-					Name:        param.SelectElement("name").Text(),
-					Description: param.SelectElement("description").Text(),
+					Name:        getElementTextValueOrEmpty(param, "name"),
+					Description: getElementTextValueOrEmpty(param, "description"),
 					Type:        ParameterTypeMap["hudson.model.FileParameterDefinition"],
 				})
 			case "hudson.model.PasswordParameterDefinition":
 				parameters = append(parameters, devopsv1alpha3.ParameterDefinition{
-					Name:         param.SelectElement("name").Text(),
-					Description:  param.SelectElement("description").Text(),
-					DefaultValue: param.SelectElement("name").Text(),
+					Name:         getElementTextValueOrEmpty(param, "name"),
+					Description:  getElementTextValueOrEmpty(param, "description"),
+					DefaultValue: getElementTextValueOrEmpty(param, "name"),
 					Type:         ParameterTypeMap["hudson.model.PasswordParameterDefinition"],
 				})
 			case "hudson.model.ChoiceParameterDefinition":
 				choiceParameter := devopsv1alpha3.ParameterDefinition{
-					Name:        param.SelectElement("name").Text(),
-					Description: param.SelectElement("description").Text(),
+					Name:        getElementTextValueOrEmpty(param, "name"),
+					Description: getElementTextValueOrEmpty(param, "description"),
 					Type:        ParameterTypeMap["hudson.model.ChoiceParameterDefinition"],
 				}
 				choicesEle := param.SelectElement("choices")
@@ -270,8 +278,8 @@ func getParametersfromEtree(properties *etree.Element) []devopsv1alpha3.Paramete
 				parameters = append(parameters, choiceParameter)
 			default:
 				parameters = append(parameters, devopsv1alpha3.ParameterDefinition{
-					Name:         param.SelectElement("name").Text(),
-					Description:  param.SelectElement("description").Text(),
+					Name:         getElementTextValueOrEmpty(param, "name"),
+					Description:  getElementTextValueOrEmpty(param, "description"),
 					DefaultValue: "unknown",
 					Type:         param.Tag,
 				})
@@ -293,8 +301,8 @@ func getMultiBranchJobTriggerfromEtree(properties *etree.Element) *devopsv1alpha
 	var s devopsv1alpha3.MultiBranchJobTrigger
 	triggerProperty := properties.SelectElement("org.jenkinsci.plugins.workflow.multibranch.PipelineTriggerProperty")
 	if triggerProperty != nil {
-		s.CreateActionJobsToTrigger = triggerProperty.SelectElement("createActionJobsToTrigger").Text()
-		s.DeleteActionJobsToTrigger = triggerProperty.SelectElement("deleteActionJobsToTrigger").Text()
+		s.CreateActionJobsToTrigger = getElementTextValueOrEmpty(triggerProperty, "createActionJobsToTrigger")
+		s.DeleteActionJobsToTrigger = getElementTextValueOrEmpty(triggerProperty, "deleteActionJobsToTrigger")
 	}
 	return &s
 }
@@ -422,20 +430,20 @@ func parseMultiBranchPipelineConfigXml(config string) (*devopsv1alpha3.MultiBran
 		}
 	}
 	if project.SelectElement("description") != nil {
-		pipeline.Description = project.SelectElement("description").Text()
+		pipeline.Description = getElementTextValueOrEmpty(project, "description")
 	}
 
 	if discarder := project.SelectElement("orphanedItemStrategy"); discarder != nil {
 		pipeline.Discarder = &devopsv1alpha3.DiscarderProperty{
-			DaysToKeep: discarder.SelectElement("daysToKeep").Text(),
-			NumToKeep:  discarder.SelectElement("numToKeep").Text(),
+			DaysToKeep: getElementTextValueOrEmpty(discarder, "daysToKeep"),
+			NumToKeep:  getElementTextValueOrEmpty(discarder, "numToKeep"),
 		}
 	}
 	if triggers := project.SelectElement("triggers"); triggers != nil {
 		if timerTrigger := triggers.SelectElement(
 			"com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger"); timerTrigger != nil {
 			pipeline.TimerTrigger = &devopsv1alpha3.TimerTrigger{
-				Interval: timerTrigger.SelectElement("interval").Text(),
+				Interval: getElementTextValueOrEmpty(timerTrigger, "interval"),
 			}
 		}
 	}

--- a/pkg/client/devops/jenkins/pipeline_internal_test.go
+++ b/pkg/client/devops/jenkins/pipeline_internal_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jenkins
 
 import (
+	"github.com/beevik/etree"
 	"github.com/stretchr/testify/assert"
 	"kubesphere.io/devops/pkg/client/devops/jenkins/internal"
 	"reflect"
@@ -1194,3 +1195,40 @@ var withTrustForBitbucketJobXML = `<?xml version='1.1' encoding='UTF-8'?>
     <scriptPath>Jenkinsfile</scriptPath>
   </factory>
 </org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject>`
+
+func Test_getElementTextValueOrEmpty(t *testing.T) {
+	fakeElement := etree.NewElement("parent")
+
+	child1 := etree.NewElement("child-1")
+	child1.SetText("value-1")
+	fakeElement.AddChild(child1)
+
+	type args struct {
+		element *etree.Element
+		name    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{{
+		name: "no target child element",
+		args: args{
+			element: fakeElement,
+			name:    "fake-2",
+		},
+		want: "",
+	}, {
+		name: "have target child element",
+		args: args{
+			element: fakeElement,
+			name:    "child-1",
+		},
+		want: "value-1",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getElementTextValueOrEmpty(tt.args.element, tt.args.name), "getElementTextValueOrEmpty(%v, %v)", tt.args.element, tt.args.name)
+		})
+	}
+}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #585

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
