### PR TITLE
Avoid using Jenkins API to convert Jenkinsfile format

### DIFF
--- a/controllers/jenkins/pipeline/constants.go
+++ b/controllers/jenkins/pipeline/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+const (
+	// ControllerGroupName is the group name of a set of controllers
+	ControllerGroupName = "jenkins"
+)

--- a/controllers/jenkins/pipeline/interface_test.go
+++ b/controllers/jenkins/pipeline/interface_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"github.com/stretchr/testify/assert"
+	"kubesphere.io/devops/controllers/core"
+	"testing"
+)
+
+func TestInterfaceImplement(t *testing.T) {
+	type interInstance struct {
+		NamedReconciler core.NamedReconciler
+		GroupReconciler core.GroupReconciler
+	}
+
+	tests := []struct {
+		name     string
+		instance interInstance
+	}{{
+		name: "JenkinsfileReconciler",
+		instance: interInstance{
+			NamedReconciler: &JenkinsfileReconciler{},
+			GroupReconciler: &JenkinsfileReconciler{},
+		},
+	}}
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotNil(t, tt.instance.NamedReconciler)
+			assert.NotEmpty(t, tt.instance.NamedReconciler.GetName())
+			assert.NotNil(t, tt.instance.GroupReconciler)
+			assert.NotEmpty(t, tt.instance.GroupReconciler.GetGroupName())
+		})
+	}
+}

--- a/controllers/jenkins/pipeline/json_converter.go
+++ b/controllers/jenkins/pipeline/json_converter.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/tools/record"
+	v1alpha3 "kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"kubesphere.io/devops/pkg/jwt/token"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+// tokenExpireIn indicates that the temporary token issued by controller will be expired in some time.
+const tokenExpireIn time.Duration = 5 * time.Minute
+
+//+kubebuilder:rbac:groups=devops.kubesphere.io,resources=pipelines,verbs=get;list;update;patch;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
+// JenkinsfileReconciler will convert between JSON and Jenkinsfile (as groovy) formats
+type JenkinsfileReconciler struct {
+	log      logr.Logger
+	recorder record.EventRecorder
+
+	client.Client
+	JenkinsCore core.JenkinsCore
+	TokenIssuer token.Issuer
+}
+
+// Reconcile is the main entrypoint of this controller
+func (r *JenkinsfileReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error) {
+	ctx := context.Background()
+
+	pip := &v1alpha3.Pipeline{}
+	if err = r.Get(ctx, req.NamespacedName, pip); err != nil {
+		err = client.IgnoreNotFound(err)
+		return
+	}
+
+	if pip.Spec.Type != v1alpha3.NoScmPipelineType || pip.Spec.Pipeline == nil {
+		return
+	}
+
+	// set up the Jenkins client
+	var c *core.JenkinsCore
+	if c, err = r.getOrCreateJenkinsCore(map[string]string{
+		v1alpha3.PipelineRunCreatorAnnoKey: "admin",
+	}); err != nil {
+		err = fmt.Errorf("failed to create Jenkins client, error: %v", err)
+		return
+	}
+	c.RoundTripper = r.JenkinsCore.RoundTripper
+	coreClient := core.Client{JenkinsCore: *c}
+
+	editMode := pip.Annotations[v1alpha3.PipelineJenkinsfileEditModeAnnoKey]
+	switch editMode {
+	case "":
+		result, err = r.reconcileJenkinsfileEditMode(pip, coreClient)
+	case v1alpha3.PipelineJenkinsfileEditModeJSON:
+		result, err = r.reconcileJSONEditMode(pip, coreClient)
+	default:
+		r.log.Info(fmt.Sprintf("invalid edit mode: %s", editMode))
+		return
+	}
+	return
+}
+
+func (r *JenkinsfileReconciler) reconcileJenkinsfileEditMode(pip *v1alpha3.Pipeline, coreClient core.Client) (
+	result ctrl.Result, err error) {
+
+	jenkinsfile := pip.Spec.Pipeline.Jenkinsfile
+
+	var toJSONResult core.GenericResult
+	if toJSONResult, err = coreClient.ToJSON(jenkinsfile); err != nil || toJSONResult.GetStatus() != "success" {
+		err = fmt.Errorf("failed to convert Jenkinsfile to JSON format, error: %v", err)
+		return
+	}
+
+	if pip.Annotations == nil {
+		pip.Annotations = map[string]string{}
+	}
+	pip.Annotations[v1alpha3.PipelineJenkinsfileValueAnnoKey] = toJSONResult.GetResult()
+	err = r.Update(context.Background(), pip)
+	return
+}
+
+func (r *JenkinsfileReconciler) reconcileJSONEditMode(pip *v1alpha3.Pipeline, coreClient core.Client) (
+	result ctrl.Result, err error) {
+	var jsonData string
+	if jsonData = pip.Annotations[v1alpha3.PipelineJenkinsfileValueAnnoKey]; jsonData != "" {
+		var toResult core.GenericResult
+		if toResult, err = coreClient.ToJenkinsfile(jsonData); err != nil || toResult.GetStatus() != "success" {
+			err = fmt.Errorf("failed to convert JSON format to Jenkinsfile, error: %v", err)
+			return
+		}
+
+		pip.Annotations[v1alpha3.PipelineJenkinsfileEditModeAnnoKey] = ""
+		pip.Spec.Pipeline.Jenkinsfile = toResult.GetResult()
+		err = r.Update(context.Background(), pip)
+	}
+	return
+}
+
+// GetName returns the name of this controller
+func (r *JenkinsfileReconciler) GetName() string {
+	return "JenkinsfileController"
+}
+
+// GetGroupName returns the group name of this controller
+func (r *JenkinsfileReconciler) GetGroupName() string {
+	return ControllerGroupName
+}
+
+func (r *JenkinsfileReconciler) getOrCreateJenkinsCore(annotations map[string]string) (*core.JenkinsCore, error) {
+	creator, ok := annotations[v1alpha3.PipelineRunCreatorAnnoKey]
+	if !ok || creator == "" {
+		return &r.JenkinsCore, nil
+	}
+	// create a new JenkinsCore for current creator
+	accessToken, err := r.TokenIssuer.IssueTo(&user.DefaultInfo{Name: creator}, token.AccessToken, tokenExpireIn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to issue access token for creator %s, error was %v", creator, err)
+	}
+	jenkinsCore := &core.JenkinsCore{
+		URL:      r.JenkinsCore.URL,
+		UserName: creator,
+		Token:    accessToken,
+	}
+	return jenkinsCore, nil
+}
+
+// SetupWithManager setups the log and recorder
+func (r *JenkinsfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.log = ctrl.Log.WithName(r.GetName())
+	r.recorder = mgr.GetEventRecorderFor(r.GetName())
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha3.Pipeline{}).
+		Complete(r)
+}

--- a/controllers/jenkins/pipeline/json_converter_test.go
+++ b/controllers/jenkins/pipeline/json_converter_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
+	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"kubesphere.io/devops/pkg/jwt/token"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func TestJenkinsfileReconciler_Reconcile(t *testing.T) {
+	schema, err := v1alpha3.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+	err = v1.SchemeBuilder.AddToScheme(schema)
+	assert.Nil(t, err)
+
+	defaultReq := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "ns",
+			Name:      "name",
+		},
+	}
+
+	pip := &v1alpha3.Pipeline{}
+	pip.SetNamespace("ns")
+	pip.SetName("name")
+	pip.Annotations = map[string]string{}
+	pip.Spec.Type = v1alpha3.NoScmPipelineType
+	pip.Spec.Pipeline = &v1alpha3.NoScmPipeline{
+		Jenkinsfile: `jenkinsfile`,
+	}
+
+	jsonEditModePip := pip.DeepCopy()
+	jsonEditModePip.Annotations[v1alpha3.PipelineJenkinsfileEditModeAnnoKey] = "json"
+	jsonEditModePip.Annotations[v1alpha3.PipelineJenkinsfileValueAnnoKey] = `json`
+
+	invalidEditMode := pip.DeepCopy()
+	invalidEditMode.Annotations[v1alpha3.PipelineJenkinsfileEditModeAnnoKey] = "invalid"
+
+	irregularPip := pip.DeepCopy()
+	irregularPip.Spec.Type = ""
+
+	type fields struct {
+		Client      client.Client
+		log         logr.Logger
+		recorder    record.EventRecorder
+		JenkinsCore core.JenkinsCore
+		TokenIssuer token.Issuer
+	}
+	type args struct {
+		req controllerruntime.Request
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		prepare    func(t *testing.T, c *core.JenkinsCore)
+		verify     func(t *testing.T, Client client.Client)
+		wantResult controllerruntime.Result
+		wantErr    assert.ErrorAssertionFunc
+	}{{
+		name: "not found",
+		fields: fields{
+			Client: fake.NewFakeClientWithScheme(schema),
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.Nil(t, err)
+			return true
+		},
+		wantResult: controllerruntime.Result{},
+	}, {
+		name: "invalid edit mode",
+		fields: fields{
+			Client:      fake.NewFakeClientWithScheme(schema, invalidEditMode),
+			JenkinsCore: core.JenkinsCore{},
+			log:         log.NullLogger{},
+			TokenIssuer: &token.FakeIssuer{},
+		},
+		args: args{
+			req: defaultReq,
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.Nil(t, err)
+			return true
+		},
+	}, {
+		name: "irregular pipeline, and jenkinsfile edit mode",
+		fields: fields{
+			Client:      fake.NewFakeClientWithScheme(schema, irregularPip),
+			JenkinsCore: core.JenkinsCore{},
+			log:         log.NullLogger{},
+		},
+		args: args{
+			req: defaultReq,
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.Nil(t, err)
+			return true
+		},
+	}, {
+		name: "a regular pipeline with jenkinsfile edit mode",
+		fields: fields{
+			Client: fake.NewFakeClientWithScheme(schema, pip),
+			JenkinsCore: core.JenkinsCore{
+				URL: "http://localhost",
+			},
+			log:         log.NullLogger{},
+			TokenIssuer: &token.FakeIssuer{},
+		},
+		args: args{
+			req: defaultReq,
+		},
+		prepare: func(t *testing.T, c *core.JenkinsCore) {
+			ctrl := gomock.NewController(t)
+			roundTripper := mhttp.NewMockRoundTripper(ctrl)
+			c.RoundTripper = roundTripper
+
+			core.PrepareForToJSON(roundTripper, "http://localhost", "", "")
+		},
+		verify: func(t *testing.T, Client client.Client) {
+			pip := &v1alpha3.Pipeline{}
+			err := Client.Get(context.Background(), types.NamespacedName{
+				Namespace: "ns",
+				Name:      "name",
+			}, pip)
+			assert.Nil(t, err)
+			assert.Equal(t, `{"a":"b"}`, pip.Annotations[v1alpha3.PipelineJenkinsfileValueAnnoKey])
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.Nil(t, err)
+			return true
+		},
+	}, {
+		name: "a regular pipeline with JSON edit mode",
+		fields: fields{
+			Client: fake.NewFakeClientWithScheme(schema, jsonEditModePip),
+			JenkinsCore: core.JenkinsCore{
+				URL: "http://localhost",
+			},
+			log:         log.NullLogger{},
+			TokenIssuer: &token.FakeIssuer{},
+		},
+		args: args{
+			req: defaultReq,
+		},
+		prepare: func(t *testing.T, c *core.JenkinsCore) {
+			ctrl := gomock.NewController(t)
+			roundTripper := mhttp.NewMockRoundTripper(ctrl)
+			c.RoundTripper = roundTripper
+
+			core.PrepareForToJenkinsfile(roundTripper, "http://localhost", "", "")
+		},
+		verify: func(t *testing.T, Client client.Client) {
+			pip := &v1alpha3.Pipeline{}
+			err := Client.Get(context.Background(), types.NamespacedName{
+				Namespace: "ns",
+				Name:      "name",
+			}, pip)
+			assert.Nil(t, err)
+			assert.Equal(t, "json", pip.Annotations[v1alpha3.PipelineJenkinsfileValueAnnoKey])
+			assert.Equal(t, "", pip.Annotations[v1alpha3.PipelineJenkinsfileEditModeAnnoKey])
+			assert.Equal(t, "jenkinsfile", pip.Spec.Pipeline.Jenkinsfile)
+		},
+		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assert.Nil(t, err)
+			return true
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.prepare != nil {
+				tt.prepare(t, &tt.fields.JenkinsCore)
+			}
+			r := &JenkinsfileReconciler{
+				Client:      tt.fields.Client,
+				log:         tt.fields.log,
+				recorder:    tt.fields.recorder,
+				JenkinsCore: tt.fields.JenkinsCore,
+				TokenIssuer: tt.fields.TokenIssuer,
+			}
+			gotResult, err := r.Reconcile(tt.args.req)
+			if !tt.wantErr(t, err, fmt.Sprintf("Reconcile(%v)", tt.args.req)) {
+				return
+			}
+			assert.Equalf(t, tt.wantResult, gotResult, "Reconcile(%v)", tt.args.req)
+			if tt.verify != nil {
+				tt.verify(t, tt.fields.Client)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/h2non/gock v1.0.9
 	github.com/jenkins-x/go-scm v1.11.4
-	github.com/jenkins-zh/jenkins-client v0.0.9
+	github.com/jenkins-zh/jenkins-client v0.0.10-0.20220706065616-22f8c7675234
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jenkins-zh/jenkins-cli v0.0.32/go.mod h1:uE1mH9PNITrg0sugv6HXuM/CSddg0zxXoYu3w57I3JY=
-github.com/jenkins-zh/jenkins-client v0.0.9 h1:yqWtjLifYWbVxR+wFdExh/cHSQ54i/Cdco2MYkc/5vI=
-github.com/jenkins-zh/jenkins-client v0.0.9/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
+github.com/jenkins-zh/jenkins-client v0.0.10-0.20220706065616-22f8c7675234 h1:gO2Ca6t/V7l7SD9H6mAy6UkcHVT0Ey3sZ6o0jIKPUHg=
+github.com/jenkins-zh/jenkins-client v0.0.10-0.20220706065616-22f8c7675234/go.mod h1:ICBk7OOoTafVP//f/VfKZ34c0ff8vJwVnOsF9btiMYU=
 github.com/jenkins-zh/jenkins-formulas v0.0.5/go.mod h1:zS8fm8u5L6FcjZM0QznXsLV9T2UtSVK+hT6Sm76iUZ4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/pkg/api/devops/v1alpha3/pipeline_types.go
+++ b/pkg/api/devops/v1alpha3/pipeline_types.go
@@ -41,13 +41,18 @@ const (
 	PipelineJenkinsBranchesAnnoKey = PipelinePrefix + "jenkins-branches"
 	// PipelineRequestToSyncRunsAnnoKey is the annotation key of requesting to synchronize PipelineRun after a dedicated time.
 	PipelineRequestToSyncRunsAnnoKey = PipelinePrefix + "request-to-sync-pipelineruns"
+	// PipelineJenkinsfileValueAnnoKey is the annotation key of the Jenkinsfile content
+	PipelineJenkinsfileValueAnnoKey = PipelinePrefix + "jenkinsfile"
+	// PipelineJenkinsfileEditModeAnnoKey is the annotation key of the Jenkinsfile edit mode
+	PipelineJenkinsfileEditModeAnnoKey = PipelinePrefix + "jenkinsfile.edit.mode"
+
+	// PipelineJenkinsfileEditModeJSON indicates the Jenkinsfile editing mode is JSON
+	PipelineJenkinsfileEditModeJSON = "json"
 )
 
 // PipelineSpec defines the desired state of Pipeline
 type PipelineSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-	Type                string               `json:"type" description:"type of devops pipeline, in scm or no scm"`
+	Type                PipelineType         `json:"type" description:"type of devops pipeline, in scm or no scm"`
 	Pipeline            *NoScmPipeline       `json:"pipeline,omitempty" description:"no scm pipeline structs"`
 	MultiBranchPipeline *MultiBranchPipeline `json:"multi_branch_pipeline,omitempty" description:"in scm pipeline structs"`
 }
@@ -91,9 +96,12 @@ func (p *Pipeline) IsMultiBranch() bool {
 	return p.Spec.Type == MultiBranchPipelineType
 }
 
+// PipelineType is an alias of string that represents the type of Pipelines
+type PipelineType string
+
 const (
-	NoScmPipelineType       = "pipeline"
-	MultiBranchPipelineType = "multi-branch-pipeline"
+	NoScmPipelineType       PipelineType = "pipeline"
+	MultiBranchPipelineType PipelineType = "multi-branch-pipeline"
 )
 
 const (

--- a/pkg/kapis/devops/v1alpha3/handler.go
+++ b/pkg/kapis/devops/v1alpha3/handler.go
@@ -204,6 +204,30 @@ func (h *devopsHandler) UpdatePipeline(request *restful.Request, response *restf
 	}
 }
 
+// GenericPayload represents a generic HTTP request payload data structure
+type GenericPayload struct {
+	Data string `json:"data"`
+}
+
+func (h *devopsHandler) UpdateJenkinsfile(request *restful.Request, response *restful.Response) {
+	projectName := request.PathParameter("devops")
+	pipelineName := request.PathParameter("pipeline")
+	mode := request.QueryParameter("mode")
+
+	var err error
+	payload := &GenericPayload{}
+	if err = request.ReadEntity(payload); err != nil {
+		kapis.HandleBadRequest(response, request, err)
+		return
+	}
+
+	var client devops.DevopsOperator
+	if client, err = h.getDevOps(request); err == nil {
+		err = client.UpdateJenkinsfile(projectName, pipelineName, mode, payload.Data)
+	}
+	errorHandle(request, response, nil, err)
+}
+
 func (h *devopsHandler) DeletePipeline(request *restful.Request, response *restful.Response) {
 	devops := request.PathParameter("devops")
 	pipeline := request.PathParameter("pipeline")

--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -171,6 +171,16 @@ func registerRoutersForPipelines(handler *devopsHandler, ws *restful.WebService)
 		Returns(http.StatusOK, api.StatusOK, v1alpha3.Pipeline{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
+	ws.Route(ws.PUT("/devops/{devops}/pipelines/{pipeline}/jenkinsfile").
+		To(handler.UpdateJenkinsfile).
+		Param(ws.PathParameter("devops", "project name")).
+		Param(ws.PathParameter("pipeline", "pipeline name")).
+		Param(ws.QueryParameter("mode", "the mode(json or raw) that you expect to update the Jenkinsfile")).
+		Reads(&GenericPayload{}, "The Jenkinsfile content should be in the 'data' field").
+		Doc("Update the Jenkinsfile of a Pipeline").
+		Returns(http.StatusOK, api.StatusOK, v1alpha3.Pipeline{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
 	ws.Route(ws.DELETE("/devops/{devops}/pipelines/{pipeline}").
 		To(handler.DeletePipeline).
 		Param(ws.PathParameter("devops", "project name")).

--- a/pkg/kapis/devops/v1alpha3/register_test.go
+++ b/pkg/kapis/devops/v1alpha3/register_test.go
@@ -159,6 +159,12 @@ func TestAPIsExist(t *testing.T) {
 			method: http.MethodDelete,
 			uri:    "/workspaces/fake/devops/fake",
 		},
+	}, {
+		name: "update jenkinsfile",
+		args: args{
+			method: http.MethodPut,
+			uri:    "/devops/fake/pipelines/fake/jenkinsfile",
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind api-change

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Related https://github.com/kubesphere/ks-devops/issues/713

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
