### PR TITLE
clean-up: Move ArgoCDOption into apiserverconfig

### DIFF
--- a/cmd/apiserver/app/server.go
+++ b/cmd/apiserver/app/server.go
@@ -36,9 +36,6 @@ func NewAPIServerCommand() (cmd *cobra.Command) {
 	// Load configuration from file
 	conf, err := config.TryLoadFromDisk()
 	if err == nil {
-		if conf.ArgoCDOption == nil {
-			conf.ArgoCDOption = &config.ArgoCDOption{}
-		}
 		s = &options.ServerRunOptions{
 			GenericServerRunOptions: s.GenericServerRunOptions,
 			Config:                  conf,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,6 +98,7 @@ func New() *Config {
 		KubernetesOptions: k8s.NewKubernetesOptions(),
 		S3Options:         s3.NewS3Options(),
 		AuthMode:          AuthModeToken,
+		ArgoCDOption:      &ArgoCDOption{},
 	}
 }
 


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:
I want to add flux config flag to make the apiserver dynamic register the route by the `fluxcd` or `argocd` flag. And I found this.


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
