### PR TITLE
Condition is always 'true' because 'user' is always not 'nil'

### DIFF
--- a/pkg/kapis/devops/v1alpha3/pipelinerun/handler.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/handler.go
@@ -138,7 +138,7 @@ func (h *apiHandler) createPipelineRun(request *restful.Request, response *restf
 	}
 	// create PipelineRun
 	pr := CreatePipelineRun(&pipeline, &payload, scm)
-	if user != nil && user.GetName() != "" {
+	if user.GetName() != "" {
 		pr.GetAnnotations()[v1alpha3.PipelineRunCreatorAnnoKey] = user.GetName()
 	}
 	if err := h.client.Create(context.Background(), pr); err != nil {

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/handler_test.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/handler_test.go
@@ -1,0 +1,112 @@
+package pipelinerun
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"kubesphere.io/devops/pkg/apiserver/request"
+	"kubesphere.io/devops/pkg/client/devops"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/emicklei/go-restful"
+	"github.com/stretchr/testify/assert"
+	"kubesphere.io/devops/pkg/apiserver/runtime"
+	fakedevops "kubesphere.io/devops/pkg/client/devops/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApis(t *testing.T) {
+	wsWithGroup := runtime.NewWebService(v1alpha3.GroupVersion)
+	schema, err := v1alpha3.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+
+	RegisterRoutes(wsWithGroup, fakedevops.NewFakeDevops(nil), fake.NewFakeClientWithScheme(schema, &v1alpha3.Pipeline{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "fake",
+			Namespace: "fake",
+		},
+		Spec: v1alpha3.PipelineSpec{
+			Type: v1alpha3.NoScmPipelineType,
+		},
+	}))
+	restful.DefaultContainer.Add(wsWithGroup)
+
+	type args struct {
+		method  string
+		uri     string
+		getBody func() io.Reader
+		ctx     context.Context
+		status  int
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "create a pipelinerun",
+			args: args{
+				method: http.MethodPost,
+				uri:    "/namespaces/fake/pipelines/fake/pipelineruns",
+				getBody: func() io.Reader {
+					payload := &devops.RunPayload{
+						Parameters: []devops.Parameter{{
+							Name:  "aname",
+							Value: "avalue",
+						}},
+					}
+					data, _ := json.Marshal(payload)
+					return bytes.NewBuffer(data)
+				},
+				ctx:    request.NewContext(),
+				status: 401,
+			},
+		},
+		{
+			name: "create a pipelinerun with a mock user",
+			args: args{
+				method: http.MethodPost,
+				uri:    "/namespaces/fake/pipelines/fake/pipelineruns",
+				getBody: func() io.Reader {
+					payload := &devops.RunPayload{
+						Parameters: []devops.Parameter{{
+							Name:  "aname",
+							Value: "avalue",
+						}},
+					}
+					data, _ := json.Marshal(payload)
+					return bytes.NewBuffer(data)
+				},
+				ctx: request.WithUser(
+					request.NewContext(),
+					&user.DefaultInfo{
+						Name:   "bob",
+						UID:    "123",
+						Groups: []string{"group1"},
+						Extra:  map[string][]string{"foo": {"bar"}},
+					},
+				),
+				status: 200,
+			},
+		}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestBody io.Reader
+			if tt.args.getBody != nil {
+				requestBody = tt.args.getBody()
+			}
+			httpRequest, _ := http.NewRequestWithContext(tt.args.ctx, tt.args.method,
+				"http://fake.com/kapis/devops.kubesphere.io/v1alpha3"+tt.args.uri, requestBody)
+			httpRequest.Header.Set("Content-Type", "application/json")
+			httpWriter := httptest.NewRecorder()
+			restful.DefaultContainer.Dispatch(httpWriter, httpRequest)
+			assert.Equal(t, tt.args.status, httpWriter.Code)
+		})
+	}
+}

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/handler_test.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/handler_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package pipelinerun
 
 import (


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:
Condition is always 'true' because 'user' is always not 'nil'

### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
None
```release-note
None
```
