### PR TITLE
update test func: storePipelineRunData

### DIFF
--- a/controllers/jenkins/pipelinerun/pipelinerun_controller_test.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller_test.go
@@ -497,7 +497,7 @@ func TestStorePipelineRunData(t *testing.T) {
 		log:                  logr.New(log.NullLogSink{}),
 		PipelineRunDataStore: "fake",
 	}
-	assert.NotNil(t, r.storePipelineRunData("", "", pipelineRun.DeepCopy()))
+	assert.NotNil(t, r.storePipelineRunData("", pipelineRun.DeepCopy()))
 
 	r = &Reconciler{
 		Client: fake.NewClientBuilder().WithScheme(schema).WithObjects(pipelineRun.DeepCopy()).Build(),
@@ -507,12 +507,12 @@ func TestStorePipelineRunData(t *testing.T) {
 		},
 		PipelineRunDataStore: "configmap",
 	}
-	assert.Nil(t, r.storePipelineRunData("", "", pipelineRun.DeepCopy()))
+	assert.Nil(t, r.storePipelineRunData("", pipelineRun.DeepCopy()))
 
 	r = &Reconciler{
 		Client:               fake.NewClientBuilder().WithScheme(schema).WithObjects(pipelineRun.DeepCopy()).Build(),
 		log:                  logr.New(log.NullLogSink{}),
 		PipelineRunDataStore: "",
 	}
-	assert.Nil(t, r.storePipelineRunData("", "", pipelineRun.DeepCopy()))
+	assert.Nil(t, r.storePipelineRunData("", pipelineRun.DeepCopy()))
 }

--- a/pkg/client/devops/jenkins/triggers/genericwebhook.go
+++ b/pkg/client/devops/jenkins/triggers/genericwebhook.go
@@ -29,7 +29,6 @@ func CreateGenericWebhookXML(parent *etree.Element, webhook *v1alpha3.GenericWeb
 		return
 	}
 
-
 	if gtE := parent.SelectElement("org.jenkinsci.plugins.gwt.GenericTrigger"); gtE != nil {
 		parent.RemoveChild(gtE)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?

/kind failing-test


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
None
```
