### PR TITLE
Change cluster secret label

### DIFF
--- a/controllers/fluxcd/multi-cluster-controller.go
+++ b/controllers/fluxcd/multi-cluster-controller.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"kubesphere.io/devops/pkg/api/gitops/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -99,7 +98,7 @@ func (r *MultiClusterReconciler) reconcileCluster(ctx context.Context, cluster *
 			newSecret.SetNamespace(ns.GetName())
 			newSecret.SetName(name)
 			newSecret.SetLabels(map[string]string{
-				"app.kubernetes.io/managed-by": v1alpha1.GroupName,
+				"app.kubernetes.io/managed-by": "fluxcd-controller",
 			})
 			newSecret.SetOwnerReferences([]metav1.OwnerReference{
 				{


### PR DESCRIPTION
### What type of PR is this?
/kind design

### What this PR does / why we need it:
I want to add `/clusters` API for fluxcd but the old label is too general. It may get more clusters than expect.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
