### PR TITLE
Add type filter for pipeline

### DIFF
--- a/.github/workflows/e2e.install.yaml
+++ b/.github/workflows/e2e.install.yaml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        k8sVersion: ["1.19", "1.20", "1.21", "1.22"]
+        k8sVersion: ["1.19", "1.20", "1.21", "1.22", "1.23"]
     steps:
       - uses: actions/checkout@v2
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,11 +11,11 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
   - get
   - list
   - update
   - watch
-  - create
 - apiGroups:
   - ""
   resources:

--- a/controllers/jenkins/config/jenkinsconfig_controller.go
+++ b/controllers/jenkins/config/jenkinsconfig_controller.go
@@ -38,7 +38,7 @@ import (
 	"time"
 )
 
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;update;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;update;watch;create
 
 // ControllerOptions is the option of Jenkins configuration controller
 type ControllerOptions struct {

--- a/test/e2e/common/kind-1.23.yaml
+++ b/test/e2e/common/kind-1.23.yaml
@@ -1,0 +1,26 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# patch the generated kubeadm config with some extra settings
+kubeadmConfigPatches:
+- |
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  kind: KubeletConfiguration
+  evictionHard:
+    nodefs.available: "0%"
+# patch it further using a JSON 6902 patch
+kubeadmConfigPatchesJSON6902:
+- group: kubeadm.k8s.io
+  version: v1beta2
+  kind: ClusterConfiguration
+  patch: |
+    - op: add
+      path: /apiServer/certSANs/-
+      value: ks-devops-e2e
+# 1 control plane node and 1 workers
+nodes:
+# the control plane node config
+- role: control-plane
+  image: kindest/node:v1.23.12
+# the one worker
+- role: worker
+  image: kindest/node:v1.23.12


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind api-change

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes part of #865 

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
support: filter pipeline by type in ListPipelineObj

Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
none
```
