### PR TITLE
change checkPipelineName and checkDevopsName apis

### DIFF
--- a/pkg/client/devops/fake/fakedevops.go
+++ b/pkg/client/devops/fake/fakedevops.go
@@ -169,7 +169,7 @@ func (d *Devops) GetPipeline(projectName, pipelineName string, httpParameters *d
 	return nil, nil
 }
 
-func (d *Devops) CheckPipelineName(projectName string, httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
+func (d *Devops) CheckPipelineName(projectName, pipelineName string, httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
 	return nil, nil
 }
 

--- a/pkg/client/devops/jclient/pipeline.go
+++ b/pkg/client/devops/jclient/pipeline.go
@@ -226,6 +226,6 @@ func (j *JenkinsClient) CheckCron(projectName string, httpParameters *devops.Htt
 	return j.jenkins.CheckCron(projectName, httpParameters)
 }
 
-func (j *JenkinsClient) CheckPipelineName(projectName string, httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
-	return j.jenkins.CheckPipelineName(projectName, httpParameters)
+func (j *JenkinsClient) CheckPipelineName(projectName, pipelineName string, httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
+	return j.jenkins.CheckPipelineName(projectName, pipelineName, httpParameters)
 }

--- a/pkg/client/devops/jenkins/jenkins.go
+++ b/pkg/client/devops/jenkins/jenkins.go
@@ -216,11 +216,13 @@ func (j *Jenkins) Poll() (int, error) {
 	return resp.StatusCode, nil
 }
 
-func (j *Jenkins) CheckPipelineName(projectName string, httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
+func (j *Jenkins) CheckPipelineName(projectName, pipelineName string, httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
+
+	httpParameters.Url.RawQuery = fmt.Sprintf("value=%s", pipelineName)
 	PipelineOjb := &Pipeline{
 		HttpParameters: httpParameters,
 		Jenkins:        j,
-		Path:           fmt.Sprintf(CheckPipelineName+httpParameters.Url.RawQuery, projectName),
+		Path:           fmt.Sprintf(CheckPipelineName, projectName),
 	}
 	res, err := PipelineOjb.CheckPipelineName()
 	return res, err

--- a/pkg/client/devops/pipeline.go
+++ b/pkg/client/devops/pipeline.go
@@ -1127,7 +1127,7 @@ type HttpParameters struct {
 
 type PipelineOperator interface {
 	// Pipelinne operator interface
-	CheckPipelineName(projectName string, httpParameters *HttpParameters) (map[string]interface{}, error)
+	CheckPipelineName(projectName, pipelineName string, httpParameters *HttpParameters) (map[string]interface{}, error)
 	GetPipeline(projectName, pipelineName string, httpParameters *HttpParameters) (*Pipeline, error)
 	ListPipelines(httpParameters *HttpParameters) (*PipelineList, error)
 	GetPipelineRun(projectName, pipelineName, runId string, httpParameters *HttpParameters) (*PipelineRun, error)

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -45,9 +45,8 @@ import (
 
 const jenkinsHeaderPre = "X-"
 
-func (h *ProjectPipelineHandler) CheckPipelineName(req *restful.Request, resp *restful.Response) {
-	jobName := req.PathParameter("devops")
-	res, err := h.devopsOperator.CheckPipelineName(jobName, req.Request)
+func (h *ProjectPipelineHandler) CheckPipelineName(req *restful.Request, resp *restful.Response, projectName, pipelineName string) {
+	res, err := h.devopsOperator.CheckPipelineName(projectName, pipelineName, req.Request)
 	if err != nil {
 		parseErr(err, resp)
 		return
@@ -60,6 +59,12 @@ func (h *ProjectPipelineHandler) CheckPipelineName(req *restful.Request, resp *r
 func (h *ProjectPipelineHandler) GetPipeline(req *restful.Request, resp *restful.Response) {
 	projectName := req.PathParameter("devops")
 	pipelineName := req.PathParameter("pipeline")
+	check := req.QueryParameter("check")
+
+	if check == "true" {
+		h.CheckPipelineName(req, resp, projectName, pipelineName)
+		return
+	}
 
 	res, err := h.devopsOperator.GetPipeline(projectName, pipelineName, req.Request)
 	if err != nil {
@@ -69,6 +74,7 @@ func (h *ProjectPipelineHandler) GetPipeline(req *restful.Request, resp *restful
 
 	resp.Header().Set(restful.HEADER_ContentType, restful.MIME_JSON)
 	resp.WriteAsJson(res)
+
 }
 
 func (h *ProjectPipelineHandler) getPipelinesByRequest(req *restful.Request) (api.ListResult, error) {

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -107,13 +107,6 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 	if projectPipelineEnable {
 		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, k8sClient)
 
-		// match Jenkins api "/job/{devops}/checkJobName?value="
-		webservice.Route(webservice.GET("/devops/{devops}/checkPipelineName").
-			To(projectPipelineHandler.CheckPipelineName).
-			Doc("check the job name does it exist").
-			Param(webservice.PathParameter("value", "the name of the new job")).
-			Returns(http.StatusOK, api.StatusOK, nil))
-
 		webservice.Route(webservice.GET("/devops/{devops}/credentials/{credential}/usage").
 			To(projectPipelineHandler.GetProjectCredentialUsage).
 			Doc("Get the specified credential usage of the DevOps project").

--- a/pkg/kapis/devops/v1alpha2/register_test.go
+++ b/pkg/kapis/devops/v1alpha2/register_test.go
@@ -93,12 +93,6 @@ func TestAPIsExist(t *testing.T) {
 			uri:    "/devops/fake/pipelines/fake",
 		},
 	}, {
-		name: "check pipeline name if exist",
-		args: args{
-			method: http.MethodGet,
-			uri:    "/devops/fake/checkPipelineName?value=fake1",
-		},
-	}, {
 		name: "search API",
 		args: args{
 			method: http.MethodGet,

--- a/pkg/kapis/devops/v1alpha3/handler.go
+++ b/pkg/kapis/devops/v1alpha3/handler.go
@@ -50,6 +50,12 @@ func (h *devopsHandler) GetDevOpsProject(request *restful.Request, response *res
 	workspace := request.PathParameter("workspace")
 	devopsProject := request.PathParameter("devops")
 	generateNameFlag := request.QueryParameter("generateName")
+	check := request.QueryParameter("check")
+
+	if check == "true" {
+		h.CheckDevopsName(request, response, workspace, devopsProject, generateNameFlag)
+		return
+	}
 
 	if client, err := h.getDevOps(request); err == nil {
 		var project *v1alpha3.DevOpsProject
@@ -395,10 +401,7 @@ func (h *devopsHandler) getDevOps(request *restful.Request) (operator devops.Dev
 	return
 }
 
-func (h *devopsHandler) CheckDevopsName(request *restful.Request, response *restful.Response) {
-	workspace := request.PathParameter("workspace")
-	devopsName := request.QueryParameter("devopsName")
-	generateNameFlag := request.QueryParameter("generateName")
+func (h *devopsHandler) CheckDevopsName(request *restful.Request, response *restful.Response, workspace, devopsName string, generateNameFlag string) {
 
 	var result map[string]interface{}
 	if client, err := h.getDevOps(request); err == nil {

--- a/pkg/kapis/devops/v1alpha3/register.go
+++ b/pkg/kapis/devops/v1alpha3/register.go
@@ -235,11 +235,6 @@ func registerRoutersForWorkspace(handler *devopsHandler, ws *restful.WebService)
 		Returns(http.StatusOK, api.StatusOK, v1alpha3.DevOpsProject{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsProjectTag}))
 
-	// /workspaces/{workspace}/devops/checkDevopsName?devopsName=xxx&generateName=true
-	ws.Route(ws.GET("/workspaces/{workspace}/devops/checkDevopsName").
-		To(handler.CheckDevopsName).
-		Doc("check the devops project name does it exist").
-		Returns(http.StatusOK, api.StatusOK, nil))
 }
 
 func registerRoutersForCI(handler *devopsHandler, ws *restful.WebService) {

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -74,7 +74,7 @@ type DevopsOperator interface {
 	UpdateCredentialObj(projectName string, secret *v1.Secret) (*v1.Secret, error)
 	ListCredentialObj(projectName string, query *query.Query) (api.ListResult, error)
 
-	CheckPipelineName(projectName string, req *http.Request) (map[string]interface{}, error)
+	CheckPipelineName(projectName, pipelineName string, req *http.Request) (map[string]interface{}, error)
 	GetPipeline(projectName, pipelineName string, req *http.Request) (*devops.Pipeline, error)
 	ListPipelines(req *http.Request) (*devops.PipelineList, error)
 	GetPipelineRun(projectName, pipelineName, runId string, req *http.Request) (*devops.PipelineRun, error)
@@ -469,8 +469,8 @@ func (d devopsOperator) ListCredentialObj(projectName string, query *query.Query
 	return *resourcesV1alpha3.DefaultList(result, query, resourcesV1alpha3.DefaultCompare(), resourcesV1alpha3.DefaultFilter()), nil
 }
 
-func (d devopsOperator) CheckPipelineName(projectName string, req *http.Request) (map[string]interface{}, error) {
-	return d.devopsClient.CheckPipelineName(projectName, convertToHttpParameters(req))
+func (d devopsOperator) CheckPipelineName(projectName, pipelineName string, req *http.Request) (map[string]interface{}, error) {
+	return d.devopsClient.CheckPipelineName(projectName, pipelineName, convertToHttpParameters(req))
 }
 
 // others


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind api-change

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #https://github.com/kubesphere/issues/issues/971

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
none
```
