### PR TITLE
Add Git Repository Support for FluxCD

### DIFF
--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -19,6 +19,7 @@ package app
 import (
 	"kubesphere.io/devops/controllers/addon"
 	"kubesphere.io/devops/controllers/argocd"
+	"kubesphere.io/devops/controllers/fluxcd"
 	"kubesphere.io/devops/controllers/gitrepository"
 	"kubesphere.io/devops/controllers/jenkins/devopscredential"
 	"kubesphere.io/devops/controllers/jenkins/devopsproject"
@@ -117,6 +118,10 @@ func getAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 	}
 	gitRepoReconcilers := gitrepository.GetReconcilers(mgr.GetClient())
 
+	fluxcdGitRepoReconciler := &fluxcd.GitRepositoryReconciler{
+		Client: mgr.GetClient(),
+	}
+
 	return map[string]func(mgr manager.Manager) error{
 		gitRepoReconcilers.GetName(): func(mgr manager.Manager) error {
 			return gitRepoReconcilers.SetupWithManager(mgr)
@@ -182,6 +187,9 @@ func getAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 		},
 		argcdImageUpdaterReconciler.GetGroupName() + "-image-updater": func(mgr manager.Manager) error {
 			return argcdImageUpdaterReconciler.SetupWithManager(mgr)
+		},
+		"fluxcd": func(mgr manager.Manager) error {
+			return fluxcdGitRepoReconciler.SetupWithManager(mgr)
 		},
 	}
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -316,3 +316,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - gitrepositories
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update

--- a/controllers/fluxcd/git-repository-controller.go
+++ b/controllers/fluxcd/git-repository-controller.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fluxcd
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"kubesphere.io/devops/pkg/utils/k8sutil"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=gitrepositories,verbs=get;list;watch;update;delete
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
+// GitRepositoryReconciler is the reconciler of the FluxCDGitRepository
+type GitRepositoryReconciler struct {
+	client.Client
+	log      logr.Logger
+	recorder record.EventRecorder
+}
+
+// Reconcile maintains the FluxCDGitRepository against to the GitRepository
+func (r *GitRepositoryReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error) {
+	ctx := context.Background()
+	repo := &v1alpha3.GitRepository{}
+
+	if err = r.Get(ctx, req.NamespacedName, repo); err != nil {
+		err = client.IgnoreNotFound(err)
+		return
+	}
+
+	err = r.reconcileFluxGitRepo(repo)
+	return
+}
+
+func (r *GitRepositoryReconciler) reconcileFluxGitRepo(repo *v1alpha3.GitRepository) (err error) {
+	ctx := context.Background()
+	FluxGitRepo := createBareFluxGitRepoObject()
+	// FluxGitRepo's namespace = v1alpha3.GitRepository's namespace
+	// FluxGitRepo's name = v1alpha3.GitRepository's name + "-flux-git-repo"
+	ns, name := repo.GetNamespace(), getFluxRepoName(repo.GetName())
+
+	if !repo.ObjectMeta.DeletionTimestamp.IsZero() {
+		if err = r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, FluxGitRepo); err != nil {
+			err = client.IgnoreNotFound(err)
+		} else {
+			r.log.Info("delete FluxCDGitRepository", "name", FluxGitRepo.GetName())
+			err = r.Delete(ctx, FluxGitRepo)
+		}
+
+		if err == nil {
+			k8sutil.RemoveFinalizer(&repo.ObjectMeta, v1alpha3.GitRepoFinalizerName)
+			err = r.Update(context.TODO(), repo)
+		}
+		return
+	}
+	if k8sutil.AddFinalizer(&repo.ObjectMeta, v1alpha3.GitRepoFinalizerName) {
+		err = r.Update(context.TODO(), repo)
+		if err != nil {
+			return
+		}
+	}
+
+	if err = r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, FluxGitRepo); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return
+		}
+		// flux git repo did not existed
+		// create
+		if FluxGitRepo, err = r.createUnstructuredFluxGitRepo(repo); err != nil {
+			return
+		}
+		if err = r.Create(ctx, FluxGitRepo); err != nil {
+			data, _ := FluxGitRepo.MarshalJSON()
+			r.log.Error(err, "failed to create FluxCDGitRepository", "data", string(data))
+			r.recorder.Eventf(FluxGitRepo, v1.EventTypeWarning, "FailedWithFluxCD",
+				"failed to create FluxCDGitRepository, error is: %v", err)
+		}
+	} else {
+		// flux git repo existed
+		// update
+		var newFluxGitRepo *unstructured.Unstructured
+		if newFluxGitRepo, err = r.createUnstructuredFluxGitRepo(repo); err == nil {
+			FluxGitRepo.Object["spec"] = newFluxGitRepo.Object["spec"]
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
+				latestGitRepo := createBareFluxGitRepoObject()
+				if err = r.Get(context.Background(), types.NamespacedName{
+					Namespace: FluxGitRepo.GetNamespace(),
+					Name:      FluxGitRepo.GetName(),
+				}, latestGitRepo); err != nil {
+					return
+				}
+
+				FluxGitRepo.SetResourceVersion(latestGitRepo.GetResourceVersion())
+				r.log.Info("update FluxCDGitRepository", "name", FluxGitRepo.GetName())
+				err = r.Update(ctx, FluxGitRepo)
+				return
+			})
+		}
+	}
+	return
+}
+
+func (r *GitRepositoryReconciler) createUnstructuredFluxGitRepo(repo *v1alpha3.GitRepository) (*unstructured.Unstructured, error) {
+	newFluxGitRepo := createBareFluxGitRepoObject()
+	newFluxGitRepo.SetNamespace(repo.GetNamespace())
+	newFluxGitRepo.SetName(getFluxRepoName(repo.GetName()))
+
+	// set url
+	if err := unstructured.SetNestedField(newFluxGitRepo.Object, repo.Spec.URL, "spec", "url"); err != nil {
+		return nil, err
+	}
+	// set interval
+	if err := unstructured.SetNestedField(newFluxGitRepo.Object, "1m", "spec", "interval"); err != nil {
+		return nil, err
+	}
+	//TODO set secretRef
+	//if err := unstructured.SetNestedField(newFluxGitRepo.Object, repo.Spec.Secret.Name, "spec", "secretRef"); err != nil {
+	//	return nil, err
+	//}
+
+	return newFluxGitRepo, nil
+}
+
+func getFluxRepoName(name string) string {
+	return fmt.Sprintf("%s-flux-git-repo", name)
+}
+
+// GetName returns the name of this reconciler
+func (r *GitRepositoryReconciler) GetName() string {
+	return "FluxGitRepositoryReconciler"
+}
+
+func createBareFluxGitRepoObject() *unstructured.Unstructured {
+	FluxGitRepo := &unstructured.Unstructured{}
+	FluxGitRepo.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "source.toolkit.fluxcd.io",
+		Version: "v1beta2",
+		Kind:    "GitRepository",
+	})
+	return FluxGitRepo
+}
+
+// SetupWithManager setups the reconciler with a manager
+// setup the logger, recorder
+func (r *GitRepositoryReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.log = ctrl.Log.WithName(r.GetName())
+	r.recorder = mgr.GetEventRecorderFor(r.GetName())
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha3.GitRepository{}).
+		Complete(r)
+}

--- a/controllers/fluxcd/git-repository-controller_test.go
+++ b/controllers/fluxcd/git-repository-controller_test.go
@@ -17,14 +17,15 @@ limitations under the License.
 package fluxcd
 
 import (
-	"fmt"
+	"context"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -32,99 +33,262 @@ import (
 	"testing"
 )
 
-func TestGitRepositoryController_Reconcile(t *testing.T) {
+func TestGitRepositoryReconciler_reconcileFluxGitRepo(t *testing.T) {
 	schema, err := v1alpha3.SchemeBuilder.Register().Build()
 	assert.Nil(t, err)
-	err = v1.SchemeBuilder.AddToScheme(schema)
-	assert.Nil(t, err)
 
-	repo := v1alpha3.GitRepository{}
-	repo.SetNamespace("ns")
-	repo.SetName("fake")
+	repo := v1alpha3.GitRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "devops-project",
+		},
+		Spec: v1alpha3.GitRepositorySpec{
+			Provider: "git",
+			URL:      "https://example.com/fake/fake",
+			Secret:   nil,
+		},
+	}
+
+	repoWithAuth := repo.DeepCopy()
+	repoWithAuth.Spec.Secret = &v1.SecretReference{
+		Name:      "fake-auth",
+		Namespace: "devops-project",
+	}
 
 	now := metav1.Now()
-	repoWithDeletion := repo.DeepCopy()
+	repoWithDeletion := repoWithAuth.DeepCopy()
 	repoWithDeletion.DeletionTimestamp = &now
+
+	repoWithNewURL := repoWithAuth.DeepCopy()
+	repoWithNewURL.Spec.URL = "https://example.com/fake/real"
+
+	FluxGitRepo := createBareFluxGitRepoObject()
+	preDelFluxGitRepo := createUnstructuredFluxGitRepo(repoWithAuth)
 
 	type fields struct {
 		Client client.Client
 	}
 	type args struct {
-		req controllerruntime.Request
+		repo *v1alpha3.GitRepository
 	}
 
 	tests := []struct {
-		name       string
-		fields     fields
-		args       args
-		wantResult controllerruntime.Result
-		wantErr    assert.ErrorAssertionFunc
+		name   string
+		fields fields
+		args   args
+		verify func(t *testing.T, Client client.Client, err error)
 	}{
 		{
-			name: "not found a git repository",
-			fields: fields{
-				Client: fake.NewFakeClientWithScheme(schema),
-			},
-			args: args{
-				req: ctrl.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: "ns",
-						Name:      "fake",
-					},
-				},
-			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return false
-			},
-		},
-		{
-			name: "create a git repository, without secret",
+			name: "create a git repository without Secret",
 			fields: fields{
 				Client: fake.NewFakeClientWithScheme(schema, repo.DeepCopy()),
 			},
 			args: args{
-				req: ctrl.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: "ns",
-						Name:      "fake",
-					},
-				},
+				repo: repo.DeepCopy(),
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return false
+			verify: func(t *testing.T, Client client.Client, err error) {
+				assert.Nil(t, err)
+				gitrepo := FluxGitRepo.DeepCopy()
+				err = Client.Get(context.TODO(), types.NamespacedName{
+					Name:      getFluxRepoName(repo.GetName()),
+					Namespace: repo.GetNamespace(),
+				}, gitrepo)
+				assert.Nil(t, err)
+				url, _, _ := unstructured.NestedString(gitrepo.Object, "spec", "url")
+				assert.Equal(t, "https://example.com/fake/fake", url)
+				secretName, _, _ := unstructured.NestedString(gitrepo.Object, "spec", "secretRef", "name")
+				assert.Equal(t, "", secretName)
 			},
 		},
 		{
-			name: "delete a git repository, without secret",
+			name: "create a git repository with Secret",
 			fields: fields{
-				Client: fake.NewFakeClientWithScheme(schema, repoWithDeletion.DeepCopy()),
+				Client: fake.NewFakeClientWithScheme(schema, repoWithAuth.DeepCopy()),
 			},
 			args: args{
-				req: ctrl.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: "ns",
-						Name:      "fake",
-					},
-				},
+				repo: repoWithAuth.DeepCopy(),
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return false
+			verify: func(t *testing.T, Client client.Client, err error) {
+				assert.Nil(t, err)
+				gitrepo := FluxGitRepo.DeepCopy()
+				err = Client.Get(context.TODO(), types.NamespacedName{
+					Name:      getFluxRepoName(repo.GetName()),
+					Namespace: repo.GetNamespace(),
+				}, gitrepo)
+				assert.Nil(t, err)
+				url, _, _ := unstructured.NestedString(gitrepo.Object, "spec", "url")
+				assert.Equal(t, "https://example.com/fake/fake", url)
+				secretName, _, _ := unstructured.NestedString(gitrepo.Object, "spec", "secretRef", "name")
+				assert.Equal(t, "fake-auth", secretName)
+			},
+		},
+		{
+			name: "delete a git repository with Secret",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, repoWithAuth.DeepCopy(), preDelFluxGitRepo.DeepCopy()),
+			},
+			args: args{
+				repo: repoWithDeletion.DeepCopy(),
+			},
+			verify: func(t *testing.T, Client client.Client, err error) {
+				assert.Nil(t, err)
+				gitrepo := FluxGitRepo.DeepCopy()
+				err = Client.Get(context.TODO(), types.NamespacedName{
+					Name:      getFluxRepoName(repo.GetName()),
+					Namespace: repo.GetNamespace(),
+				}, gitrepo)
+				assert.True(t, apierrors.IsNotFound(err))
+			},
+		},
+		{
+			name: "delete a git repository but not found a corresponding flux git repository",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, repoWithAuth.DeepCopy()),
+			},
+			args: args{
+				repo: repoWithDeletion.DeepCopy(),
+			},
+			verify: func(t *testing.T, Client client.Client, err error) {
+				assert.Nil(t, err)
+				gitrepo := FluxGitRepo.DeepCopy()
+				err = Client.Get(context.TODO(), types.NamespacedName{
+					Name:      getFluxRepoName(repo.GetName()),
+					Namespace: repo.GetNamespace(),
+				}, gitrepo)
+				assert.True(t, apierrors.IsNotFound(err))
+			},
+		},
+		{
+			name: "update a git repository with Secret",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, repoWithAuth.DeepCopy(), preDelFluxGitRepo.DeepCopy()),
+			},
+			args: args{
+				repo: repoWithNewURL.DeepCopy(),
+			},
+			verify: func(t *testing.T, Client client.Client, err error) {
+				assert.Nil(t, err)
+				gitrepo := FluxGitRepo.DeepCopy()
+				err = Client.Get(context.TODO(), types.NamespacedName{
+					Name:      getFluxRepoName(repo.GetName()),
+					Namespace: repo.GetNamespace(),
+				}, gitrepo)
+				assert.Nil(t, err)
+				url, _, _ := unstructured.NestedString(gitrepo.Object, "spec", "url")
+				assert.Equal(t, "https://example.com/fake/real", url)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &GitRepositoryReconciler{
+			r := &GitRepositoryReconciler{
 				Client:   tt.fields.Client,
 				log:      log.NullLogger{},
 				recorder: &record.FakeRecorder{},
 			}
-			gotResult, err := c.Reconcile(tt.args.req)
-			if !tt.wantErr(t, err, fmt.Sprintf("Reconcile(%v)", tt.args.req)) {
-				return
-			}
-			assert.Equalf(t, tt.wantResult, gotResult, "Reconcile(%v)", tt.args.req)
+			err := r.reconcileFluxGitRepo(tt.args.repo)
+			tt.verify(t, tt.fields.Client, err)
 		})
 	}
+}
+
+func TestGitRepositoryReconciler_getFluxRepoName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{{
+		name: "normal case",
+		args: args{
+			name: "fake-git-repo",
+		},
+		want: "fluxcd-fake-git-repo",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getFluxRepoName(tt.args.name), "getSecretName(%v)", tt.args.name)
+		})
+	}
+}
+
+func TestGitRepositoryReconciler_Reconcile(t *testing.T) {
+	schema, err := v1alpha3.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+	err = v1.SchemeBuilder.AddToScheme(schema)
+	assert.Nil(t, err)
+
+	repo := v1alpha3.GitRepository{}
+	repo.SetName("fake-git-repo")
+	repo.SetNamespace("devops-project")
+
+	type fields struct {
+		Client client.Client
+	}
+	type args struct {
+		req ctrl.Request
+	}
+
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantResult ctrl.Result
+		wantErr    assert.ErrorAssertionFunc
+	}{
+		{
+			name: "not found",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, repo.DeepCopy()),
+			},
+			args: args{
+				req: ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      "fake-git-repo",
+						Namespace: "another-devops-project",
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "found",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, repo.DeepCopy()),
+			},
+			args: args{
+				req: ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      "fake-git-repo",
+						Namespace: "devops-project",
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &GitRepositoryReconciler{
+				Client:   tt.fields.Client,
+				recorder: &record.FakeRecorder{},
+			}
+			gotResult, err := r.Reconcile(tt.args.req)
+			if tt.wantErr(t, err) {
+				assert.Equal(t, tt.wantResult, gotResult)
+			}
+		})
+	}
+}
+
+func TestGitRepositoryReconciler_GetName(t *testing.T) {
+	t.Run("get GitRepositoryReconciler name", func(t *testing.T) {
+
+		r := &GitRepositoryReconciler{}
+		assert.Equal(t, "FluxGitRepositoryReconciler", r.GetName())
+	})
 }

--- a/controllers/fluxcd/git-repository-controller_test.go
+++ b/controllers/fluxcd/git-repository-controller_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fluxcd
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func TestGitRepositoryController_Reconcile(t *testing.T) {
+	schema, err := v1alpha3.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+	err = v1.SchemeBuilder.AddToScheme(schema)
+	assert.Nil(t, err)
+
+	repo := v1alpha3.GitRepository{}
+	repo.SetNamespace("ns")
+	repo.SetName("fake")
+
+	now := metav1.Now()
+	repoWithDeletion := repo.DeepCopy()
+	repoWithDeletion.DeletionTimestamp = &now
+
+	type fields struct {
+		Client client.Client
+	}
+	type args struct {
+		req controllerruntime.Request
+	}
+
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantResult controllerruntime.Result
+		wantErr    assert.ErrorAssertionFunc
+	}{
+		{
+			name: "not found a git repository",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema),
+			},
+			args: args{
+				req: ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "ns",
+						Name:      "fake",
+					},
+				},
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return false
+			},
+		},
+		{
+			name: "create a git repository, without secret",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, repo.DeepCopy()),
+			},
+			args: args{
+				req: ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "ns",
+						Name:      "fake",
+					},
+				},
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return false
+			},
+		},
+		{
+			name: "delete a git repository, without secret",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, repoWithDeletion.DeepCopy()),
+			},
+			args: args{
+				req: ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "ns",
+						Name:      "fake",
+					},
+				},
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return false
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &GitRepositoryReconciler{
+				Client:   tt.fields.Client,
+				log:      log.NullLogger{},
+				recorder: &record.FakeRecorder{},
+			}
+			gotResult, err := c.Reconcile(tt.args.req)
+			if !tt.wantErr(t, err, fmt.Sprintf("Reconcile(%v)", tt.args.req)) {
+				return
+			}
+			assert.Equalf(t, tt.wantResult, gotResult, "Reconcile(%v)", tt.args.req)
+		})
+	}
+}

--- a/pkg/api/gitops/v1alpha1/constants.go
+++ b/pkg/api/gitops/v1alpha1/constants.go
@@ -36,3 +36,5 @@ const ApplicationFinalizerName = "application." + GroupName
 
 // ArgoCDResourcesFinalizer is the name of Argo CD resource finalizer
 const ArgoCDResourcesFinalizer = "resources-finalizer.argocd.argoproj.io"
+
+const ArtifactRepoLabelKey = GroupName + "/is-artifact-repository"


### PR DESCRIPTION
### What type of PR is this?

/kind feature
/kind design

### What this PR does / why we need it:
- Add controllers/fluxcd/git-repository-controller.go for reconciling [source.toolkit.fluxcd.io/v1/beta2/GitRepository](https://github.com/fluxcd/source-controller/blob/812f6e49ddfbe42d5e11da2805b8feb9121cdb88/api/v1beta2/gitrepository_types.go#L273) and devops.kubesphere.io/v1alpha3/GitRepository
- Add controllers/fluxcd/git-repository-controller_test.go for testing the function of the controller
- Add the controller to cmd/controller/app/controllers.go
- Update the config/rbac/role.yaml

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #679 

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:
It has no auth support yet.

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [x] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
None

```release-note

```
