### PR TITLE
Auto sync jenkinsfile for pre version pipeline

### DIFF
--- a/controllers/jenkins/pipeline/json_converter_test.go
+++ b/controllers/jenkins/pipeline/json_converter_test.go
@@ -95,7 +95,7 @@ func TestJenkinsfileReconciler_Reconcile(t *testing.T) {
 	}{{
 		name: "not found",
 		fields: fields{
-			Client: fake.NewFakeClientWithScheme(schema),
+			Client: fake.NewClientBuilder().WithScheme(schema).Build(),
 		},
 		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 			assert.Nil(t, err)
@@ -105,7 +105,7 @@ func TestJenkinsfileReconciler_Reconcile(t *testing.T) {
 	}, {
 		name: "invalid edit mode",
 		fields: fields{
-			Client:      fake.NewFakeClientWithScheme(schema, invalidEditMode),
+			Client:      fake.NewClientBuilder().WithScheme(schema).WithRuntimeObjects(invalidEditMode).Build(),
 			JenkinsCore: core.JenkinsCore{},
 			log:         logr.Logger{},
 			TokenIssuer: &token.FakeIssuer{},
@@ -120,7 +120,7 @@ func TestJenkinsfileReconciler_Reconcile(t *testing.T) {
 	}, {
 		name: "empty edit mode",
 		fields: fields{
-			Client:      fake.NewFakeClientWithScheme(schema, emptyEditMode),
+			Client:      fake.NewClientBuilder().WithScheme(schema).WithRuntimeObjects(emptyEditMode).Build(),
 			JenkinsCore: core.JenkinsCore{},
 			log:         logr.Logger{},
 			TokenIssuer: &token.FakeIssuer{},
@@ -135,7 +135,7 @@ func TestJenkinsfileReconciler_Reconcile(t *testing.T) {
 	}, {
 		name: "irregular pipeline, and jenkinsfile edit mode",
 		fields: fields{
-			Client:      fake.NewFakeClientWithScheme(schema, irregularPip),
+			Client:      fake.NewClientBuilder().WithScheme(schema).WithRuntimeObjects(irregularPip).Build(),
 			JenkinsCore: core.JenkinsCore{},
 			log:         logr.Logger{},
 		},
@@ -149,7 +149,7 @@ func TestJenkinsfileReconciler_Reconcile(t *testing.T) {
 	}, {
 		name: "a regular pipeline with jenkinsfile edit mode",
 		fields: fields{
-			Client: fake.NewFakeClientWithScheme(schema, pip),
+			Client: fake.NewClientBuilder().WithScheme(schema).WithRuntimeObjects(pip).Build(),
 			JenkinsCore: core.JenkinsCore{
 				URL: "http://localhost",
 			},
@@ -174,6 +174,8 @@ func TestJenkinsfileReconciler_Reconcile(t *testing.T) {
 			}, pip)
 			assert.Nil(t, err)
 			assert.Equal(t, `{"a":"b"}`, pip.Annotations[v1alpha3.PipelineJenkinsfileValueAnnoKey])
+			assert.Equal(t, "", pip.Annotations[v1alpha3.PipelineJenkinsfileEditModeAnnoKey])
+			assert.Equal(t, v1alpha3.PipelineJenkinsfileValidateSuccess, pip.Annotations[v1alpha3.PipelineJenkinsfileValidateAnnoKey])
 		},
 		wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 			assert.Nil(t, err)
@@ -182,7 +184,7 @@ func TestJenkinsfileReconciler_Reconcile(t *testing.T) {
 	}, {
 		name: "a regular pipeline with JSON edit mode",
 		fields: fields{
-			Client: fake.NewFakeClientWithScheme(schema, jsonEditModePip),
+			Client: fake.NewClientBuilder().WithScheme(schema).WithRuntimeObjects(jsonEditModePip).Build(),
 			JenkinsCore: core.JenkinsCore{
 				URL: "http://localhost",
 			},

--- a/controllers/jenkins/pipeline/pipeline_metadata_controller.go
+++ b/controllers/jenkins/pipeline/pipeline_metadata_controller.go
@@ -162,7 +162,7 @@ func (r *Reconciler) updateAnnotations(annotations map[string]string, pipelineKe
 	})
 }
 
-// pipelineMetadataPredicate returns a predicate which only cares about CreateEvent.
+// pipelineMetadataPredicate returns a predicate.
 var pipelineMetadataPredicate = predicate.Funcs{
 	CreateFunc: func(ce event.CreateEvent) bool {
 		return true

--- a/controllers/jenkins/pipelinerun/pipelinerun_controller.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller.go
@@ -133,7 +133,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err != nil {
 			if err.Error() == BuildNotExistMsg { // delete pipelinerun if build not exist in jenkins
 				runID, _ := pipelineRun.GetPipelineRunID()
-				log.Info(fmt.Sprintf("the build(ID: %s) not exist in jenkins, delete it..", runID) )
+				log.Info(fmt.Sprintf("the build(ID: %s) not exist in jenkins, delete it..", runID))
 				if err = r.Client.Delete(ctx, pipelineRun); err != nil {
 					log.Error(err, "failed to delete pipelinerun")
 					return ctrl.Result{RequeueAfter: 3 * time.Second}, err

--- a/pkg/api/devops/v1alpha3/pipeline_types.go
+++ b/pkg/api/devops/v1alpha3/pipeline_types.go
@@ -45,11 +45,18 @@ const (
 	PipelineJenkinsfileValueAnnoKey = PipelinePrefix + "jenkinsfile"
 	// PipelineJenkinsfileEditModeAnnoKey is the annotation key of the Jenkinsfile edit mode
 	PipelineJenkinsfileEditModeAnnoKey = PipelinePrefix + "jenkinsfile.edit.mode"
+	// PipelineJenkinsfileValidateAnnoKey is the annotation key of the Jenkinsfile validate, success or failure
+	PipelineJenkinsfileValidateAnnoKey = PipelinePrefix + "jenkinsfile.validate"
 
 	// PipelineJenkinsfileEditModeJSON indicates the Jenkinsfile editing mode is JSON
 	PipelineJenkinsfileEditModeJSON = "json"
 	// PipelineJenkinsfileEditModeRaw indicates the Jenkinsfile editing mode is groovy
 	PipelineJenkinsfileEditModeRaw = "raw"
+
+	// PipelineJenkinsfileValidateSuccess indicates the Jenkinsfile validate is success
+	PipelineJenkinsfileValidateSuccess = "success"
+	// PipelineJenkinsfileValidateFailure indicates the Jenkinsfile validate is failure
+	PipelineJenkinsfileValidateFailure = "failure"
 )
 
 // PipelineSpec defines the desired state of Pipeline


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:
Now front end get jenkinsfile from annotations.pipeline.devops.kubesphere.io/jenkinsfile in pipeline cr.
Old created pipelines, there are not such annotations, ui will not show.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #714

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
auto sync jenkinsfile for pre version pipeline
```
