### PR TITLE
Support to store PipelineRun data into ConfigMap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,9 @@ generate-listers:
 
 # Build the docker image of controller-manager
 docker-build-controller:
-	${CONTAINER_CLI} build . -f config/dockerfiles/controller-manager/Dockerfile -t ${CONTROLLER_IMG}
+	${CONTAINER_CLI} build . -f config/dockerfiles/controller-manager/Dockerfile --build-arg GOPROXY=${GOPROXY} -t ${CONTROLLER_IMG}
+build-controller:
+	buildctl build --frontend dockerfile.v0 --local dockerfile=config/dockerfiles/controller-manager/
 
 # Push the docker image of controller-manager
 docker-push-controller:
@@ -98,7 +100,7 @@ run-apiserver:
 	go run cmd/apiserver/apiserver.go
 # Build the docker image of apiserver
 docker-build-apiserver:
-	${CONTAINER_CLI} build . -f config/dockerfiles/apiserver/Dockerfile -t ${APISERVER_IMG}
+	${CONTAINER_CLI} build . -f config/dockerfiles/apiserver/Dockerfile --build-arg GOPROXY=${GOPROXY} -t ${APISERVER_IMG}
 
 # Push the docker image of controller-manager
 docker-push-apiserver:
@@ -109,7 +111,7 @@ docker-build-push-apiserver: docker-build-apiserver docker-push-apiserver
 
 # Build the docker image of apiserver
 docker-build-tools:
-	${CONTAINER_CLI} build . -f config/dockerfiles/tools/Dockerfile -t ${TOOLS_IMG}
+	${CONTAINER_CLI} build . -f config/dockerfiles/tools/Dockerfile --build-arg GOPROXY=${GOPROXY} -t ${TOOLS_IMG}
 
 # Push the docker image of controller-manager
 docker-push-tools:

--- a/cmd/controller/app/options/feature.go
+++ b/cmd/controller/app/options/feature.go
@@ -26,10 +26,11 @@ import (
 
 // FeatureOptions provide some feature options, such as specifying the controller to be enabled.
 type FeatureOptions struct {
-	Controllers     map[string]bool
-	SystemNamespace string
-	ExternalAddress string
-	ClusterName     string
+	Controllers          map[string]bool
+	SystemNamespace      string
+	ExternalAddress      string
+	ClusterName          string
+	PipelineRunDataStore string
 }
 
 // GetControllers returns the controllers map
@@ -81,6 +82,8 @@ func (o *FeatureOptions) AddFlags(fs *pflag.FlagSet, c *FeatureOptions) {
 		"The system namespace that contains ConfigMap, Secrets e.g.")
 	fs.StringVarP(&o.ExternalAddress, "external-address", "", "", "The external address for the UI")
 	fs.StringVarP(&o.ClusterName, "cluster-name", "", "default", "Current cluster name")
+	fs.StringVarP(&o.PipelineRunDataStore, "pipelinerun-data-store", "", "configmap",
+		"The data store type of the PipelineRun data, could be empty or configmap")
 }
 
 func (o *FeatureOptions) knownControllers() []string {

--- a/cmd/controller/app/options/feature_test.go
+++ b/cmd/controller/app/options/feature_test.go
@@ -120,4 +120,5 @@ func TestFeatureOptions(t *testing.T) {
 	assert.NotNil(t, flagSet.Lookup("system-namespace"))
 	assert.NotNil(t, flagSet.Lookup("external-address"))
 	assert.NotNil(t, flagSet.Lookup("cluster-name"))
+	assert.NotNil(t, flagSet.Lookup("pipelinerun-data-store"))
 }

--- a/pkg/store/configmap/pipelinerun.go
+++ b/pkg/store/configmap/pipelinerun.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubesphere.io/devops/pkg/store/store"
+	"kubesphere.io/devops/pkg/utils/k8sutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConfigMapStore represents a key-value store base on ConfigMap
+type ConfigMapStore struct {
+	ctx       context.Context
+	k8sClient client.Client
+
+	cache *v1.ConfigMap
+	owner metav1.OwnerReference
+}
+
+// NewConfigMapStore creates a PipelineRun data store
+func NewConfigMapStore(ctx context.Context, key client.ObjectKey, k8sClient client.Client) (
+	result store.ConfigMapStore, err error) {
+	cm := &v1.ConfigMap{Data: map[string]string{}}
+	cm.Namespace = key.Namespace
+	cm.Name = key.Name
+	if err = k8sClient.Get(ctx, key, cm); err != nil {
+		err = client.IgnoreNotFound(err)
+	}
+
+	result = &ConfigMapStore{
+		cache:     cm,
+		k8sClient: k8sClient,
+		ctx:       ctx,
+	}
+	return
+}
+
+// GetStages returns the stage data
+func (s *ConfigMapStore) GetStages() string {
+	return s.Get(store.DataKeyStage)
+}
+
+// SetStages stores the stage data
+func (s *ConfigMapStore) SetStages(stages string) {
+	s.Set(store.DataKeyStage, stages)
+}
+
+// GetStatus returns the status
+func (s *ConfigMapStore) GetStatus() string {
+	return s.Get(store.DataKeyStatus)
+}
+
+// SetStatus stores the status
+func (s *ConfigMapStore) SetStatus(status string) {
+	s.Set(store.DataKeyStatus, status)
+}
+
+// GetStepLog returns the step log
+func (s *ConfigMapStore) GetStepLog(stage, step int) string {
+	return s.Get(store.StepLogKey(stage, step))
+}
+
+// SetStepLog stores the step log
+func (s *ConfigMapStore) SetStepLog(stage, step int, log string) {
+	s.Set(store.StepLogKey(stage, step), log)
+}
+
+// GetAllLog returns the whole log
+func (s *ConfigMapStore) GetAllLog() string {
+	return s.Get(store.DataKeyAllLog)
+}
+
+// SetAllLog store the whole log
+func (s *ConfigMapStore) SetAllLog(log string) {
+	s.Set(store.DataKeyAllLog, log)
+}
+
+// Get returns the value by a key
+func (s *ConfigMapStore) Get(key string) string {
+	return s.cache.Data[key]
+}
+
+// Set puts a key and value
+func (s *ConfigMapStore) Set(key, value string) {
+	s.cache.Data[key] = value
+}
+
+// Save puts the data into ConfigMap via Kubernetes client
+func (s *ConfigMapStore) Save() (err error) {
+	// it might be a new ConfigMap or not
+	if s.cache.GetResourceVersion() == "" {
+		k8sutil.SetOwnerReference(s.cache, s.owner)
+		err = s.k8sClient.Create(s.ctx, s.cache)
+	} else {
+		err = s.k8sClient.Update(s.ctx, s.cache)
+	}
+	return
+}
+
+// SetOwnerReference set the owner reference
+func (s *ConfigMapStore) SetOwnerReference(owner metav1.OwnerReference) {
+	s.owner = owner
+}

--- a/pkg/store/configmap/pipelinerun_test.go
+++ b/pkg/store/configmap/pipelinerun_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"kubesphere.io/devops/pkg/store/store"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestConfigMapStore(t *testing.T) {
+	var err error
+	var cmStore store.ConfigMapStore
+	cmStore, err = NewConfigMapStore(context.Background(), types.NamespacedName{
+		Namespace: "ns",
+		Name:      "name",
+	}, fake.NewClientBuilder().Build())
+	assert.NotNil(t, cmStore)
+	assert.Nil(t, err)
+
+	cmStore.SetOwnerReference(v1.OwnerReference{})
+	assert.Nil(t, cmStore.Save())
+
+	assert.Empty(t, cmStore.GetStages())
+	cmStore.SetStages("stages")
+	assert.Equal(t, "stages", cmStore.GetStages())
+
+	assert.Empty(t, cmStore.GetStatus())
+	cmStore.SetStatus("status")
+	assert.Equal(t, "status", cmStore.GetStatus())
+
+	assert.Empty(t, cmStore.GetStepLog(1, 2))
+	cmStore.SetStepLog(1, 2, "step")
+	assert.Equal(t, "step", cmStore.GetStepLog(1, 2))
+
+	assert.Empty(t, cmStore.GetAllLog())
+	cmStore.SetAllLog("log")
+	assert.Equal(t, "log", cmStore.GetAllLog())
+
+	assert.Nil(t, cmStore.Save())
+}

--- a/pkg/store/fake/fake_core_test.go
+++ b/pkg/store/fake/fake_core_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFakeStore(t *testing.T) {
+	store := NewFakeStore()
+	assert.NotNil(t, store)
+
+	assert.Empty(t, store.Get("fake"))
+	store.Set("fake", "fake")
+	assert.Equal(t, "fake", store.Get("fake"))
+
+	assert.Empty(t, store.GetAllLog())
+	store.SetAllLog("log")
+	assert.Equal(t, "log", store.GetAllLog())
+
+	assert.Empty(t, store.GetStages())
+	store.SetStages("stages")
+	assert.Equal(t, "stages", store.GetStages())
+
+	assert.Empty(t, store.GetStatus())
+	store.SetStatus("status")
+	assert.Equal(t, "status", store.GetStatus())
+
+	assert.Empty(t, store.GetStepLog(1, 1))
+	store.SetStepLog(1, 1, "step")
+	assert.Equal(t, "step", store.GetStepLog(1, 1))
+
+	assert.Nil(t, store.Save())
+	assert.NotNil(t, store.WithError(errors.New("fake")).Save())
+}

--- a/pkg/store/fake/fake_store.go
+++ b/pkg/store/fake/fake_store.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import "kubesphere.io/devops/pkg/store/store"
+
+// FakeStore is a fake store
+type FakeStore struct {
+	data map[string]string
+	err  error
+}
+
+// NewFakeStore creates an instance of the fake store
+func NewFakeStore() *FakeStore {
+	return &FakeStore{
+		data: map[string]string{},
+	}
+}
+
+// WithError sets the error for expect error
+func (s *FakeStore) WithError(err error) *FakeStore {
+	s.err = err
+	return s
+}
+
+// Get is a fake method
+func (s *FakeStore) Get(key string) string {
+	return s.data[key]
+}
+
+// Set is a fake method
+func (s *FakeStore) Set(key, value string) {
+	s.data[key] = value
+}
+
+// Save is a fake method
+func (s *FakeStore) Save() error {
+	return s.err
+}
+
+// GetStages is a fake method
+func (s *FakeStore) GetStages() string {
+	return s.Get(store.DataKeyStage)
+}
+
+// SetStages is fake method
+func (s *FakeStore) SetStages(stages string) {
+	s.Set(store.DataKeyStage, stages)
+}
+
+// GetStatus is a fake method
+func (s *FakeStore) GetStatus() string {
+	return s.Get(store.DataKeyStatus)
+}
+
+// SetStatus is a fake method
+func (s *FakeStore) SetStatus(status string) {
+	s.Set(store.DataKeyStatus, status)
+}
+
+// GetStepLog is a fake method
+func (s *FakeStore) GetStepLog(stage, step int) string {
+	return s.Get(store.StepLogKey(stage, step))
+}
+
+// SetStepLog is a fake method
+func (s *FakeStore) SetStepLog(stage, step int, log string) {
+	s.Set(store.StepLogKey(stage, step), log)
+}
+
+// GetAllLog is a fake method
+func (s *FakeStore) GetAllLog() string {
+	return s.Get(store.DataKeyAllLog)
+}
+
+// SetAllLog is a fake method
+func (s *FakeStore) SetAllLog(log string) {
+	s.data[store.DataKeyAllLog] = log
+}

--- a/pkg/store/store/types.go
+++ b/pkg/store/store/types.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// DataKeyAllLog is the key of all log
+	DataKeyAllLog = "log-all"
+	// DataKeyStage is the key of stage data
+	DataKeyStage = "stage"
+	// DataKeyStatus is the key of status
+	DataKeyStatus = "status"
+)
+
+// StepLogKey generates a unique key by stage and step number
+func StepLogKey(stage, step int) string {
+	return fmt.Sprintf("log-step-%d-%d", stage, step)
+}
+
+// KeyValueStore represents a key-value store
+type KeyValueStore interface {
+	Get(key string) string
+	Set(key, value string)
+	Save() error
+}
+
+// PipelineRunDataStore represents a PipelineRun data store
+type PipelineRunDataStore interface {
+	KeyValueStore
+
+	GetStages() string
+	SetStages(stages string)
+	GetStatus() string
+	SetStatus(status string)
+	GetStepLog(stage, step int) string
+	SetStepLog(stage, step int, log string)
+	GetAllLog() string
+	SetAllLog(log string)
+}
+
+// ConfigMapStore represents a store base on a ConfigMap
+type ConfigMapStore interface {
+	PipelineRunDataStore
+	SetOwnerReference(owner metav1.OwnerReference)
+}

--- a/pkg/store/store/types_test.go
+++ b/pkg/store/store/types_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import "testing"
+
+func TestStepLogKey(t *testing.T) {
+	type args struct {
+		stage int
+		step  int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{{
+		name: "normal",
+		args: args{
+			stage: 1,
+			step:  2,
+		},
+		want: "log-step-1-2",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StepLogKey(tt.args.stage, tt.args.step); got != tt.want {
+				t.Errorf("StepLogKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
Support to store PipelineRun data into ConfigMap
```
