### PR TITLE
Support to store PipelineRun data into ConfigMap (#825)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,9 @@ generate-listers:
 
 # Build the docker image of controller-manager
 docker-build-controller:
-	${CONTAINER_CLI} build . -f config/dockerfiles/controller-manager/Dockerfile -t ${CONTROLLER_IMG}
+	${CONTAINER_CLI} build . -f config/dockerfiles/controller-manager/Dockerfile --build-arg GOPROXY=${GOPROXY} -t ${CONTROLLER_IMG}
+build-controller:
+	buildctl build --frontend dockerfile.v0 --local dockerfile=config/dockerfiles/controller-manager/
 
 # Push the docker image of controller-manager
 docker-push-controller:
@@ -97,7 +99,7 @@ run-apiserver:
 	go run cmd/apiserver/apiserver.go
 # Build the docker image of apiserver
 docker-build-apiserver:
-	${CONTAINER_CLI} build . -f config/dockerfiles/apiserver/Dockerfile -t ${APISERVER_IMG}
+	${CONTAINER_CLI} build . -f config/dockerfiles/apiserver/Dockerfile --build-arg GOPROXY=${GOPROXY} -t ${APISERVER_IMG}
 
 # Push the docker image of controller-manager
 docker-push-apiserver:
@@ -108,7 +110,7 @@ docker-build-push-apiserver: docker-build-apiserver docker-push-apiserver
 
 # Build the docker image of apiserver
 docker-build-tools:
-	${CONTAINER_CLI} build . -f config/dockerfiles/tools/Dockerfile -t ${TOOLS_IMG}
+	${CONTAINER_CLI} build . -f config/dockerfiles/tools/Dockerfile --build-arg GOPROXY=${GOPROXY} -t ${TOOLS_IMG}
 
 # Push the docker image of controller-manager
 docker-push-tools:

--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -48,11 +48,12 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 	tokenIssuer := token.NewTokenIssuer(s.JWTOptions.Secret, s.JWTOptions.MaximumClockSkew)
 	// add PipelineRun controller
 	if err := (&pipelinerun.Reconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		DevOpsClient: devopsClient,
-		JenkinsCore:  jenkinsCore,
-		TokenIssuer:  tokenIssuer,
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		DevOpsClient:         devopsClient,
+		JenkinsCore:          jenkinsCore,
+		TokenIssuer:          tokenIssuer,
+		PipelineRunDataStore: s.FeatureOptions.PipelineRunDataStore,
 	}).SetupWithManager(mgr); err != nil {
 		klog.Errorf("unable to create pipelinerun-controller, err: %v", err)
 		return err

--- a/cmd/controller/app/options/feature.go
+++ b/cmd/controller/app/options/feature.go
@@ -26,7 +26,11 @@ import (
 
 // FeatureOptions provide some feature options, such as specifying the controller to be enabled.
 type FeatureOptions struct {
-	Controllers map[string]bool
+	Controllers          map[string]bool
+	SystemNamespace      string
+	ExternalAddress      string
+	ClusterName          string
+	PipelineRunDataStore string
 }
 
 // GetControllers returns the controllers map
@@ -72,6 +76,12 @@ func (o *FeatureOptions) ApplyTo(options *FeatureOptions) {
 func (o *FeatureOptions) AddFlags(fs *pflag.FlagSet, c *FeatureOptions) {
 	fs.Var(cliflag.NewMapStringBool(&o.Controllers), "enabled-controllers", "A set of key=value pairs that describe feature options for controllers. "+
 		"Options are:\n"+strings.Join(c.knownControllers(), "\n"))
+	fs.StringVarP(&o.SystemNamespace, "system-namespace", "", "kubesphere-devops-system",
+		"The system namespace that contains ConfigMap, Secrets e.g.")
+	fs.StringVarP(&o.ExternalAddress, "external-address", "", "", "The external address for the UI")
+	fs.StringVarP(&o.ClusterName, "cluster-name", "", "default", "Current cluster name")
+	fs.StringVarP(&o.PipelineRunDataStore, "pipelinerun-data-store", "", "configmap",
+		"The data store type of the PipelineRun data, could be empty or configmap")
 }
 
 func (o *FeatureOptions) knownControllers() []string {

--- a/cmd/controller/app/options/feature_test.go
+++ b/cmd/controller/app/options/feature_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package options
 
 import (
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
@@ -84,4 +86,32 @@ func TestFeatureOptions_GetControllers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFeatureOptions(t *testing.T) {
+	opt := NewFeatureOptions()
+	assert.NotNil(t, opt)
+	assert.Equal(t, []error{}, opt.Validate())
+
+	opt.Controllers = map[string]bool{
+		"fake": true,
+	}
+	assert.Equal(t, []string{"fake"}, opt.knownControllers())
+
+	opt.ExternalAddress = "fake-address"
+	assert.Equal(t, "fake-address", opt.ExternalAddress)
+
+	newOpt := NewFeatureOptions()
+	assert.Empty(t, newOpt.ExternalAddress)
+	opt.ApplyTo(newOpt)
+	assert.Equal(t, "fake-address", newOpt.ExternalAddress)
+
+	flagSet := &pflag.FlagSet{}
+	opt.AddFlags(flagSet, opt)
+	assert.True(t, flagSet.HasFlags())
+	assert.NotNil(t, flagSet.Lookup("enabled-controllers"))
+	assert.NotNil(t, flagSet.Lookup("system-namespace"))
+	assert.NotNil(t, flagSet.Lookup("external-address"))
+	assert.NotNil(t, flagSet.Lookup("cluster-name"))
+	assert.NotNil(t, flagSet.Lookup("pipelinerun-data-store"))
 }

--- a/controllers/jenkins/pipelinerun/pipelinerun_controller.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller.go
@@ -57,7 +57,7 @@ type Reconciler struct {
 	JenkinsCore          core.JenkinsCore
 	TokenIssuer          token.Issuer
 	recorder             record.EventRecorder
-	pipelineRunDataStore string
+	PipelineRunDataStore string
 }
 
 //+kubebuilder:rbac:groups=devops.kubesphere.io,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete
@@ -227,7 +227,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 func (r *Reconciler) storePipelineRunData(runResultJSON, nodeDetailsJSON string, pipelineRunCopied *v1alpha3.PipelineRun) (err error) {
-	if r.pipelineRunDataStore == "" {
+	if r.PipelineRunDataStore == "" {
 		if pipelineRunCopied.Annotations == nil {
 			pipelineRunCopied.Annotations = make(map[string]string)
 		}
@@ -238,7 +238,7 @@ func (r *Reconciler) storePipelineRunData(runResultJSON, nodeDetailsJSON string,
 		if err = r.updateLabelsAndAnnotations(r.ctx, pipelineRunCopied); err != nil {
 			r.log.Error(err, "unable to update PipelineRun labels and annotations.")
 		}
-	} else if r.pipelineRunDataStore == "configmap" {
+	} else if r.PipelineRunDataStore == "configmap" {
 		var cmStore storeInter.ConfigMapStore
 		if cmStore, err = cmstore.NewConfigMapStore(r.ctx, r.req.NamespacedName, r.Client); err == nil {
 			cmStore.SetStages(nodeDetailsJSON)
@@ -252,7 +252,7 @@ func (r *Reconciler) storePipelineRunData(runResultJSON, nodeDetailsJSON string,
 			err = cmStore.Save()
 		}
 	} else {
-		err = fmt.Errorf("unknown pipelineRun data store type: %s", r.pipelineRunDataStore)
+		err = fmt.Errorf("unknown pipelineRun data store type: %s", r.PipelineRunDataStore)
 	}
 	return
 }

--- a/controllers/jenkins/pipelinerun/pipelinerun_controller.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/go-logr/logr"
+	cmstore "kubesphere.io/devops/pkg/store/configmap"
+	storeInter "kubesphere.io/devops/pkg/store/store"
 	"kubesphere.io/devops/pkg/utils/k8sutil"
 	"reflect"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"github.com/jenkins-zh/jenkins-client/pkg/job"
 	corev1 "k8s.io/api/core/v1"
@@ -47,12 +49,15 @@ const tokenExpireIn time.Duration = 5 * time.Minute
 // Reconciler reconciles a PipelineRun object
 type Reconciler struct {
 	client.Client
-	log          logr.Logger
-	Scheme       *runtime.Scheme
-	DevOpsClient devopsClient.Interface
-	JenkinsCore  core.JenkinsCore
-	TokenIssuer  token.Issuer
-	recorder     record.EventRecorder
+	req                  ctrl.Request
+	ctx                  context.Context
+	log                  logr.Logger
+	Scheme               *runtime.Scheme
+	DevOpsClient         devopsClient.Interface
+	JenkinsCore          core.JenkinsCore
+	TokenIssuer          token.Issuer
+	recorder             record.EventRecorder
+	pipelineRunDataStore string
 }
 
 //+kubebuilder:rbac:groups=devops.kubesphere.io,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete
@@ -63,6 +68,8 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	log := r.log.WithValues("PipelineRun", req.NamespacedName)
+	r.ctx = ctx
+	r.req = req
 
 	// get PipelineRun
 	pipelineRun := &v1alpha3.PipelineRun{}
@@ -152,15 +159,8 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			log.Error(err, "unable to marshal nodes details to JSON")
 			nodeDetailsJSON = []byte("[]")
 		}
-		if pipelineRunCopied.Annotations == nil {
-			pipelineRunCopied.Annotations = make(map[string]string)
-		}
-		pipelineRunCopied.Annotations[v1alpha3.JenkinsPipelineRunStatusAnnoKey] = string(runResultJSON)
-		pipelineRunCopied.Annotations[v1alpha3.JenkinsPipelineRunStagesStatusAnnoKey] = string(nodeDetailsJSON)
 
-		// update labels and annotations
-		if err := r.updateLabelsAndAnnotations(ctx, pipelineRunCopied); err != nil {
-			log.Error(err, "unable to update PipelineRun labels and annotations.")
+		if err = r.storePipelineRunData(string(runResultJSON), string(nodeDetailsJSON), pipelineRunCopied); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -226,6 +226,37 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+func (r *Reconciler) storePipelineRunData(runResultJSON, nodeDetailsJSON string, pipelineRunCopied *v1alpha3.PipelineRun) (err error) {
+	if r.pipelineRunDataStore == "" {
+		if pipelineRunCopied.Annotations == nil {
+			pipelineRunCopied.Annotations = make(map[string]string)
+		}
+		pipelineRunCopied.Annotations[v1alpha3.JenkinsPipelineRunStatusAnnoKey] = runResultJSON
+		pipelineRunCopied.Annotations[v1alpha3.JenkinsPipelineRunStagesStatusAnnoKey] = nodeDetailsJSON
+
+		// update labels and annotations
+		if err = r.updateLabelsAndAnnotations(r.ctx, pipelineRunCopied); err != nil {
+			r.log.Error(err, "unable to update PipelineRun labels and annotations.")
+		}
+	} else if r.pipelineRunDataStore == "configmap" {
+		var cmStore storeInter.ConfigMapStore
+		if cmStore, err = cmstore.NewConfigMapStore(r.ctx, r.req.NamespacedName, r.Client); err == nil {
+			cmStore.SetStages(nodeDetailsJSON)
+			cmStore.SetStatus(runResultJSON)
+			cmStore.SetOwnerReference(v1.OwnerReference{
+				APIVersion: pipelineRunCopied.APIVersion,
+				Kind:       pipelineRunCopied.Kind,
+				Name:       pipelineRunCopied.Name,
+				UID:        pipelineRunCopied.UID,
+			})
+			err = cmStore.Save()
+		}
+	} else {
+		err = fmt.Errorf("unknown pipelineRun data store type: %s", r.pipelineRunDataStore)
+	}
+	return
+}
+
 func (r *Reconciler) hasSamePipelineRun(jobRun *job.PipelineRun, pipeline *v1alpha3.Pipeline) (exists bool, err error) {
 	// check if the run ID exists in the PipelineRun
 	pipelineRuns := &v1alpha3.PipelineRunList{}
@@ -256,22 +287,20 @@ func getSCMRefName(prSpec *v1alpha3.PipelineRunSpec) (string, error) {
 	return branch, nil
 }
 
-func (r *Reconciler) updateLabelsAndAnnotations(ctx context.Context, pr *v1alpha3.PipelineRun) error {
+func (r *Reconciler) updateLabelsAndAnnotations(ctx context.Context, pr *v1alpha3.PipelineRun) (err error) {
 	// get pipeline
 	prToUpdate := v1alpha3.PipelineRun{}
-	err := r.Get(ctx, client.ObjectKey{Namespace: pr.Namespace, Name: pr.Name}, &prToUpdate)
-	if err != nil {
-		return err
+	if err = r.Get(ctx, client.ObjectKey{Namespace: pr.Namespace, Name: pr.Name}, &prToUpdate); err == nil {
+		if !reflect.DeepEqual(pr.Labels, prToUpdate.Labels) || !reflect.DeepEqual(pr.Annotations, prToUpdate.Annotations) {
+			prToUpdate = *prToUpdate.DeepCopy()
+			prToUpdate.Labels = pr.Labels
+			prToUpdate.Annotations = pr.Annotations
+			// make sure all PipelineRuns have the finalizer
+			k8sutil.AddFinalizer(&prToUpdate.ObjectMeta, v1alpha3.PipelineRunFinalizerName)
+			err = r.Update(ctx, &prToUpdate)
+		}
 	}
-	if reflect.DeepEqual(pr.Labels, prToUpdate.Labels) && reflect.DeepEqual(pr.Annotations, prToUpdate.Annotations) {
-		return nil
-	}
-	prToUpdate = *prToUpdate.DeepCopy()
-	prToUpdate.Labels = pr.Labels
-	prToUpdate.Annotations = pr.Annotations
-	// make sure all PipelineRuns have the finalizer
-	k8sutil.AddFinalizer(&prToUpdate.ObjectMeta, v1alpha3.PipelineRunFinalizerName)
-	return r.Update(ctx, &prToUpdate)
+	return
 }
 
 func (r *Reconciler) updateStatus(ctx context.Context, desiredStatus *v1alpha3.PipelineRunStatus, prKey client.ObjectKey) error {
@@ -290,24 +319,25 @@ func (r *Reconciler) updateStatus(ctx context.Context, desiredStatus *v1alpha3.P
 	})
 }
 
-func (r *Reconciler) makePipelineRunOrphan(ctx context.Context, pr *v1alpha3.PipelineRun) error {
+func (r *Reconciler) makePipelineRunOrphan(ctx context.Context, pr *v1alpha3.PipelineRun) (err error) {
 	// make the PipelineRun as orphan
 	prToUpdate := pr.DeepCopy()
 	prToUpdate.LabelAsAnOrphan()
-	if err := r.updateLabelsAndAnnotations(ctx, prToUpdate); err != nil {
-		return err
+	now := v1.Now()
+	if err = r.updateLabelsAndAnnotations(ctx, prToUpdate); err == nil {
+		condition := v1alpha3.Condition{
+			Type:               v1alpha3.ConditionSucceeded,
+			Status:             v1alpha3.ConditionUnknown,
+			Reason:             "SKIPPED",
+			Message:            "skipped to reconcile this PipelineRun due to not found Pipeline reference in PipelineRun.",
+			LastTransitionTime: now,
+			LastProbeTime:      now,
+		}
+		prToUpdate.Status.AddCondition(&condition)
+		prToUpdate.Status.Phase = v1alpha3.Unknown
+		err = r.updateStatus(ctx, &pr.Status, client.ObjectKey{Namespace: pr.Namespace, Name: pr.Name})
 	}
-	condition := v1alpha3.Condition{
-		Type:               v1alpha3.ConditionSucceeded,
-		Status:             v1alpha3.ConditionUnknown,
-		Reason:             "SKIPPED",
-		Message:            "skipped to reconcile this PipelineRun due to not found Pipeline reference in PipelineRun.",
-		LastTransitionTime: v1.Now(),
-		LastProbeTime:      v1.Now(),
-	}
-	prToUpdate.Status.AddCondition(&condition)
-	prToUpdate.Status.Phase = v1alpha3.Unknown
-	return r.updateStatus(ctx, &pr.Status, client.ObjectKey{Namespace: pr.Namespace, Name: pr.Name})
+	return
 }
 
 func (r *Reconciler) getOrCreateJenkinsCore(annotations map[string]string) (*core.JenkinsCore, error) {

--- a/controllers/jenkins/pipelinerun/pipelinerun_controller_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller_test.go
@@ -17,21 +17,19 @@ limitations under the License.
 package pipelinerun
 
 import (
-	"reflect"
-	"testing"
-
 	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"github.com/jenkins-zh/jenkins-client/pkg/job"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
 	"kubesphere.io/devops/pkg/client/clientset/versioned/scheme"
 	"kubesphere.io/devops/pkg/jwt/token"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	"testing"
 	// nolint
 	// The fakeclient will undeprecated starting with v0.7.0
 	// Reference:
@@ -136,7 +134,7 @@ var _ = Describe("TestReconciler_hasSamePipelineRun", func() {
 
 	BeforeEach(func() {
 		genernalPipeline = &v1alpha3.Pipeline{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "general-pipeline",
 				Namespace: "default",
 			},
@@ -145,7 +143,7 @@ var _ = Describe("TestReconciler_hasSamePipelineRun", func() {
 			},
 		}
 		multiBranchPipeline = &v1alpha3.Pipeline{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "multi-branch-pipeline",
 				Namespace: "default",
 			},
@@ -155,7 +153,7 @@ var _ = Describe("TestReconciler_hasSamePipelineRun", func() {
 		}
 
 		generalPipelineRun = &v1alpha3.PipelineRun{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pipeline-run-2",
 				Namespace: "default",
 				Annotations: map[string]string{
@@ -168,7 +166,7 @@ var _ = Describe("TestReconciler_hasSamePipelineRun", func() {
 		}
 
 		multiBranchPipelineRun = &v1alpha3.PipelineRun{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pipeline-run-1",
 				Namespace: "default",
 				Annotations: map[string]string{

--- a/pkg/kapis/devops/v1alpha3/pipelinerun/handler_test.go
+++ b/pkg/kapis/devops/v1alpha3/pipelinerun/handler_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pipelinerun
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha3"
+	"kubesphere.io/devops/pkg/apiserver/request"
+	"kubesphere.io/devops/pkg/client/devops"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/emicklei/go-restful"
+	"github.com/stretchr/testify/assert"
+	"kubesphere.io/devops/pkg/apiserver/runtime"
+	fakedevops "kubesphere.io/devops/pkg/client/devops/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApis(t *testing.T) {
+	wsWithGroup := runtime.NewWebService(v1alpha3.GroupVersion)
+	schema, err := v1alpha3.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+
+	RegisterRoutes(wsWithGroup, fakedevops.NewFakeDevops(nil), fake.NewFakeClientWithScheme(schema, &v1alpha3.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake",
+			Namespace: "fake",
+		},
+		Spec: v1alpha3.PipelineSpec{
+			Type: v1alpha3.NoScmPipelineType,
+		},
+	}))
+	restful.DefaultContainer.Add(wsWithGroup)
+
+	type args struct {
+		method  string
+		uri     string
+		getBody func() io.Reader
+		ctx     context.Context
+		status  int
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "create a pipelinerun",
+			args: args{
+				method: http.MethodPost,
+				uri:    "/namespaces/fake/pipelines/fake/pipelineruns",
+				getBody: func() io.Reader {
+					payload := &devops.RunPayload{
+						Parameters: []devops.Parameter{{
+							Name:  "aname",
+							Value: "avalue",
+						}},
+					}
+					data, _ := json.Marshal(payload)
+					return bytes.NewBuffer(data)
+				},
+				ctx:    request.NewContext(),
+				status: 401,
+			},
+		},
+		{
+			name: "create a pipelinerun with a mock user",
+			args: args{
+				method: http.MethodPost,
+				uri:    "/namespaces/fake/pipelines/fake/pipelineruns",
+				getBody: func() io.Reader {
+					payload := &devops.RunPayload{
+						Parameters: []devops.Parameter{{
+							Name:  "aname",
+							Value: "avalue",
+						}},
+					}
+					data, _ := json.Marshal(payload)
+					return bytes.NewBuffer(data)
+				},
+				ctx: request.WithUser(
+					request.NewContext(),
+					&user.DefaultInfo{
+						Name:   "bob",
+						UID:    "123",
+						Groups: []string{"group1"},
+						Extra:  map[string][]string{"foo": {"bar"}},
+					},
+				),
+				status: 200,
+			},
+		}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestBody io.Reader
+			if tt.args.getBody != nil {
+				requestBody = tt.args.getBody()
+			}
+			httpRequest, _ := http.NewRequestWithContext(tt.args.ctx, tt.args.method,
+				"http://fake.com/kapis/devops.kubesphere.io/v1alpha3"+tt.args.uri, requestBody)
+			httpRequest.Header.Set("Content-Type", "application/json")
+			httpWriter := httptest.NewRecorder()
+			restful.DefaultContainer.Dispatch(httpWriter, httpRequest)
+			assert.Equal(t, tt.args.status, httpWriter.Code)
+		})
+	}
+}

--- a/pkg/store/configmap/pipelinerun.go
+++ b/pkg/store/configmap/pipelinerun.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubesphere.io/devops/pkg/store/store"
+	"kubesphere.io/devops/pkg/utils/k8sutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Store represents a key-value store base on ConfigMap
+type Store struct {
+	ctx       context.Context
+	k8sClient client.Client
+
+	cache *v1.ConfigMap
+	owner metav1.OwnerReference
+}
+
+// NewConfigMapStore creates a PipelineRun data store
+func NewConfigMapStore(ctx context.Context, key client.ObjectKey, k8sClient client.Client) (
+	result store.ConfigMapStore, err error) {
+	cm := &v1.ConfigMap{Data: map[string]string{}}
+	cm.Namespace = key.Namespace
+	cm.Name = key.Name
+	if err = k8sClient.Get(ctx, key, cm); err != nil {
+		err = client.IgnoreNotFound(err)
+	}
+
+	result = &Store{
+		cache:     cm,
+		k8sClient: k8sClient,
+		ctx:       ctx,
+	}
+	return
+}
+
+// GetStages returns the stage data
+func (s *Store) GetStages() string {
+	return s.Get(store.DataKeyStage)
+}
+
+// SetStages stores the stage data
+func (s *Store) SetStages(stages string) {
+	s.Set(store.DataKeyStage, stages)
+}
+
+// GetStatus returns the status
+func (s *Store) GetStatus() string {
+	return s.Get(store.DataKeyStatus)
+}
+
+// SetStatus stores the status
+func (s *Store) SetStatus(status string) {
+	s.Set(store.DataKeyStatus, status)
+}
+
+// GetStepLog returns the step log
+func (s *Store) GetStepLog(stage, step int) string {
+	return s.Get(store.StepLogKey(stage, step))
+}
+
+// SetStepLog stores the step log
+func (s *Store) SetStepLog(stage, step int, log string) {
+	s.Set(store.StepLogKey(stage, step), log)
+}
+
+// GetAllLog returns the whole log
+func (s *Store) GetAllLog() string {
+	return s.Get(store.DataKeyAllLog)
+}
+
+// SetAllLog store the whole log
+func (s *Store) SetAllLog(log string) {
+	s.Set(store.DataKeyAllLog, log)
+}
+
+// Get returns the value by a key
+func (s *Store) Get(key string) string {
+	return s.cache.Data[key]
+}
+
+// Set puts a key and value
+func (s *Store) Set(key, value string) {
+	s.cache.Data[key] = value
+}
+
+// Save puts the data into ConfigMap via Kubernetes client
+func (s *Store) Save() (err error) {
+	// it might be a new ConfigMap or not
+	if s.cache.GetResourceVersion() == "" {
+		k8sutil.SetOwnerReference(s.cache, s.owner)
+		err = s.k8sClient.Create(s.ctx, s.cache)
+	} else {
+		err = s.k8sClient.Update(s.ctx, s.cache)
+	}
+	return
+}
+
+// SetOwnerReference set the owner reference
+func (s *Store) SetOwnerReference(owner metav1.OwnerReference) {
+	s.owner = owner
+}

--- a/pkg/store/configmap/pipelinerun_test.go
+++ b/pkg/store/configmap/pipelinerun_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"kubesphere.io/devops/pkg/store/store"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestConfigMapStore(t *testing.T) {
+	var err error
+	var cmStore store.ConfigMapStore
+	cmStore, err = NewConfigMapStore(context.Background(), types.NamespacedName{
+		Namespace: "ns",
+		Name:      "name",
+	}, fake.NewFakeClientWithScheme(scheme.Scheme))
+	assert.NotNil(t, cmStore)
+	assert.Nil(t, err)
+
+	cmStore.SetOwnerReference(v1.OwnerReference{})
+	assert.Nil(t, cmStore.Save())
+
+	assert.Empty(t, cmStore.GetStages())
+	cmStore.SetStages("stages")
+	assert.Equal(t, "stages", cmStore.GetStages())
+
+	assert.Empty(t, cmStore.GetStatus())
+	cmStore.SetStatus("status")
+	assert.Equal(t, "status", cmStore.GetStatus())
+
+	assert.Empty(t, cmStore.GetStepLog(1, 2))
+	cmStore.SetStepLog(1, 2, "step")
+	assert.Equal(t, "step", cmStore.GetStepLog(1, 2))
+
+	assert.Empty(t, cmStore.GetAllLog())
+	cmStore.SetAllLog("log")
+	assert.Equal(t, "log", cmStore.GetAllLog())
+
+	assert.Nil(t, cmStore.Save())
+}

--- a/pkg/store/fake/fake_core_test.go
+++ b/pkg/store/fake/fake_core_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFakeStore(t *testing.T) {
+	store := NewFakeStore()
+	assert.NotNil(t, store)
+
+	assert.Empty(t, store.Get("fake"))
+	store.Set("fake", "fake")
+	assert.Equal(t, "fake", store.Get("fake"))
+
+	assert.Empty(t, store.GetAllLog())
+	store.SetAllLog("log")
+	assert.Equal(t, "log", store.GetAllLog())
+
+	assert.Empty(t, store.GetStages())
+	store.SetStages("stages")
+	assert.Equal(t, "stages", store.GetStages())
+
+	assert.Empty(t, store.GetStatus())
+	store.SetStatus("status")
+	assert.Equal(t, "status", store.GetStatus())
+
+	assert.Empty(t, store.GetStepLog(1, 1))
+	store.SetStepLog(1, 1, "step")
+	assert.Equal(t, "step", store.GetStepLog(1, 1))
+
+	assert.Nil(t, store.Save())
+	assert.NotNil(t, store.WithError(errors.New("fake")).Save())
+}

--- a/pkg/store/fake/fake_store.go
+++ b/pkg/store/fake/fake_store.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import "kubesphere.io/devops/pkg/store/store"
+
+// Store is a fake store
+type Store struct {
+	data map[string]string
+	err  error
+}
+
+// NewFakeStore creates an instance of the fake store
+func NewFakeStore() *Store {
+	return &Store{
+		data: map[string]string{},
+	}
+}
+
+// WithError sets the error for expect error
+func (s *Store) WithError(err error) *Store {
+	s.err = err
+	return s
+}
+
+// Get is a fake method
+func (s *Store) Get(key string) string {
+	return s.data[key]
+}
+
+// Set is a fake method
+func (s *Store) Set(key, value string) {
+	s.data[key] = value
+}
+
+// Save is a fake method
+func (s *Store) Save() error {
+	return s.err
+}
+
+// GetStages is a fake method
+func (s *Store) GetStages() string {
+	return s.Get(store.DataKeyStage)
+}
+
+// SetStages is fake method
+func (s *Store) SetStages(stages string) {
+	s.Set(store.DataKeyStage, stages)
+}
+
+// GetStatus is a fake method
+func (s *Store) GetStatus() string {
+	return s.Get(store.DataKeyStatus)
+}
+
+// SetStatus is a fake method
+func (s *Store) SetStatus(status string) {
+	s.Set(store.DataKeyStatus, status)
+}
+
+// GetStepLog is a fake method
+func (s *Store) GetStepLog(stage, step int) string {
+	return s.Get(store.StepLogKey(stage, step))
+}
+
+// SetStepLog is a fake method
+func (s *Store) SetStepLog(stage, step int, log string) {
+	s.Set(store.StepLogKey(stage, step), log)
+}
+
+// GetAllLog is a fake method
+func (s *Store) GetAllLog() string {
+	return s.Get(store.DataKeyAllLog)
+}
+
+// SetAllLog is a fake method
+func (s *Store) SetAllLog(log string) {
+	s.data[store.DataKeyAllLog] = log
+}

--- a/pkg/store/store/types.go
+++ b/pkg/store/store/types.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// DataKeyAllLog is the key of all log
+	DataKeyAllLog = "log-all"
+	// DataKeyStage is the key of stage data
+	DataKeyStage = "stage"
+	// DataKeyStatus is the key of status
+	DataKeyStatus = "status"
+)
+
+// StepLogKey generates a unique key by stage and step number
+func StepLogKey(stage, step int) string {
+	return fmt.Sprintf("log-step-%d-%d", stage, step)
+}
+
+// KeyValueStore represents a key-value store
+type KeyValueStore interface {
+	Get(key string) string
+	Set(key, value string)
+	Save() error
+}
+
+// PipelineRunDataStore represents a PipelineRun data store
+type PipelineRunDataStore interface {
+	KeyValueStore
+
+	GetStages() string
+	SetStages(stages string)
+	GetStatus() string
+	SetStatus(status string)
+	GetStepLog(stage, step int) string
+	SetStepLog(stage, step int, log string)
+	GetAllLog() string
+	SetAllLog(log string)
+}
+
+// ConfigMapStore represents a store base on a ConfigMap
+type ConfigMapStore interface {
+	PipelineRunDataStore
+	SetOwnerReference(owner metav1.OwnerReference)
+}

--- a/pkg/store/store/types_test.go
+++ b/pkg/store/store/types_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import "testing"
+
+func TestStepLogKey(t *testing.T) {
+	type args struct {
+		stage int
+		step  int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{{
+		name: "normal",
+		args: args{
+			stage: 1,
+			step:  2,
+		},
+		want: "log-step-1-2",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StepLogKey(tt.args.stage, tt.args.step); got != tt.want {
+				t.Errorf("StepLogKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
Support to store PipelineRun data into ConfigMap
```
