### PR TITLE
Fix the Jenkins cron expression check error

### DIFF
--- a/pkg/client/devops/jenkins/devops_test.go
+++ b/pkg/client/devops/jenkins/devops_test.go
@@ -30,12 +30,28 @@ func Test_parseCronJobTime(t *testing.T) {
 		Input    string
 		Expected Except
 	}{
-		{"上次运行的时间 Tuesday, September 10, 2019 8:59:09 AM UTC; 下次运行的时间 Tuesday, September 10, 2019 9:14:09 AM UTC.", Except{Last: "2019-09-10T08:59:09Z", Next: "2019-09-10T09:14:09Z"}},
-		{"上次运行的时间 Thursday, January 3, 2019 11:56:30 PM UTC; 下次运行的时间 Friday, January 3, 2020 12:11:30 AM UTC.", Except{Last: "2019-01-03T23:56:30Z", Next: "2020-01-03T00:11:30Z"}},
-		{"上次运行的时间 Tuesday, September 10, 2019 8:41:34 AM UTC; 下次运行的时间 Tuesday, September 10, 2019 9:41:34 AM UTC.", Except{Last: "2019-09-10T08:41:34Z", Next: "2019-09-10T09:41:34Z"}},
-		{"上次运行的时间 Tuesday, September 10, 2019 9:15:26 AM UTC; 下次运行的时间 Tuesday, September 10, 2019 10:03:26 AM UTC.", Except{Last: "2019-09-10T09:15:26Z", Next: "2019-09-10T10:03:26Z"}},
-		{"Would last have run at Tuesday, September 10, 2019 9:15:26 AM UTC; would next run at Tuesday, September 10, 2019 10:03:26 AM UTC.", Except{Last: "2019-09-10T09:15:26Z", Next: "2019-09-10T10:03:26Z"}},
-		{"Would last have run at Tuesday, September 10, 2019 8:41:34 AM UTC; would next run at Tuesday, September 10, 2019 9:41:34 AM UTC.", Except{Last: "2019-09-10T08:41:34Z", Next: "2019-09-10T09:41:34Z"}},
+		{
+			Input:    "上次运行的时间 Tuesday, September 10, 2019 8:59:09 AM UTC; 下次运行的时间 Tuesday, September 10, 2019 9:14:09 AM UTC.",
+			Expected: Except{Last: "2019-09-10T08:59:09Z", Next: "2019-09-10T09:14:09Z"}},
+		{
+			Input:    "上次运行的时间 Thursday, January 3, 2019 11:56:30 PM UTC; 下次运行的时间 Friday, January 3, 2020 12:11:30 AM UTC.",
+			Expected: Except{Last: "2019-01-03T23:56:30Z", Next: "2020-01-03T00:11:30Z"}},
+		{
+			Input:    "上次运行的时间 Tuesday, September 10, 2019 8:41:34 AM UTC; 下次运行的时间 Tuesday, September 10, 2019 9:41:34 AM UTC.",
+			Expected: Except{Last: "2019-09-10T08:41:34Z", Next: "2019-09-10T09:41:34Z"}},
+		{
+			Input:    "上次运行的时间 Tuesday, September 10, 2019 9:15:26 AM UTC; 下次运行的时间 Tuesday, September 10, 2019 10:03:26 AM UTC.",
+			Expected: Except{Last: "2019-09-10T09:15:26Z", Next: "2019-09-10T10:03:26Z"}},
+		{
+			Input:    "上次运行的时间 Tuesday, August 16, 2022 at 12:09:37 AM Coordinated Universal Time; 下次运行的时间 Wednesday, August 17, 2022 at 12:09:37 AM Coordinated Universal Time.",
+			Expected: Except{Last: "2022-08-16T00:09:37Z", Next: "2022-08-17T00:09:37Z"}},
+		{
+			Input:    "Would last have run at Tuesday, September 10, 2019 9:15:26 AM UTC; would next run at Tuesday, September 10, 2019 10:03:26 AM UTC.",
+			Expected: Except{Last: "2019-09-10T09:15:26Z", Next: "2019-09-10T10:03:26Z"}},
+		{
+			Input:    "Would last have run at Tuesday, September 10, 2019 8:41:34 AM UTC; would next run at Tuesday, September 10, 2019 9:41:34 AM UTC.",
+			Expected: Except{Last: "2019-09-10T08:41:34Z", Next: "2019-09-10T09:41:34Z"},
+		},
 	}
 
 	for _, item := range Items {
@@ -51,6 +67,5 @@ func Test_parseCronJobTime(t *testing.T) {
 		if next != item.Expected.Next {
 			t.Errorf("got %#v, expected %#v", next, item.Expected.Next)
 		}
-
 	}
 }

--- a/pkg/client/devops/jenkins/pipeline.go
+++ b/pkg/client/devops/jenkins/pipeline.go
@@ -824,7 +824,8 @@ func interanlErrorMessage() *devops.CheckCronRes {
 }
 
 func parseCronJobTime(msg string) (string, string, error) {
-
+	msg = strings.ReplaceAll(msg, "Coordinated Universal Time", "UTC")
+	msg = strings.ReplaceAll(msg, " at ", " ")
 	times := strings.Split(msg, ";")
 
 	lastTmp := strings.Split(times[0], " ")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
The cron expression check failed due to Jenkins made some changes.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #661

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
