### PR TITLE
Fix the webhook settings doc errors

### DIFF
--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -14,7 +14,7 @@ There are two types of Jenkins based Pipelines: regular or multi-branch Pipeline
 the server will search all Pipelines by the Git URL, then trigger the scan action if it's a multi-branch Pipeline,
 or create a new PipelineRun if there is an annotation key-value likes the following one:
 ```
-scm.devops.kubesphere.io=https=https://github.com/linuxsuren/tools
+scm.devops.kubesphere.io=https://github.com/linuxsuren/tools
 ```
 
 In case you only want some Pipelines to be triggered when specific branches changed. You can add an annotation:
@@ -25,6 +25,11 @@ scm.devops.kubesphere.io/ref='["master","fea-.*"]'
 The webhook address is:
 ```
 http://ip:port/v1alpha3/webhooks/scm
+```
+
+or, please use the following link if you're using ks-devops in KubeSphere:
+```
+http://ip:port/kapis/clusters/{cluster}/devops.kubesphere.io/v1alpha3/webhooks/scm
 ```
 
 ### Using webhook locally


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
