### PR TITLE
Support to set the cluster name

### DIFF
--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -144,6 +144,7 @@ func getAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 			err := (&gitrepository.PullRequestStatusReconciler{
 				Client:          mgr.GetClient(),
 				ExternalAddress: s.FeatureOptions.ExternalAddress,
+				ClusterName:     s.FeatureOptions.ClusterName,
 			}).SetupWithManager(mgr)
 			if err != nil {
 				return err

--- a/cmd/controller/app/options/feature.go
+++ b/cmd/controller/app/options/feature.go
@@ -29,6 +29,7 @@ type FeatureOptions struct {
 	Controllers     map[string]bool
 	SystemNamespace string
 	ExternalAddress string
+	ClusterName     string
 }
 
 // GetControllers returns the controllers map
@@ -79,6 +80,7 @@ func (o *FeatureOptions) AddFlags(fs *pflag.FlagSet, c *FeatureOptions) {
 	fs.StringVarP(&o.SystemNamespace, "system-namespace", "", "kubesphere-devops-system",
 		"The system namespace that contains ConfigMap, Secrets e.g.")
 	fs.StringVarP(&o.ExternalAddress, "external-address", "", "", "The external address for the UI")
+	fs.StringVarP(&o.ClusterName, "cluster-name", "", "default", "Current cluster name")
 }
 
 func (o *FeatureOptions) knownControllers() []string {

--- a/cmd/controller/app/options/feature_test.go
+++ b/cmd/controller/app/options/feature_test.go
@@ -119,4 +119,5 @@ func TestFeatureOptions(t *testing.T) {
 	assert.NotNil(t, flagSet.Lookup("enabled-controllers"))
 	assert.NotNil(t, flagSet.Lookup("system-namespace"))
 	assert.NotNil(t, flagSet.Lookup("external-address"))
+	assert.NotNil(t, flagSet.Lookup("cluster-name"))
 }

--- a/controllers/gitrepository/pull_request_status_controller.go
+++ b/controllers/gitrepository/pull_request_status_controller.go
@@ -35,6 +35,7 @@ import (
 type PullRequestStatusReconciler struct {
 	client.Client
 	ExternalAddress string
+	ClusterName     string
 
 	log      logr.Logger
 	recorder record.EventRecorder
@@ -150,8 +151,9 @@ func getRepoInfo(repo *v1alpha3.MultiBranchPipeline) (info repoInfo) {
 func (r *PullRequestStatusReconciler) getExternalPipelineRunAddress(ctx context.Context, pipelineRun *v1alpha3.PipelineRun) (target string, err error) {
 	var ws string
 	if ws, err = r.getWorkspace(ctx, pipelineRun.GetNamespace()); err == nil {
-		target = fmt.Sprintf("%s/%s/clusters/default/devops/%s/pipelines/%s/run/%s/task-status",
-			net.ParseURL(r.ExternalAddress), ws, pipelineRun.Namespace, pipelineRun.Spec.PipelineRef.Name, pipelineRun.Name)
+		target = fmt.Sprintf("%s/%s/clusters/%s/devops/%s/pipelines/%s/branch/%s/run/%s/task-status",
+			net.ParseURL(r.ExternalAddress), ws, r.ClusterName,
+			pipelineRun.Namespace, pipelineRun.Spec.PipelineRef.Name, pipelineRun.Spec.SCM.RefName, pipelineRun.Name)
 	}
 	return
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
