### PR TITLE
Bugfix ks 5193

### DIFF
--- a/pkg/client/devops/jclient/projectPipeline.go
+++ b/pkg/client/devops/jclient/projectPipeline.go
@@ -82,7 +82,6 @@ func (j *JenkinsClient) DeleteProjectPipeline(projectID string, pipelineID strin
 
 // UpdateProjectPipeline updates pipeline
 func (j *JenkinsClient) UpdateProjectPipeline(projectID string, pipeline *devopsv1alpha3.Pipeline) (string, error) {
-	// TODO: Update a pipeline
 	return j.jenkins.UpdateProjectPipeline(projectID, pipeline)
 }
 

--- a/pkg/client/devops/jenkins/constants.go
+++ b/pkg/client/devops/jenkins/constants.go
@@ -35,6 +35,35 @@ const (
 	PROJECT_ROLE = "projectRoles"
 )
 
+const (
+	StringNull = ""
+
+	FlowTag                 = "flow-definition"
+	PropertiesTag           = "properties"
+	DisableConcurrentJobTag = "org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty"
+	BuildDiscarderTag       = "jenkins.model.BuildDiscarderProperty"
+	StrategyTag             = "strategy"
+	DaysToKeepTag           = "daysToKeep"
+	NumToKeepTag            = "numToKeep"
+	ArtiDaysToKeepTag       = "artifactDaysToKeep"
+	ArtiNumToKeepTag        = "artifactNumToKeep"
+
+	ParamDefiPropTag = "hudson.model.ParametersDefinitionProperty"
+	ParamDefiTag     = "parameterDefinitions"
+
+	PipelineTriggersJobTag = "org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty"
+	TriggersTag            = "triggers"
+	TimerTriggerTag        = "hudson.triggers.TimerTrigger"
+
+	DefinitionTag = "definition"
+	ClassKey      = "class"
+	PluginKey     = "plugin"
+	ScriptTag     = "script"
+	SandboxTag    = "sandbox"
+	AuthTokenTag  = "authToken"
+	DisabledTag   = "disabled"
+)
+
 // ParameterTypeMap aims for simplifying representation of parameter definition type.
 var ParameterTypeMap = map[string]string{
 	"hudson.model.StringParameterDefinition":   "string",

--- a/pkg/client/devops/jenkins/pipeline_internal.go
+++ b/pkg/client/devops/jenkins/pipeline_internal.go
@@ -146,19 +146,20 @@ func updatePipelineConfigXml(config string, pipeline *devopsv1alpha3.NoScmPipeli
 		removeChildElement(properties, ParamDefiPropTag)
 	}
 
-	// create trigger xml structure
-	if pipeline.TimerTrigger != nil || pipeline.GenericWebhook != nil {
-		pipelineTriggerE := addOrUpdateElement(properties, PipelineTriggersJobTag, StringNull)
-		triggersEle := addOrUpdateElement(pipelineTriggerE, TriggersTag, StringNull)
+	// update triggers xml structure
+	var pipelineTriggerEle, triggersEle *etree.Element
+	pipelineTriggerEle = addOrUpdateElement(properties, PipelineTriggersJobTag, StringNull)
+	triggersEle = addOrUpdateElement(pipelineTriggerEle, TriggersTag, StringNull)
 
-		if pipeline.TimerTrigger != nil {
-			timeTriggerE := addOrUpdateElement(triggersEle, TimerTriggerTag, StringNull)
-			addOrUpdateElement(timeTriggerE, "spec", pipeline.TimerTrigger.Cron)
-		} else {
-			removeChildElement(triggersEle, TimerTriggerTag)
-		}
+	if pipeline.TimerTrigger != nil {
+		timerTriggerEle := addOrUpdateElement(triggersEle, TimerTriggerTag, StringNull)
+		addOrUpdateElement(timerTriggerEle, "spec", pipeline.TimerTrigger.Cron)
+	} else {
+		removeChildElement(triggersEle, TimerTriggerTag)
+	}
 
-		// issue: if support GenericWebhook in console, need to delete GenericWebhook tag when pipeline.GenericWebhook is nil;
+	if pipeline.GenericWebhook != nil {
+		// TODO issue: if support GenericWebhook in console, need to delete GenericWebhook tag when pipeline.GenericWebhook is nil;
 		triggers.CreateGenericWebhookXML(triggersEle, pipeline.GenericWebhook)
 	}
 
@@ -176,7 +177,7 @@ func updatePipelineConfigXml(config string, pipeline *devopsv1alpha3.NoScmPipeli
 	if flow.SelectElement(TriggersTag) == nil {
 		flow.CreateElement(TriggersTag)
 	}
-	// issue: if support RemoteTrigger in console, need to delete GenericWebhook tag when pipeline.GenericWebhook is nil;
+	// TODO issue: if support RemoteTrigger in console, need to delete GenericWebhook tag when pipeline.GenericWebhook is nil;
 	if pipeline.RemoteTrigger != nil {
 		addOrUpdateElement(flow, AuthTokenTag, pipeline.RemoteTrigger.Token)
 	}

--- a/pkg/client/devops/jenkins/pipeline_internal.go
+++ b/pkg/client/devops/jenkins/pipeline_internal.go
@@ -72,7 +72,7 @@ func createPipelineConfigXml(pipeline *devopsv1alpha3.NoScmPipeline) (string, er
 		strategy.CreateElement("artifactNumToKeep").SetText("-1")
 	}
 	if pipeline.Parameters != nil {
-		appendParametersToEtree(properties, pipeline.Parameters)
+		replaceParametersInEtree(properties, pipeline.Parameters)
 	}
 
 	// create trigger xml structure
@@ -103,6 +103,86 @@ func createPipelineConfigXml(pipeline *devopsv1alpha3.NoScmPipeline) (string, er
 	}
 	flow.CreateElement("disabled").SetText("false")
 
+	doc.Indent(2)
+	stringXml, err := doc.WriteToString()
+	if err != nil {
+		return "", err
+	}
+	return replaceXmlVersion(stringXml, "1.0", "1.1"), err
+}
+
+func updatePipelineConfigXml(config string, pipeline *devopsv1alpha3.NoScmPipeline) (string, error) {
+	config = replaceXmlVersion(config, "1.1", "1.0")
+	doc := etree.NewDocument()
+	err := doc.ReadFromString(config)
+	if err != nil {
+		return "", err
+	}
+	flow := doc.SelectElement(FlowTag)
+	// ------------------------------------------------
+	// update properties
+	properties := flow.SelectElement(PropertiesTag)
+	if pipeline.DisableConcurrent {
+		addOrUpdateElement(properties, DisableConcurrentJobTag, StringNull)
+	} else {
+		removeChildElement(properties, DisableConcurrentJobTag)
+	}
+
+	if pipeline.Discarder != nil {
+		var discarder, strategy *etree.Element
+		discarder = addOrUpdateElement(properties, BuildDiscarderTag, StringNull)
+		strategy = addOrUpdateElement(discarder, StrategyTag, StringNull)
+
+		replaceAttr(strategy, ClassKey, "hudson.tasks.LogRotator")
+		addOrUpdateElement(strategy, DaysToKeepTag, pipeline.Discarder.DaysToKeep)
+		addOrUpdateElement(strategy, NumToKeepTag, pipeline.Discarder.NumToKeep)
+		addOrUpdateElement(strategy, ArtiDaysToKeepTag, "-1")
+		addOrUpdateElement(strategy, ArtiNumToKeepTag, "-1")
+	}
+
+	if pipeline.Parameters != nil { // overwrite parameters
+		replaceParametersInEtree(properties, pipeline.Parameters)
+	} else {
+		removeChildElement(properties, ParamDefiPropTag)
+	}
+
+	// create trigger xml structure
+	if pipeline.TimerTrigger != nil || pipeline.GenericWebhook != nil {
+		pipelineTriggerE := addOrUpdateElement(properties, PipelineTriggersJobTag, StringNull)
+		triggersEle := addOrUpdateElement(pipelineTriggerE, TriggersTag, StringNull)
+
+		if pipeline.TimerTrigger != nil {
+			timeTriggerE := addOrUpdateElement(triggersEle, TimerTriggerTag, StringNull)
+			addOrUpdateElement(timeTriggerE, "spec", pipeline.TimerTrigger.Cron)
+		} else {
+			removeChildElement(triggersEle, TimerTriggerTag)
+		}
+
+		// issue: if support GenericWebhook in console, need to delete GenericWebhook tag when pipeline.GenericWebhook is nil;
+		triggers.CreateGenericWebhookXML(triggersEle, pipeline.GenericWebhook)
+	}
+
+	// ------------------------------------------------
+	// replace definition(all fields could update from console)
+	removeChildElement(flow, DefinitionTag)
+	pipelineDefine := flow.CreateElement(DefinitionTag)
+	pipelineDefine.CreateAttr(ClassKey, "org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition")
+	pipelineDefine.CreateAttr(PluginKey, "workflow-cps")
+	pipelineDefine.CreateElement(ScriptTag).SetText(pipeline.Jenkinsfile)
+	pipelineDefine.CreateElement(SandboxTag).SetText("true")
+
+	// ------------------------------------------------
+	// update others
+	if flow.SelectElement(TriggersTag) == nil {
+		flow.CreateElement(TriggersTag)
+	}
+	// issue: if support RemoteTrigger in console, need to delete GenericWebhook tag when pipeline.GenericWebhook is nil;
+	if pipeline.RemoteTrigger != nil {
+		addOrUpdateElement(flow, AuthTokenTag, pipeline.RemoteTrigger.Token)
+	}
+	addOrUpdateElement(flow, DisabledTag, "false")
+
+	// format xml string
 	doc.Indent(2)
 	stringXml, err := doc.WriteToString()
 	if err != nil {
@@ -177,13 +257,21 @@ func parsePipelineConfigXml(config string) (*devopsv1alpha3.NoScmPipeline, error
 	return pipeline, nil
 }
 
-func appendParametersToEtree(properties *etree.Element, parameters []devopsv1alpha3.ParameterDefinition) {
-	parameterDefinitions := properties.CreateElement("hudson.model.ParametersDefinitionProperty").
-		CreateElement("parameterDefinitions")
+func replaceParametersInEtree(properties *etree.Element, parameters []devopsv1alpha3.ParameterDefinition) {
+	var paramDefiPropsE, paramDefiE *etree.Element
+	if paramDefiPropsE = properties.SelectElement(ParamDefiPropTag); paramDefiPropsE == nil {
+		paramDefiE = properties.CreateElement(ParamDefiPropTag).CreateElement(ParamDefiTag)
+	} else {
+		if paramDefiE = paramDefiPropsE.SelectElement(ParamDefiTag); paramDefiE != nil {
+			paramDefiPropsE.RemoveChild(paramDefiE)
+		}
+		paramDefiE = paramDefiPropsE.CreateElement(ParamDefiTag)
+	}
+
 	for _, parameter := range parameters {
 		for className, typeName := range ParameterTypeMap {
 			if typeName == parameter.Type {
-				paramDefine := parameterDefinitions.CreateElement(className)
+				paramDefine := paramDefiE.CreateElement(className)
 				paramDefine.CreateElement("name").SetText(parameter.Name)
 				paramDefine.CreateElement("description").SetText(parameter.Description)
 				switch parameter.Type {
@@ -509,4 +597,28 @@ func toCrontab(millis int64) string {
 	}
 	return "H H * * *"
 
+}
+
+func addOrUpdateElement(parent *etree.Element, tag, text string) *etree.Element {
+	var e *etree.Element
+	if e = parent.SelectElement(tag); e == nil {
+		e = parent.CreateElement(tag)
+	}
+	if text != "" {
+		e.SetText(text)
+	}
+	return e
+}
+
+func replaceAttr(e *etree.Element, key, value string) *etree.Element {
+	e.RemoveAttr(key)
+	e.CreateAttr(key, value)
+	return e
+}
+
+func removeChildElement(parent *etree.Element, childTag string) *etree.Element {
+	if e := parent.SelectElement(childTag); e != nil {
+		parent.RemoveChild(e)
+	}
+	return parent
 }

--- a/pkg/client/devops/jenkins/triggers/genericwebhook.go
+++ b/pkg/client/devops/jenkins/triggers/genericwebhook.go
@@ -29,6 +29,10 @@ func CreateGenericWebhookXML(parent *etree.Element, webhook *v1alpha3.GenericWeb
 		return
 	}
 
+
+	if gtE := parent.SelectElement("org.jenkinsci.plugins.gwt.GenericTrigger"); gtE != nil {
+		parent.RemoveChild(gtE)
+	}
 	ele = parent.CreateElement("org.jenkinsci.plugins.gwt.GenericTrigger")
 
 	ele.CreateElement("spec")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

fix bug of the some jenkins configxml overwrite by pipelienrun-controller.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes https://github.com/kubesphere/kubesphere/issues/5193

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
support updatePipelinerunConfigXml in pipelinerun-controller
```
