### PR TITLE
Set a generic response for the jenkinsfile update API

### DIFF
--- a/pkg/kapis/devops/v1alpha3/handler.go
+++ b/pkg/kapis/devops/v1alpha3/handler.go
@@ -209,6 +209,18 @@ type GenericPayload struct {
 	Data string `json:"data"`
 }
 
+// GenericResponse represents a generic HTTP response data structure
+type GenericResponse struct {
+	Result string `json:"result"`
+}
+
+// NewSuccessResponse creates a response for the success case
+func NewSuccessResponse() *GenericResponse {
+	return &GenericResponse{
+		Result: "success",
+	}
+}
+
 func (h *devopsHandler) UpdateJenkinsfile(request *restful.Request, response *restful.Response) {
 	projectName := request.PathParameter("devops")
 	pipelineName := request.PathParameter("pipeline")
@@ -225,7 +237,7 @@ func (h *devopsHandler) UpdateJenkinsfile(request *restful.Request, response *re
 	if client, err = h.getDevOps(request); err == nil {
 		err = client.UpdateJenkinsfile(projectName, pipelineName, mode, payload.Data)
 	}
-	errorHandle(request, response, nil, err)
+	errorHandle(request, response, NewSuccessResponse(), err)
 }
 
 func (h *devopsHandler) DeletePipeline(request *restful.Request, response *restful.Response) {

--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -178,8 +178,7 @@ func registerRoutersForPipelines(handler *devopsHandler, ws *restful.WebService)
 		Param(ws.QueryParameter("mode", "the mode(json or raw) that you expect to update the Jenkinsfile")).
 		Reads(&GenericPayload{}, "The Jenkinsfile content should be in the 'data' field").
 		Doc("Update the Jenkinsfile of a Pipeline").
-		Returns(http.StatusOK, api.StatusOK, v1alpha3.Pipeline{}).
-		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+		Returns(http.StatusOK, api.StatusOK, GenericResponse{}))
 
 	ws.Route(ws.DELETE("/devops/{devops}/pipelines/{pipeline}").
 		To(handler.DeletePipeline).

--- a/pkg/kapis/devops/v1alpha3/register_test.go
+++ b/pkg/kapis/devops/v1alpha3/register_test.go
@@ -86,6 +86,14 @@ func TestAPIsExist(t *testing.T) {
 		},
 		expectCode: 400,
 	}, {
+		name: "create a credential with body",
+		args: args{
+			method: http.MethodPost,
+			uri:    "/devops/fake/credentials",
+		},
+		body:       `{}`,
+		expectCode: 200,
+	}, {
 		name: "get a credential",
 		args: args{
 			method: http.MethodGet,
@@ -98,6 +106,14 @@ func TestAPIsExist(t *testing.T) {
 			uri:    "/devops/fake/credentials/fake",
 		},
 		expectCode: 400,
+	}, {
+		name: "update a credential with body",
+		args: args{
+			method: http.MethodPut,
+			uri:    "/devops/fake/credentials/fake",
+		},
+		body:       `{}`,
+		expectCode: 200,
 	}, {
 		name: "delete a credential",
 		args: args{
@@ -118,6 +134,14 @@ func TestAPIsExist(t *testing.T) {
 		},
 		expectCode: 400,
 	}, {
+		name: "create a pipeline with body",
+		args: args{
+			method: http.MethodPost,
+			uri:    "/devops/fake/pipelines",
+		},
+		body:       `{}`,
+		expectCode: 200,
+	}, {
 		name: "get a pipeline",
 		args: args{
 			method: http.MethodGet,
@@ -137,7 +161,7 @@ func TestAPIsExist(t *testing.T) {
 			uri:    "/devops/fake/pipelines/fake",
 		},
 		body:       `{}`,
-		expectCode: 400,
+		expectCode: 200,
 	}, {
 		name: "delete a pipeline",
 		args: args{
@@ -158,6 +182,14 @@ func TestAPIsExist(t *testing.T) {
 		},
 		expectCode: 400,
 	}, {
+		name: "create a devops with body",
+		args: args{
+			method: http.MethodPost,
+			uri:    "/workspaces/fake/devops",
+		},
+		body:       `{}`,
+		expectCode: 400,
+	}, {
 		name: "get a devops",
 		args: args{
 			method: http.MethodGet,
@@ -170,6 +202,14 @@ func TestAPIsExist(t *testing.T) {
 			uri:    "/workspaces/fake/devops/fake",
 		},
 		expectCode: 400,
+	}, {
+		name: "update a devops with body",
+		args: args{
+			method: http.MethodPut,
+			uri:    "/workspaces/fake/devops/fake",
+		},
+		body:       `{}`,
+		expectCode: 404,
 	}, {
 		name: "delete a devops",
 		args: args{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
