### PR TITLE
fix argocd controller

### DIFF
--- a/controllers/argocd/multi-cluster-controller.go
+++ b/controllers/argocd/multi-cluster-controller.go
@@ -62,11 +62,6 @@ func (r *MultiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
-	// ignore the host cluster
-	if ignore(cluster) {
-		return
-	}
-
 	ownerRef := getOwnerReference(cluster)
 	argoCluster := createArgoCluster(cluster)
 	argoCluster.SetNamespace(r.argocdNamespace)
@@ -194,14 +189,6 @@ func getCluster(client client.Reader, namespacedName types.NamespacedName) (clus
 		cluster = nil
 	}
 	return
-}
-
-func ignore(cluster *unstructured.Unstructured) bool {
-	if cluster != nil {
-		_, ok := cluster.GetLabels()["cluster-role.kubesphere.io/host"]
-		return ok
-	}
-	return true
 }
 
 // GetName returns the name of this controller

--- a/controllers/argocd/multi-cluster-controller_test.go
+++ b/controllers/argocd/multi-cluster-controller_test.go
@@ -37,49 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func Test_ignore(t *testing.T) {
-	sampleCluster := &unstructured.Unstructured{}
-	sampleCluster.SetKind("Cluster")
-	sampleCluster.SetAPIVersion("cluster.kubesphere.io/v1alpha1")
-
-	type args struct {
-		cluster func() *unstructured.Unstructured
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{{
-		name: "cluster is nil",
-		want: true,
-	}, {
-		name: "cluster without the particular label",
-		args: args{cluster: func() *unstructured.Unstructured {
-			return sampleCluster.DeepCopy()
-		}},
-		want: false,
-	}, {
-		name: "with the particular label",
-		args: args{cluster: func() *unstructured.Unstructured {
-			cluster := sampleCluster.DeepCopy()
-			cluster.SetLabels(map[string]string{
-				"cluster-role.kubesphere.io/host": "",
-			})
-			return cluster
-		}},
-		want: true,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var cluster *unstructured.Unstructured
-			if tt.args.cluster != nil {
-				cluster = tt.args.cluster()
-			}
-			assert.Equalf(t, tt.want, ignore(cluster), "ignore(%v)", tt.args.cluster)
-		})
-	}
-}
-
 func Test_createArgoCluster(t *testing.T) {
 	defaultCluster := &unstructured.Unstructured{}
 	defaultCluster.SetKind("Cluster")

--- a/controllers/fluxcd/multi-cluster-controller.go
+++ b/controllers/fluxcd/multi-cluster-controller.go
@@ -57,24 +57,11 @@ func (r *MultiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return
 	}
 
-	// ignore the host cluster
-	if ignore(cluster) {
-		return
-	}
-
 	if err = r.reconcileCluster(ctx, cluster); err != nil {
 		return
 	}
 
 	return
-}
-
-func ignore(cluster *unstructured.Unstructured) bool {
-	if cluster != nil {
-		_, ok := cluster.GetLabels()["cluster-role.kubesphere.io/host"]
-		return ok
-	}
-	return true
 }
 
 func (r *MultiClusterReconciler) reconcileCluster(ctx context.Context, cluster *unstructured.Unstructured) (err error) {

--- a/controllers/fluxcd/multi-cluster-controller_test.go
+++ b/controllers/fluxcd/multi-cluster-controller_test.go
@@ -37,49 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func Test_ignore(t *testing.T) {
-	sampleCluster := &unstructured.Unstructured{}
-	sampleCluster.SetKind("Cluster")
-	sampleCluster.SetAPIVersion("cluster.kubesphere.io/v1alpha1")
-
-	type args struct {
-		cluster func() *unstructured.Unstructured
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{{
-		name: "cluster is nil",
-		want: true,
-	}, {
-		name: "cluster without the particular label",
-		args: args{cluster: func() *unstructured.Unstructured {
-			return sampleCluster.DeepCopy()
-		}},
-		want: false,
-	}, {
-		name: "with the particular label",
-		args: args{cluster: func() *unstructured.Unstructured {
-			cluster := sampleCluster.DeepCopy()
-			cluster.SetLabels(map[string]string{
-				"cluster-role.kubesphere.io/host": "",
-			})
-			return cluster
-		}},
-		want: true,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var cluster *unstructured.Unstructured
-			if tt.args.cluster != nil {
-				cluster = tt.args.cluster()
-			}
-			assert.Equalf(t, tt.want, ignore(cluster), "ignore(%v)", tt.args.cluster)
-		})
-	}
-}
-
 func TestMultiClusterReconciler_Reconcile(t *testing.T) {
 	schema, err := v1alpha1.SchemeBuilder.Register().Build()
 	assert.Nil(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:
allow deploy application on host cluster

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes https://github.com/kubesphere/project/issues/6084

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
Fix argocd cluster controller
```
