### PR TITLE
fix: pipelinerun deleted by controller when get build failed

### DIFF
--- a/controllers/jenkins/pipelinerun/pipelinerun_controller.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller.go
@@ -136,10 +136,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 				runID, _ := pipelineRun.GetPipelineRunID()
 				log.Info(fmt.Sprintf("get pipelinerun data(id: %s) error with not exit, retry.", runID) )
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-			} else {
-				log.Error(err, "unable get PipelineRun data.")
-				r.recorder.Eventf(pipelineRunCopied, corev1.EventTypeWarning, v1alpha3.RetrieveFailed, "Failed to retrieve running data from Jenkins, and error was %v", err)
 			}
+			log.Error(err, "unable get PipelineRun data.")
+			r.recorder.Eventf(pipelineRunCopied, corev1.EventTypeWarning, v1alpha3.RetrieveFailed, "Failed to retrieve running data from Jenkins, and error was %v", err)
 			return ctrl.Result{}, err
 		}
 

--- a/controllers/jenkins/pipelinerun/pipelinerun_controller.go
+++ b/controllers/jenkins/pipelinerun/pipelinerun_controller.go
@@ -132,13 +132,10 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		log.V(5).Info("pipeline has already started, and we are retrieving run data from Jenkins.")
 		pipelineBuild, err := jHandler.getPipelineRunResult(namespaceName, pipelineName, pipelineRunCopied)
 		if err != nil {
-			if err.Error() == BuildNotExistMsg { // delete pipelinerun if build not exist in jenkins
+			if err.Error() == BuildNotExistMsg { // retry if get pipelinerun failed by not exist
 				runID, _ := pipelineRun.GetPipelineRunID()
-				log.Info(fmt.Sprintf("the build(ID: %s) not exist in jenkins, delete it..", runID) )
-				if err = r.Client.Delete(ctx, pipelineRun); err != nil {
-					log.Error(err, "failed to delete pipelinerun")
-					return ctrl.Result{RequeueAfter: 3 * time.Second}, err
-				}
+				log.Info(fmt.Sprintf("get pipelinerun data(id: %s) error with not exit, retry.", runID) )
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 			} else {
 				log.Error(err, "unable get PipelineRun data.")
 				r.recorder.Eventf(pipelineRunCopied, corev1.EventTypeWarning, v1alpha3.RetrieveFailed, "Failed to retrieve running data from Jenkins, and error was %v", err)


### PR DESCRIPTION
fix bug that pipelinerun deleted by controller
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?

/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #920 

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
pipelinerun deleted by controller if get build failed with error
```
