### PR TITLE
Update nightly-build workflow

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -8,7 +8,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  check:
+    runs-on: ubuntu-20.04
+    outputs:
+      status: ${{ steps.early.outputs.status}}
+    steps:
+      - name: Early exit
+        id: early
+        run: |
+          if [ "${{ secrets.GHCR_TOKEN }}" != "" ]
+          then
+            echo "::set-output name=status::success"
+          else
+            echo "::set-output name=status::fail"
+          fi
+
   BuildController:
+    needs:
+      - check
+    if: needs.check.outputs.status == 'success'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -38,20 +56,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
       - name: Login to GHCR
-        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: kubesphere-sigs
-          password: ${{ secrets.GHCR_TOKEN_NIGHTLY }}
+          password: ${{ secrets.GHCR_TOKEN }}
       - name: login to GHCR for Contributors
-        if: github.event_name != 'pull_request' && github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere' 
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -63,20 +81,23 @@ jobs:
         with:
           file: config/dockerfiles/controller-manager/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
       - name: Build and push Docker images for Contributors
         uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere' 
         with:
           file: config/dockerfiles/controller-manager/Dockerfile
           tags: ${{ steps.metaContributors.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           labels: ${{ steps.metaContributors.outputs.labels }}
           platforms: linux/amd64,linux/arm64
 
   BuildAPIServer:
+    needs:
+      - check
+    if: needs.check.outputs.status == 'success'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -106,20 +127,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
       - name: Login to GHCR
-        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: kubesphere-sigs
-          password: ${{ secrets.GHCR_TOKEN_NIGHTLY }}
+          password: ${{ secrets.GHCR_TOKEN }}
       - name: login to GHCR for Contributors
-        if: github.event_name != 'pull_request' && github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere' 
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -131,20 +152,23 @@ jobs:
         with:
           file: config/dockerfiles/apiserver/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
       - name: Build and push Docker images for Contributors
         uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere' 
         with:
           file: config/dockerfiles/apiserver/Dockerfile
           tags: ${{ steps.metaContributors.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           labels: ${{ steps.metaContributors.outputs.labels }}
           platforms: linux/amd64,linux/arm64
 
   BuildTools:
+    needs:
+      - check
+    if: needs.check.outputs.status == 'success'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -174,20 +198,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
       - name: Login to GHCR
-        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+        if: github.repository_owner == 'kubesphere'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: kubesphere-sigs
-          password: ${{ secrets.GHCR_TOKEN_NIGHTLY }}
+          password: ${{ secrets.GHCR_TOKEN }}
       - name: login to GHCR for Contributors
-        if: github.event_name != 'pull_request' && github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere' 
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -199,15 +223,15 @@ jobs:
         with:
           file: config/dockerfiles/tools/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
       - name: Build and push Docker images for Contributors
         uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
+        if: github.repository_owner != 'kubesphere' 
         with:
           file: config/dockerfiles/tools/Dockerfile
           tags: ${{ steps.metaContributors.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           labels: ${{ steps.metaContributors.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -174,7 +174,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           images: |
             kubespheredev/devops-controller
-            ghcr.io/${{ github.repository_owner }}/devops-controller
+            ghcr.io/kubesphere-sigs/devops-controller
           tags: |
             type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
             type=raw,enable=true,value=nightly-{{date 'YYYYMMDD'}}
@@ -44,7 +44,14 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: kubesphere-sigs
+          password: ${{ secrets.GHCR_TOKEN_NIGHTLY }}
+      - name: login to GHCR for Contributors
+        if: github.event_name != 'pull_request' && github.repository_owner != 'kubesphere'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -80,7 +87,7 @@ jobs:
         with:
           images: |
             kubespheredev/devops-apiserver
-            ghcr.io/${{ github.repository_owner }}/devops-apiserver
+            ghcr.io/kubesphere-sigs/devops-apiserver
           tags: |
             type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
             type=raw,enable=true,value=nightly-{{date 'YYYYMMDD'}}
@@ -105,7 +112,14 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: kubesphere-sigs
+          password: ${{ secrets.GHCR_TOKEN_NIGHTLY }}
+      - name: login to GHCR for Contributors
+        if: github.event_name != 'pull_request' && github.repository_owner != 'kubesphere'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -141,7 +155,7 @@ jobs:
         with:
           images: |
             kubespheredev/devops-tools
-            ghcr.io/${{ github.repository_owner }}/devops-tools
+            ghcr.io/kubesphere-sigs/devops-tools
           tags: |
             type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
             type=raw,enable=true,value=nightly-{{date 'YYYYMMDD'}}
@@ -166,7 +180,14 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: kubesphere-sigs
+          password: ${{ secrets.GHCR_TOKEN_NIGHTLY }}
+      - name: login to GHCR for Contributors
+        if: github.event_name != 'pull_request' && github.repository_owner != 'kubesphere'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?

/kind chore

### What this PR does / why we need it:
- Change the destination of nightly-build container images from `ghcr.io/kubesphere` to `ghcr.io/kubesphere-nightly`.
- Remain the `ghcr.io/${{ github.repository_owner }}` destination registry for contributors.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #419 

### Special notes for reviewers:
Should create **a new repo** and add the **`GHCR_TOKEN_NIGHTLY`** secret.

Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
