### PR TITLE
bugfix: nil pointer of CompletionTime

### DIFF
--- a/controllers/gitrepository/pull_request_status_controller.go
+++ b/controllers/gitrepository/pull_request_status_controller.go
@@ -98,10 +98,9 @@ func (r *PullRequestStatusReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	maker.WithExpirationCheck(createExpirationCheckFunc(ctx, r, pipelinerun.DeepCopy()))
 
 	var desc string
-	sinceFinishedTime := r.getTimeSinceFinished(pipelinerun.Status.CompletionTime)
-
 	switch pipelinerun.Status.Phase {
 	case v1alpha3.Succeeded:
+		sinceFinishedTime := r.getTimeSinceFinished(pipelinerun.Status.CompletionTime)
 		desc = "Successful in " + sinceFinishedTime
 	case v1alpha3.Failed:
 		desc = pipelinerun.Status.GetLatestCondition().Reason


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:
Fix bug of nil pointer of pipelinerun.Status.CompletionTime when pipelinerun doesn't complete.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #811 

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
```release-note
None
```
