### PR TITLE
Skip CVE-2022-1996 for now due to it might cause too many changes

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,0 +1,3 @@
+# Need to upgrade github.com/emicklei/go-restful to v3.8.0
+# It might cause a lot of changes.
+CVE-2022-1996

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,7 +125,7 @@ jobs:
           labels: ${{ steps.metaContributors.outputs.labels }}
           platforms: ${{ steps.build_env.outputs.platforms }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.2.0
+        uses: aquasecurity/trivy-action@0.5.1
         if: github.event_name == 'pull_request'
         with:
           image-ref: 'ghcr.io/kubesphere/devops-controller:sha-${{ steps.build_env.outputs.short_sha }}'
@@ -134,6 +134,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          trivyignores: .github/workflows/.trivyignore
 
   BuildAPIServer:
     runs-on: ubuntu-20.04
@@ -218,7 +219,7 @@ jobs:
           labels: ${{ steps.metaContributors.outputs.labels }}
           platforms: ${{ steps.build_env.outputs.platforms }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.2.0
+        uses: aquasecurity/trivy-action@0.5.1
         if: github.event_name == 'pull_request'
         with:
           image-ref: 'ghcr.io/kubesphere/devops-apiserver:sha-${{ steps.build_env.outputs.short_sha }}'
@@ -227,6 +228,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          trivyignores: .github/workflows/.trivyignore
 
   BuildTools:
     runs-on: ubuntu-20.04
@@ -311,7 +313,7 @@ jobs:
           labels: ${{ steps.metaContributors.outputs.labels }}
           platforms: ${{ steps.build_env.outputs.platforms }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.2.0
+        uses: aquasecurity/trivy-action@0.5.1
         if: github.event_name == 'pull_request'
         with:
           image-ref: 'ghcr.io/kubesphere/devops-tools:sha-${{ steps.build_env.outputs.short_sha }}'
@@ -320,6 +322,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          trivyignores: .github/workflows/.trivyignore
 
   UnitTest:
     name: Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
related #725

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
