### PR TITLE
Using a new API to fetch both public and private repos of a user

### DIFF
--- a/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
+++ b/pkg/kapis/devops/v1alpha3/scm/scmhandler.go
@@ -101,7 +101,9 @@ func (h *handler) getRepositories(scm, server, org, secret, namespace string, pa
 		var listRepositoryFunc listRepository
 		if user, err = h.getCurrentUsername(c); err == nil {
 			if user == org && !strings.HasPrefix(scm, "bitbucket") {
-				listRepositoryFunc = c.Repositories.ListUser
+				listRepositoryFunc = func(ctx context.Context, s string, options goscm.ListOptions) ([]*goscm.Repository, *goscm.Response, error) {
+					return c.Repositories.List(ctx, options)
+				}
 			} else {
 				listRepositoryFunc = c.Repositories.ListOrganisation
 			}

--- a/pkg/kapis/devops/v1alpha3/scm/scmhandler_test.go
+++ b/pkg/kapis/devops/v1alpha3/scm/scmhandler_test.go
@@ -278,9 +278,11 @@ func TestSCMAPI(t *testing.T) {
 			}
 
 			gock.New("https://api.github.com").
-				Get("users/octocat/repos").
+				Get("/user/repos").
 				MatchParam("per_page", "1").
 				MatchParam("page", "1").
+				MatchParam("visibility", "all").
+				MatchParam("affiliation", "owner").
 				Reply(200).
 				Type("application/json").
 				SetHeaders(mockHeaders).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

See the following screenshot with this PR:

![image](https://user-images.githubusercontent.com/1450685/173486985-2685357c-5a10-46a7-840a-68a7d6ba92bb.png)
![image](https://user-images.githubusercontent.com/1450685/173487007-47e1d494-c8b1-40a1-8f2e-06835833dfb5.png)

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #668

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
