### PR TITLE
Fix the issue of removing argocd resources without cascade parameter

### DIFF
--- a/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
+++ b/pkg/kapis/gitops/v1alpha1/argocd/route_test.go
@@ -236,6 +236,14 @@ func TestPublicAPIs(t *testing.T) {
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Kind: v1alpha1.ArgoCD,
+			ArgoApp: &v1alpha1.ArgoApplication{
+				Operation: nil,
+				Spec: v1alpha1.ArgoApplicationSpec{
+					SyncPolicy: &v1alpha1.SyncPolicy{
+						Automated: nil,
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/kapis/gitops/v1alpha1/gitops/handler.go
+++ b/pkg/kapis/gitops/v1alpha1/gitops/handler.go
@@ -86,9 +86,7 @@ func (h *Handler) DelApplication(req *restful.Request, res *restful.Response) {
 	}
 	err := h.Get(ctx, objectKey, application)
 	if err == nil {
-		switch application.Spec.Kind {
-		case v1alpha1.ArgoCD:
-			// add the Argo CD resources finalizer if cascade is true
+		if argo := application.Spec.ArgoApp; argo != nil {
 			if cascade == "true" {
 				if k8sutil.AddFinalizer(&application.ObjectMeta, v1alpha1.ArgoCDResourcesFinalizer) {
 					if err = h.Update(ctx, application); err != nil {
@@ -102,7 +100,6 @@ func (h *Handler) DelApplication(req *restful.Request, res *restful.Response) {
 					}
 				}
 			}
-		case v1alpha1.FluxCD:
 		}
 		err = h.Delete(ctx, application)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes https://github.com/kubesphere/issues/issues/1052

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
Fix the issue of removing argocd resources without cascade parameter
```
