### PR TITLE
Bugfix 971 add check job name api

### DIFF
--- a/pkg/client/devops/fake/fakedevops.go
+++ b/pkg/client/devops/fake/fakedevops.go
@@ -169,6 +169,10 @@ func (d *Devops) GetPipeline(projectName, pipelineName string, httpParameters *d
 	return nil, nil
 }
 
+func (d *Devops) CheckPipelineName(projectName string, httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
+	return nil, nil
+}
+
 func (d *Devops) ListPipelines(httpParameters *devops.HttpParameters) (*devops.PipelineList, error) {
 	return nil, nil
 }

--- a/pkg/client/devops/jclient/pipeline.go
+++ b/pkg/client/devops/jclient/pipeline.go
@@ -225,3 +225,7 @@ func (j *JenkinsClient) CheckScriptCompile(projectName, pipelineName string, htt
 func (j *JenkinsClient) CheckCron(projectName string, httpParameters *devops.HttpParameters) (*devops.CheckCronRes, error) {
 	return j.jenkins.CheckCron(projectName, httpParameters)
 }
+
+func (j *JenkinsClient) CheckPipelineName(projectName string, httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
+	return j.jenkins.CheckPipelineName(projectName, httpParameters)
+}

--- a/pkg/client/devops/jenkins/jenkins.go
+++ b/pkg/client/devops/jenkins/jenkins.go
@@ -216,6 +216,16 @@ func (j *Jenkins) Poll() (int, error) {
 	return resp.StatusCode, nil
 }
 
+func (j *Jenkins) CheckPipelineName(projectName string, httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
+	PipelineOjb := &Pipeline{
+		HttpParameters: httpParameters,
+		Jenkins:        j,
+		Path:           fmt.Sprintf(CheckPipelineName+httpParameters.Url.RawQuery, projectName),
+	}
+	res, err := PipelineOjb.CheckPipelineName()
+	return res, err
+}
+
 func (j *Jenkins) GetPipeline(projectName, pipelineName string, httpParameters *devops.HttpParameters) (*devops.Pipeline, error) {
 	PipelineOjb := &Pipeline{
 		HttpParameters: httpParameters,

--- a/pkg/client/devops/jenkins/pipeline.go
+++ b/pkg/client/devops/jenkins/pipeline.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -84,7 +85,32 @@ const (
 	CheckCronUrl         = "/job/%s/descriptorByName/hudson.triggers.TimerTrigger/checkSpec?%s"
 
 	cronJobLayout = "Monday, January 2, 2006 15:04:05 PM"
+
+	CheckPipelineName = "/job/%s/checkJobName?"
 )
+
+func (p *Pipeline) CheckPipelineName() (map[string]interface{}, error) {
+	res, err := p.Jenkins.SendPureRequest(p.Path, p.HttpParameters)
+	if err != nil {
+		return nil, err
+	}
+
+	pattern := `>[^<]+<`
+
+	// 编译正则表达式
+	reg := regexp.MustCompile(pattern)
+
+	result := make(map[string]interface{})
+	// 提取错误消息
+	match := reg.FindString(string(res))
+	if match != "" {
+		result["exist"] = true
+	} else {
+		result["exist"] = false
+	}
+
+	return result, nil
+}
 
 func (p *Pipeline) GetPipeline() (*devops.Pipeline, error) {
 	res, err := p.Jenkins.SendPureRequest(p.Path, p.HttpParameters)

--- a/pkg/client/devops/jenkins/pipeline.go
+++ b/pkg/client/devops/jenkins/pipeline.go
@@ -95,13 +95,16 @@ func (p *Pipeline) CheckPipelineName() (map[string]interface{}, error) {
 		return nil, err
 	}
 
+	/*
+		if the name exist , the res will be
+		 <div class=error><img src='/static/7abb227e/images/none.gif' height=16 width=1>A job already exists with the name ‘devopsd6b97’</div>
+	*/
 	pattern := `>[^<]+<`
 
-	// 编译正则表达式
 	reg := regexp.MustCompile(pattern)
 
 	result := make(map[string]interface{})
-	// 提取错误消息
+
 	match := reg.FindString(string(res))
 	if match != "" {
 		result["exist"] = true

--- a/pkg/client/devops/pipeline.go
+++ b/pkg/client/devops/pipeline.go
@@ -1127,6 +1127,7 @@ type HttpParameters struct {
 
 type PipelineOperator interface {
 	// Pipelinne operator interface
+	CheckPipelineName(projectName string, httpParameters *HttpParameters) (map[string]interface{}, error)
 	GetPipeline(projectName, pipelineName string, httpParameters *HttpParameters) (*Pipeline, error)
 	ListPipelines(httpParameters *HttpParameters) (*PipelineList, error)
 	GetPipelineRun(projectName, pipelineName, runId string, httpParameters *HttpParameters) (*PipelineRun, error)

--- a/pkg/client/devops/project.go
+++ b/pkg/client/devops/project.go
@@ -26,5 +26,4 @@ type ProjectOperator interface {
 	CreateDevOpsProject(projectId string) (string, error)
 	DeleteDevOpsProject(projectId string) error
 	GetDevOpsProject(projectId string) (string, error)
-	//CheckDevOpsProject(projectId string)
 }

--- a/pkg/client/devops/project.go
+++ b/pkg/client/devops/project.go
@@ -26,4 +26,5 @@ type ProjectOperator interface {
 	CreateDevOpsProject(projectId string) (string, error)
 	DeleteDevOpsProject(projectId string) error
 	GetDevOpsProject(projectId string) (string, error)
+	//CheckDevOpsProject(projectId string)
 }

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -45,6 +45,18 @@ import (
 
 const jenkinsHeaderPre = "X-"
 
+func (h *ProjectPipelineHandler) CheckPipelineName(req *restful.Request, resp *restful.Response) {
+	jobName := req.PathParameter("devops")
+	res, err := h.devopsOperator.CheckPipelineName(jobName, req.Request)
+	if err != nil {
+		parseErr(err, resp)
+		return
+	}
+
+	resp.Header().Set(restful.HEADER_ContentType, restful.MIME_JSON)
+	resp.WriteAsJson(res)
+}
+
 func (h *ProjectPipelineHandler) GetPipeline(req *restful.Request, resp *restful.Response) {
 	projectName := req.PathParameter("devops")
 	pipelineName := req.PathParameter("pipeline")

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -108,7 +108,7 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, k8sClient)
 
 		// match Jenkins api "/job/{devops}/checkJobName?value="
-		webservice.Route(webservice.GET("/job/{devops}/checkJobName").
+		webservice.Route(webservice.GET("/devops/{devops}/checkPipelineName").
 			To(projectPipelineHandler.CheckPipelineName).
 			Doc("check the job name does it exist").
 			Param(webservice.PathParameter("value", "the name of the new job")).

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -107,6 +107,13 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 	if projectPipelineEnable {
 		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, k8sClient)
 
+		// match Jenkins api "/job/{devops}/checkJobName?value="
+		webservice.Route(webservice.GET("/job/{devops}/checkJobName").
+			To(projectPipelineHandler.CheckPipelineName).
+			Doc("check the job name does it exist").
+			Param(webservice.PathParameter("value", "the name of the new job")).
+			Returns(http.StatusOK, api.StatusOK, nil))
+
 		webservice.Route(webservice.GET("/devops/{devops}/credentials/{credential}/usage").
 			To(projectPipelineHandler.GetProjectCredentialUsage).
 			Doc("Get the specified credential usage of the DevOps project").

--- a/pkg/kapis/devops/v1alpha2/register_test.go
+++ b/pkg/kapis/devops/v1alpha2/register_test.go
@@ -93,6 +93,12 @@ func TestAPIsExist(t *testing.T) {
 			uri:    "/devops/fake/pipelines/fake",
 		},
 	}, {
+		name: "check pipeline name if exist",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/devops/fake/checkPipelineName?value=fake1",
+		},
+	}, {
 		name: "search API",
 		args: args{
 			method: http.MethodGet,

--- a/pkg/kapis/devops/v1alpha3/handler.go
+++ b/pkg/kapis/devops/v1alpha3/handler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"fmt"
 	"github.com/emicklei/go-restful"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -392,4 +393,27 @@ func (h *devopsHandler) getDevOps(request *restful.Request) (operator devops.Dev
 		operator = devops.NewDevopsOperator(h.devopsClient, k8sClient.Kubernetes(), k8sClient.KubeSphere())
 	}
 	return
+}
+
+func (h *devopsHandler) CheckDevopsName(request *restful.Request, response *restful.Response) {
+	workspace := request.PathParameter("workspace")
+	devopsName := request.QueryParameter("devopsName")
+	generateNameFlag := request.QueryParameter("generateName")
+
+	var result map[string]interface{}
+	if client, err := h.getDevOps(request); err == nil {
+
+		switch generateNameFlag {
+		case "true":
+			result, err = client.CheckDevopsProject(workspace, devopsName)
+			if err != nil {
+				errorHandle(request, response, result, err)
+			}
+			errorHandle(request, response, result, nil)
+		default:
+			errorHandle(request, response, nil, fmt.Errorf("generateNameFlag can not be false"))
+		}
+	} else {
+		kapis.HandleBadRequest(response, request, err)
+	}
 }

--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -234,6 +234,12 @@ func registerRoutersForWorkspace(handler *devopsHandler, ws *restful.WebService)
 		Doc("Get the devopsproject of the specified workspace for the current user").
 		Returns(http.StatusOK, api.StatusOK, v1alpha3.DevOpsProject{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
+
+	// /workspaces/{workspace}/devops/checkDevopsName?devopsName=xxx&generateName=true
+	ws.Route(ws.GET("/workspaces/{workspace}/devops/checkDevopsName").
+		To(handler.CheckDevopsName).
+		Doc("check the devops project name does it exist").
+		Returns(http.StatusOK, api.StatusOK, nil))
 }
 
 func registerRoutersForCI(handler *devopsHandler, ws *restful.WebService) {

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -73,6 +73,7 @@ type DevopsOperator interface {
 	UpdateCredentialObj(projectName string, secret *v1.Secret) (*v1.Secret, error)
 	ListCredentialObj(projectName string, query *query.Query) (api.ListResult, error)
 
+	CheckPipelineName(projectName string, req *http.Request) (map[string]interface{}, error)
 	GetPipeline(projectName, pipelineName string, req *http.Request) (*devops.Pipeline, error)
 	ListPipelines(req *http.Request) (*devops.PipelineList, error)
 	GetPipelineRun(projectName, pipelineName, runId string, req *http.Request) (*devops.PipelineRun, error)
@@ -441,6 +442,10 @@ func (d devopsOperator) ListCredentialObj(projectName string, query *query.Query
 	}
 
 	return *resourcesV1alpha3.DefaultList(result, query, resourcesV1alpha3.DefaultCompare(), resourcesV1alpha3.DefaultFilter()), nil
+}
+
+func (d devopsOperator) CheckPipelineName(projectName string, req *http.Request) (map[string]interface{}, error) {
+	return d.devopsClient.CheckPipelineName(projectName, convertToHttpParameters(req))
 }
 
 // others


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind api-change

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #https://github.com/kubesphere/issues/issues/971

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
add apis to check if the name of DevOps-Project or Pipeline exist
```
