### PR TITLE
Fix nil in log

### DIFF
--- a/controllers/argocd/multi-cluster-controller.go
+++ b/controllers/argocd/multi-cluster-controller.go
@@ -155,7 +155,7 @@ func getArgoClusterConfigObject(configText string) (object *ClusterConfig) {
 	rawDecodedconfig, _ := base64.StdEncoding.DecodeString(configText)
 
 	var kubeconfig *config
-	if kubeconfig = parseKubeConfig(rawDecodedconfig); kubeconfig == nil {
+	if kubeconfig, _ = parseKubeConfig(rawDecodedconfig); kubeconfig == nil {
 		return
 	}
 

--- a/controllers/argocd/types.go
+++ b/controllers/argocd/types.go
@@ -19,7 +19,6 @@ limitations under the License.
 package argocd
 
 import (
-	"fmt"
 	"gopkg.in/yaml.v2"
 )
 
@@ -58,11 +57,12 @@ type TLSClientConfig struct {
 	CAData []byte `json:"caData,omitempty"`
 }
 
-func parseKubeConfig(data []byte) (cfg *config) {
-	cfg = &config{}
-	err := yaml.Unmarshal(data, cfg)
-	fmt.Println(err)
-	return
+func parseKubeConfig(data []byte) (*config, error) {
+	cfg := &config{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }
 
 type config struct {

--- a/controllers/argocd/types_test.go
+++ b/controllers/argocd/types_test.go
@@ -63,7 +63,9 @@ users:
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, parseKubeConfig(tt.args.data), "parseKubeConfig(%v)", tt.args.data)
+			config, err := parseKubeConfig(tt.args.data)
+			assert.Nil(t, err)
+			assert.Equalf(t, tt.want, config, "parseKubeConfig(%v)", tt.args.data)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
Fix nil in log
```
