### PR TITLE
Fix nil pointer issue when building helmchart

### DIFF
--- a/controllers/fluxcd/application-controller.go
+++ b/controllers/fluxcd/application-controller.go
@@ -33,6 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"time"
 )
 
 //+kubebuilder:rbac:groups=gitops.kubesphere.io,resources=applications,verbs=watch;get;list
@@ -396,7 +397,7 @@ func buildTemplateFromApp(fluxApp *v1alpha1.FluxApplication) (*sourcev1.HelmChar
 			},
 			Chart:             c.Chart,
 			Version:           c.Version,
-			Interval:          *c.Interval,
+			Interval:          convertInterval(c.Interval),
 			ReconcileStrategy: c.ReconcileStrategy,
 			ValuesFiles:       c.ValuesFiles,
 		},
@@ -490,6 +491,13 @@ func convertKubeconfig(kubeconfig *helmv2.KubeConfig) *kusv1.KubeConfig {
 		return nil
 	}
 	return &kusv1.KubeConfig{SecretRef: kubeconfig.SecretRef}
+}
+
+func convertInterval(interval *metav1.Duration) metav1.Duration {
+	if interval == nil {
+		return metav1.Duration{Duration: 10 * time.Minute}
+	}
+	return *interval
 }
 
 func checkFluxApp(fluxApp *v1alpha1.FluxApplication) (err error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

We should provide the nil pointer check and set a default value (10m0s) to the HelmChart's Interval field.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
