### PR TITLE
Add Multi-Cluster Management for Flux Application

### DIFF
--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -132,8 +132,10 @@ func getAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 		Client:                   mgr.GetClient(),
 		TargetConfigMapNamespace: s.FeatureOptions.SystemNamespace,
 	}
-
 	fluxcdApplicationReconciler := &fluxcd.ApplicationReconciler{
+		Client: mgr.GetClient(),
+	}
+	fluxcdMultiClusterReconciler := &fluxcd.MultiClusterReconciler{
 		Client: mgr.GetClient(),
 	}
 
@@ -220,6 +222,9 @@ func getAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 		},
 		fluxcdApplicationReconciler.GetGroupName(): func(mgr manager.Manager) (err error) {
 			if err = fluxcdGitRepoReconciler.SetupWithManager(mgr); err != nil {
+				return
+			}
+			if err = fluxcdMultiClusterReconciler.SetupWithManager(mgr); err != nil {
 				return
 			}
 			return fluxcdApplicationReconciler.SetupWithManager(mgr)

--- a/config/samples/gitops/fluxcd-application-helmrelease.yaml
+++ b/config/samples/gitops/fluxcd-application-helmrelease.yaml
@@ -27,6 +27,7 @@ spec:
           template:
           deploy:
             - destination:
+                # host cluster
                 kubeConfig:
                 targetNamespace: helm-app
               interval: 1m0s
@@ -37,8 +38,15 @@ spec:
               install:
                 createNamespace: true
             - destination:
+                # member cluster
                 kubeConfig:
-                targetNamespace: another-helm-app
+                  secretRef:
+                    name: node-1
+                    key: value
+                targetNamespace: helm-app
+              # StorageNamespace used for the Helm storage.
+              # Defaults to the namespace of the HelmRelease.
+              storageNamespace: default
               interval: 1m0s
               upgrade:
                 remediation:

--- a/config/samples/gitops/fluxcd-application-helmtemplate.yaml
+++ b/config/samples/gitops/fluxcd-application-helmtemplate.yaml
@@ -14,8 +14,24 @@ spec:
           template: chengleqi-test-helm
           deploy:
             - destination:
+                # host cluster
                 kubeConfig:
                 targetNamespace: template-app
+              interval: 1m0s
+              upgrade:
+                remediation:
+                  remediateLastFailure: true
+                force: true
+              install:
+                createNamespace: true
+            - destination:
+                # member cluster
+                kubeConfig:
+                  secretRef:
+                    name: node-1
+                    key: value
+                targetNamespace: template-app
+              storageNamespace: default
               interval: 1m0s
               upgrade:
                 remediation:

--- a/config/samples/gitops/fluxcd-application-kustomization.yaml
+++ b/config/samples/gitops/fluxcd-application-kustomization.yaml
@@ -15,7 +15,18 @@ spec:
       config:
         kustomization:
           - destination:
+              # host cluster
               kubeConfig:
+              targetNamespace: default
+            interval: 8m0s
+            prune: true
+            path: "nginx"
+          - destination:
+              # member cluster
+              kubeConfig:
+                secretRef:
+                  name: node-1
+                  key: value
               targetNamespace: default
             interval: 8m0s
             prune: true

--- a/controllers/fluxcd/constants.go
+++ b/controllers/fluxcd/constants.go
@@ -27,3 +27,7 @@ const (
 	// Kustomization stand for FluxCD Kustomization Application Type
 	Kustomization AppType = "Kustomization"
 )
+
+// DefaultKubeConfigKey is the Default key for kubeconfig
+// https://fluxcd.io/docs/components/helm/helmreleases/#remote-clusters--cluster-api
+const DefaultKubeConfigKey = "value"

--- a/controllers/fluxcd/multi-cluster-controller.go
+++ b/controllers/fluxcd/multi-cluster-controller.go
@@ -62,7 +62,7 @@ func (r *MultiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return
 	}
 
-	if err = r.reconcileCluster(cluster); err != nil {
+	if err = r.reconcileCluster(ctx, cluster); err != nil {
 		return
 	}
 
@@ -77,8 +77,7 @@ func ignore(cluster *unstructured.Unstructured) bool {
 	return true
 }
 
-func (r *MultiClusterReconciler) reconcileCluster(cluster *unstructured.Unstructured) (err error) {
-	ctx := context.Background()
+func (r *MultiClusterReconciler) reconcileCluster(ctx context.Context, cluster *unstructured.Unstructured) (err error) {
 	name := cluster.GetName()
 	nsList := &v1.NamespaceList{}
 	if err = r.getFluxAppNsList(ctx, nsList); err != nil {

--- a/controllers/fluxcd/multi-cluster-controller.go
+++ b/controllers/fluxcd/multi-cluster-controller.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fluxcd
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+//+kubebuilder:rbac:groups=cluster.kubesphere.io,resources=clusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;create;update
+
+// MultiClusterReconciler represents a controller to sync cluster to ArgoCD cluster
+type MultiClusterReconciler struct {
+	client.Client
+	log      logr.Logger
+	recorder record.EventRecorder
+}
+
+// Reconcile sync the cluster.kubesphere.io/clusters to kubeconfig secret
+// in DevopsProject Namespaces where Flux Application(HelmRelease and Kustomization) exist.
+func (r *MultiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	r.log.Info(fmt.Sprintf("start to reconcile member cluster kubeconfig: %s", req.String()))
+
+	cluster := createBareClusterObject()
+	if err = r.Get(ctx, req.NamespacedName, cluster); err != nil {
+		err = client.IgnoreNotFound(err)
+		return
+	}
+
+	// ignore the host cluster
+	if ignore(cluster) {
+		return
+	}
+
+	if err = r.reconcileCluster(cluster); err != nil {
+		return
+	}
+
+	return
+}
+
+func ignore(cluster *unstructured.Unstructured) bool {
+	if cluster != nil {
+		_, ok := cluster.GetLabels()["cluster-role.kubesphere.io/host"]
+		return ok
+	}
+	return true
+}
+
+func (r *MultiClusterReconciler) reconcileCluster(cluster *unstructured.Unstructured) (err error) {
+	ctx := context.Background()
+	name := cluster.GetName()
+	nsList := &v1.NamespaceList{}
+	if err = r.getFluxAppNsList(ctx, nsList); err != nil {
+		return
+	}
+
+	for _, ns := range nsList.Items {
+		secret := &v1.Secret{}
+		if err = r.Get(ctx, types.NamespacedName{Namespace: ns.GetName(), Name: name}, secret); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return
+			}
+			// not found kubeconfig
+			// create
+			newSecret := &v1.Secret{
+				Type: "Opaque",
+			}
+			setKubeConfig(newSecret, cluster)
+			newSecret.SetNamespace(ns.GetName())
+			newSecret.SetName(name)
+			newSecret.SetLabels(map[string]string{
+				"app.kubernetes.io/managed-by": v1alpha1.GroupName,
+			})
+			newSecret.SetOwnerReferences([]metav1.OwnerReference{
+				{
+					APIVersion: "cluster.kubesphere.io/v1alpha1",
+					Kind:       "Cluster",
+					Name:       cluster.GetName(),
+					UID:        cluster.GetUID(),
+				},
+			})
+			if err = r.Create(ctx, newSecret); err != nil {
+				return
+			}
+			r.log.Info("Create member cluster kubeconfig", "name", newSecret.GetName())
+			r.recorder.Eventf(newSecret, v1.EventTypeNormal, "Created", "Created Secret %s", newSecret.GetName())
+		} else {
+			// found kubeconfig
+			// update
+			newSecret := &v1.Secret{}
+			setKubeConfig(newSecret, cluster)
+			secret.StringData = newSecret.StringData
+			if err = r.Update(ctx, secret); err != nil {
+				return
+			}
+			r.log.Info("Update member cluster kubeconfig", "name", secret.GetName())
+			r.recorder.Eventf(secret, v1.EventTypeNormal, "Updated", "Created Secret %s", secret.GetName())
+		}
+	}
+	return
+}
+
+func setKubeConfig(secret *v1.Secret, cluster *unstructured.Unstructured) {
+	kubeconfig, _, _ := unstructured.NestedString(cluster.Object, "spec", "connection", "kubeconfig")
+	secret.StringData = map[string]string{
+		// set the default key that fluxApp(HelmRelease and Kustomization) need.
+		DefaultKubeConfigKey: base64DecodeWithoutErrorCheck(kubeconfig),
+	}
+}
+
+func base64DecodeWithoutErrorCheck(str string) string {
+	data, _ := base64.StdEncoding.DecodeString(str)
+	return string(data)
+}
+
+// getFluxAppNs get the namespaces where the fluxApp (HelmRelease or Kustomization) existed.
+// The secret must be in the same namespace as the fluxApp.
+func (r *MultiClusterReconciler) getFluxAppNsList(ctx context.Context, nsList *v1.NamespaceList) (err error) {
+	devops, _ := labels.NewRequirement("kubesphere.io/devopsproject", selection.Exists, nil)
+	selector := labels.NewSelector().Add(*devops)
+	if err = r.List(ctx, nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return
+	}
+	return
+}
+
+// GetName returns the name of this controller
+func (r *MultiClusterReconciler) GetName() string {
+	return "FluxCDMultiClusterController"
+}
+
+func createBareClusterObject() *unstructured.Unstructured {
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cluster.kubesphere.io",
+		Version: "v1alpha1",
+		Kind:    "Cluster",
+	})
+	return cluster
+}
+
+// SetupWithManager init the logger, recorder and filters
+func (r *MultiClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	cluster := createBareClusterObject()
+	r.log = ctrl.Log.WithName(r.GetName())
+	r.recorder = mgr.GetEventRecorderFor(r.GetName())
+	return ctrl.NewControllerManagedBy(mgr).
+		For(cluster).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		Complete(r)
+}

--- a/controllers/fluxcd/multi-cluster-controller_test.go
+++ b/controllers/fluxcd/multi-cluster-controller_test.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fluxcd
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"kubesphere.io/devops/controllers/core"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_ignore(t *testing.T) {
+	sampleCluster := &unstructured.Unstructured{}
+	sampleCluster.SetKind("Cluster")
+	sampleCluster.SetAPIVersion("cluster.kubesphere.io/v1alpha1")
+
+	type args struct {
+		cluster func() *unstructured.Unstructured
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{{
+		name: "cluster is nil",
+		want: true,
+	}, {
+		name: "cluster without the particular label",
+		args: args{cluster: func() *unstructured.Unstructured {
+			return sampleCluster.DeepCopy()
+		}},
+		want: false,
+	}, {
+		name: "with the particular label",
+		args: args{cluster: func() *unstructured.Unstructured {
+			cluster := sampleCluster.DeepCopy()
+			cluster.SetLabels(map[string]string{
+				"cluster-role.kubesphere.io/host": "",
+			})
+			return cluster
+		}},
+		want: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cluster *unstructured.Unstructured
+			if tt.args.cluster != nil {
+				cluster = tt.args.cluster()
+			}
+			assert.Equalf(t, tt.want, ignore(cluster), "ignore(%v)", tt.args.cluster)
+		})
+	}
+}
+
+func TestMultiClusterReconciler_Reconcile(t *testing.T) {
+	schema, err := v1alpha1.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+	err = v1.SchemeBuilder.AddToScheme(schema)
+	assert.Nil(t, err)
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: "fake-cluster",
+		},
+	}
+
+	memberCluster := createBareClusterObject()
+	memberCluster.SetName("fake-cluster")
+
+	hostCluster := memberCluster.DeepCopy()
+	hostCluster.SetLabels(map[string]string{
+		"cluster-role.kubesphere.io/host": "",
+	})
+
+	devopsNs := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fake-devops-project-ns",
+			Labels: map[string]string{
+				"kubesphere.io/devopsproject": "fake-devops-project-ns",
+			},
+		},
+	}
+
+	type fields struct {
+		Client client.Client
+		log    logr.Logger
+	}
+	type args struct {
+		req ctrl.Request
+	}
+
+	tests := []struct {
+		name string
+		fields
+		args
+		verify func(t *testing.T, c client.Client, err error)
+	}{
+		{
+			name: "not found cluster",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(nil),
+				log:    logr.New(log.NullLogSink{}),
+			},
+			args: args{
+				req: req,
+			},
+			verify: func(t *testing.T, c client.Client, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			name: "found a hostCluster",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(nil, hostCluster.DeepCopy()),
+				log:    logr.New(log.NullLogSink{}),
+			},
+			args: args{
+				req: req,
+			},
+			verify: func(t *testing.T, c client.Client, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			name: "found a memberCluster",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, memberCluster.DeepCopy(), devopsNs.DeepCopy()),
+				log:    logr.New(log.NullLogSink{}),
+			},
+			args: args{
+				req: req,
+			},
+			verify: func(t *testing.T, c client.Client, err error) {
+				assert.Nil(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &MultiClusterReconciler{
+				Client:   tt.fields.Client,
+				log:      tt.fields.log,
+				recorder: &record.FakeRecorder{},
+			}
+			_, err := r.Reconcile(context.Background(), tt.args.req)
+			tt.verify(t, tt.fields.Client, err)
+		})
+	}
+}
+
+func TestMultiClusterReconciler_reconcileCluster(t *testing.T) {
+	schema, err := v1alpha1.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+	err = v1.SchemeBuilder.AddToScheme(schema)
+	assert.Nil(t, err)
+
+	fakeKubeConfig := "fake-kubeconfig-data"
+	base64Str := base64.StdEncoding.EncodeToString([]byte(fakeKubeConfig))
+	memberCluster := createBareClusterObject()
+	_ = unstructured.SetNestedField(memberCluster.Object, base64Str, "spec", "connection", "kubeconfig")
+
+	memberCluster.SetName("fake-cluster")
+
+	newFakeKubeConfig := "new-fake-kubeconfig-data"
+	NewBase64Str := base64.StdEncoding.EncodeToString([]byte(newFakeKubeConfig))
+	newMemberCluster := memberCluster.DeepCopy()
+	_ = unstructured.SetNestedField(newMemberCluster.Object, NewBase64Str, "spec", "connection", "kubeconfig")
+
+	oldSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-cluster",
+			Namespace: "fake-devops-project-ns",
+		},
+		Type: "Opaque",
+		StringData: map[string]string{
+			DefaultKubeConfigKey: base64.StdEncoding.EncodeToString([]byte("fake-kubeconfig-data")),
+		},
+	}
+
+	hostCluster := memberCluster.DeepCopy()
+	hostCluster.SetLabels(map[string]string{
+		"cluster-role.kubesphere.io/host": "",
+	})
+
+	type fields struct {
+		Client client.Client
+		log    logr.Logger
+	}
+	type args struct {
+		cluster *unstructured.Unstructured
+	}
+
+	devopsProjectNs := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fake-devops-project-ns",
+			Labels: map[string]string{
+				"kubesphere.io/devopsproject": "fake-devops-project-ns",
+			},
+		},
+	}
+
+	anotherDevopsProjectNs := devopsProjectNs.DeepCopy()
+	anotherDevopsProjectNs.SetName("another-fake-devops-project-ns")
+
+	tests := []struct {
+		name string
+		fields
+		args
+		verify func(t *testing.T, c client.Client, err error)
+	}{
+		{
+			name: "there is no devops project namespace",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema),
+				log:    logr.New(log.NullLogSink{}),
+			},
+			args: args{
+				cluster: memberCluster.DeepCopy(),
+			},
+			verify: func(t *testing.T, Client client.Client, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			name: "create kubeconfig secret in devops project namespaces",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, devopsProjectNs.DeepCopy(), anotherDevopsProjectNs.DeepCopyObject()),
+				log:    logr.New(log.NullLogSink{}),
+			},
+			args: args{
+				cluster: memberCluster.DeepCopy(),
+			},
+			verify: func(t *testing.T, c client.Client, err error) {
+				assert.Nil(t, err)
+				secret := &v1.Secret{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Namespace: "fake-devops-project-ns",
+					Name:      "fake-cluster",
+				}, secret)
+				assert.Nil(t, err)
+				assert.Equal(t, fakeKubeConfig, secret.StringData[DefaultKubeConfigKey])
+
+				anotherSecret := &v1.Secret{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Namespace: "another-fake-devops-project-ns",
+					Name:      "fake-cluster",
+				}, anotherSecret)
+				assert.Nil(t, err)
+				assert.Equal(t, fakeKubeConfig, anotherSecret.StringData[DefaultKubeConfigKey])
+			},
+		},
+		{
+			name: "update a kubeconfig secret",
+			fields: fields{
+				Client: fake.NewFakeClientWithScheme(schema, memberCluster.DeepCopy(), devopsProjectNs.DeepCopy(), anotherDevopsProjectNs.DeepCopyObject(), oldSecret.DeepCopy()),
+				log:    logr.New(log.NullLogSink{}),
+			},
+			args: args{
+				cluster: newMemberCluster.DeepCopy(),
+			},
+			verify: func(t *testing.T, c client.Client, err error) {
+				assert.Nil(t, err)
+				secret := &v1.Secret{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Namespace: "fake-devops-project-ns",
+					Name:      "fake-cluster",
+				}, secret)
+				assert.Nil(t, err)
+				assert.Equal(t, newFakeKubeConfig, secret.StringData[DefaultKubeConfigKey])
+
+				anotherSecret := &v1.Secret{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Namespace: "another-fake-devops-project-ns",
+					Name:      "fake-cluster",
+				}, anotherSecret)
+				assert.Nil(t, err)
+				assert.Equal(t, newFakeKubeConfig, anotherSecret.StringData[DefaultKubeConfigKey])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &MultiClusterReconciler{
+				Client:   tt.fields.Client,
+				log:      tt.fields.log,
+				recorder: &record.FakeRecorder{},
+			}
+
+			err := r.reconcileCluster(tt.args.cluster)
+			tt.verify(t, tt.fields.Client, err)
+		})
+	}
+}
+
+func TestMultiClusterReconciler_GetName(t *testing.T) {
+	r := &MultiClusterReconciler{}
+	assert.Equal(t, "FluxCDMultiClusterController", r.GetName())
+}
+
+func TestMultiClusterReconciler_SetupWithManager(t *testing.T) {
+	schema, err := v1alpha1.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+
+	type fields struct {
+		Client client.Client
+		log    logr.Logger
+	}
+	type args struct {
+		mgr ctrl.Manager
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{{
+		name: "normal",
+		args: args{
+			mgr: &core.FakeManager{
+				Scheme: schema,
+				Client: fake.NewFakeClientWithScheme(schema),
+			},
+		},
+		wantErr: core.NoErrors,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &MultiClusterReconciler{
+				Client:   tt.fields.Client,
+				log:      tt.fields.log,
+				recorder: &record.FakeRecorder{},
+			}
+			tt.wantErr(t, r.SetupWithManager(tt.args.mgr), fmt.Sprintf("SetupWithManager(%v)", tt.args.mgr))
+		})
+	}
+}

--- a/controllers/fluxcd/multi-cluster-controller_test.go
+++ b/controllers/fluxcd/multi-cluster-controller_test.go
@@ -315,7 +315,7 @@ func TestMultiClusterReconciler_reconcileCluster(t *testing.T) {
 				recorder: &record.FakeRecorder{},
 			}
 
-			err := r.reconcileCluster(tt.args.cluster)
+			err := r.reconcileCluster(context.Background(), tt.args.cluster)
 			tt.verify(t, tt.fields.Client, err)
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?

/kind feature


### What this PR does / why we need it:
Add **fluxcd/multi-cluster-controller** to sync the _cluster.kubesphere.io/clusters_ and kubeconfig secret which FluxCD Application(_[Kustomization](https://github.com/fluxcd/kustomize-controller/blob/d6688648df46139a97f273138ccd5fc1d69d46b5/api/v1beta2/kustomization_types.go#L67)_ and _[HelmRelease](https://github.com/fluxcd/helm-controller/blob/a2147639031eb1362360b52c6f596c066270ecc4/api/v2beta1/helmrelease_types.go#L84)_) needs for Multi-Cluster Management. 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #767 

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [x] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
