### PR TITLE
Support to copy argocd-related annotations and labels

### DIFF
--- a/controllers/argocd/application_controller.go
+++ b/controllers/argocd/application_controller.go
@@ -205,6 +205,9 @@ func createUnstructuredApplication(app *v1alpha1.Application) (result *unstructu
 	newArgoApp.SetName(app.GetName())
 	newArgoApp.SetNamespace(app.GetNamespace())
 
+	// make sure all Argo CD supported annotations and labels exist
+	copyArgoAnnotationsAndLabels(app, newArgoApp)
+
 	// copy all potential finalizers
 	finalizers := app.GetFinalizers()
 	targetFinalizers := make([]string, 0)
@@ -226,6 +229,30 @@ func createUnstructuredApplication(app *v1alpha1.Application) (result *unstructu
 		}
 	}
 	return newArgoApp, nil
+}
+
+func copyArgoAnnotationsAndLabels(app *v1alpha1.Application, argoApp *unstructured.Unstructured) {
+	var annotations map[string]string
+	if annotations = argoApp.GetAnnotations(); annotations == nil {
+		annotations = map[string]string{}
+	}
+	for k, v := range app.Annotations {
+		if strings.Contains(k, "argoproj.io") {
+			annotations[k] = v
+		}
+	}
+	argoApp.SetAnnotations(annotations)
+
+	var labels map[string]string
+	if labels = argoApp.GetLabels(); labels == nil {
+		labels = map[string]string{}
+	}
+	for k, v := range app.Labels {
+		if strings.Contains(k, "argoproj.io") {
+			labels[k] = v
+		}
+	}
+	argoApp.SetLabels(labels)
 }
 
 func (r *ApplicationReconciler) addArgoAppNameIntoLabels(namespace, name, argoAppName string) (err error) {

--- a/controllers/argocd/application_controller.go
+++ b/controllers/argocd/application_controller.go
@@ -357,7 +357,7 @@ func (p specificAnnotationsOrLabelsChangedPredicate) Update(e event.UpdateEvent)
 
 func mapKeysContains(filter string, annotations ...map[string]string) (has bool) {
 	for _, anno := range annotations {
-		for k, _ := range anno {
+		for k := range anno {
 			if has = strings.Contains(k, filter); has {
 				return
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Some Argo CD features rely on annotations. For example, the image updater relies on the annotation `argocd-image-updater.argoproj.io/image-list`.

This is part of #676

Please feel free to help us to test it via:
```
ghcr.io/linuxsuren/devops-controller:dev-v3.2.1-6803647
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
