### PR TITLE
support kubeconfig saving type

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,48 +44,40 @@ jobs:
           echo ::set-output name=version::${VERSION}
       - name: Docker meta for kubesphere
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             kubesphere/devops-controller
           tags: ${{ steps.prepare.outputs.version }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
       - name: Build env
         id: build_env
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]
+          if [ ${{ github.ref_type }} == "tag" ]
           then
-              echo "::set-output name=platforms::linux/amd64"
-              echo "::set-output name=push::false"
-              echo "::set-output name=load::true"
-              echo "::set-output name=ref::pr-$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
-          else
               echo "::set-output name=platforms::linux/amd64,linux/arm64"
-              echo "::set-output name=push::true"
-              echo "::set-output name=load::false"
-              echo "::set-output name=ref::${{github.ref_name}}"
+          else
+              echo "::set-output name=platforms::linux/amd64"
           fi
+          echo "::set-output name=push::true"
+          echo "::set-output name=ref::${{github.ref_name}}"
           echo "::set-output name=short_sha::${GITHUB_SHA::7}"
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v6
         with:
           file: config/dockerfiles/controller-manager/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ steps.build_env.outputs.push }}
-          load: ${{ steps.build_env.outputs.load }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ steps.build_env.outputs.platforms }}
-          provenance: false
-          sbom: false
 
   BuildAPIServer:
     runs-on: ubuntu-latest
@@ -104,48 +96,40 @@ jobs:
           echo ::set-output name=version::${VERSION}
       - name: Docker meta for kubesphere
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             kubesphere/devops-apiserver
           tags: ${{ steps.prepare.outputs.version }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
       - name: Build env
         id: build_env
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]
+          if [ ${{ github.ref_type }} == "tag" ]
           then
-              echo "::set-output name=platforms::linux/amd64"
-              echo "::set-output name=push::false"
-              echo "::set-output name=load::true"
-              echo "::set-output name=ref::pr-$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
-          else
               echo "::set-output name=platforms::linux/amd64,linux/arm64"
-              echo "::set-output name=push::true"
-              echo "::set-output name=load::false"
-              echo "::set-output name=ref::${{github.ref_name}}"
+          else
+              echo "::set-output name=platforms::linux/amd64"
           fi
+          echo "::set-output name=push::true"
+          echo "::set-output name=ref::${{github.ref_name}}"
           echo "::set-output name=short_sha::${GITHUB_SHA::7}"
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v6
         with:
           file: config/dockerfiles/apiserver/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ steps.build_env.outputs.push }}
-          load: ${{ steps.build_env.outputs.load }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ steps.build_env.outputs.platforms }}
-          provenance: false
-          sbom: false
 
   BuildTools:
     runs-on: ubuntu-latest
@@ -164,45 +148,37 @@ jobs:
           echo ::set-output name=version::${VERSION}
       - name: Docker meta for kubesphere
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             kubesphere/devops-tools
           tags: ${{ steps.prepare.outputs.version }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
       - name: Build env
         id: build_env
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]
+          if [ ${{ github.ref_type }} == "tag" ]
           then
-              echo "::set-output name=platforms::linux/amd64"
-              echo "::set-output name=push::false"
-              echo "::set-output name=load::true"
-              echo "::set-output name=ref::pr-$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
-          else
               echo "::set-output name=platforms::linux/amd64,linux/arm64"
-              echo "::set-output name=push::true"
-              echo "::set-output name=load::false"
-              echo "::set-output name=ref::${{github.ref_name}}"
+          else
+              echo "::set-output name=platforms::linux/amd64"
           fi
+          echo "::set-output name=push::true"
+          echo "::set-output name=ref::${{github.ref_name}}"
           echo "::set-output name=short_sha::${GITHUB_SHA::7}"
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v6
         with:
           file: config/dockerfiles/tools/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ steps.build_env.outputs.push }}
-          load: ${{ steps.build_env.outputs.load }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ steps.build_env.outputs.platforms }}
-          provenance: false
-          sbom: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,16 +86,6 @@ jobs:
           platforms: ${{ steps.build_env.outputs.platforms }}
           provenance: false
           sbom: false
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
-        if: github.event_name == 'pull_request'
-        with:
-          image-ref: 'docker.io/kubesphere/devops-controller:${{ steps.build_env.outputs.ref }}-${{ steps.build_env.outputs.short_sha }}'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
 
   BuildAPIServer:
     runs-on: ubuntu-latest
@@ -156,16 +146,6 @@ jobs:
           platforms: ${{ steps.build_env.outputs.platforms }}
           provenance: false
           sbom: false
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
-        if: github.event_name == 'pull_request'
-        with:
-          image-ref: 'docker.io/kubesphere/devops-apiserver:${{ steps.build_env.outputs.ref }}-${{ steps.build_env.outputs.short_sha }}'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
 
   BuildTools:
     runs-on: ubuntu-latest
@@ -226,13 +206,3 @@ jobs:
           platforms: ${{ steps.build_env.outputs.platforms }}
           provenance: false
           sbom: false
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
-        if: github.event_name == 'pull_request'
-        with:
-          image-ref: 'docker.io/kubesphere/devops-tools:${{ steps.build_env.outputs.ref }}-${{ steps.build_env.outputs.short_sha }}'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,9 @@ on:
       tag:
         description: "Image Tag"
         default: "latest"
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master

--- a/pkg/api/devops/v1alpha3/credential_types.go
+++ b/pkg/api/devops/v1alpha3/credential_types.go
@@ -52,19 +52,21 @@ const (
 	// SSHAuthPrivateKey is the key of the privatekey for SecretTypeSSHAuth secrets
 	SSHAuthPrivateKey = "private_key"
 
+	SecretTextString = "secret-text"
 	// SecretTypeSecretText contains data.
 	//
 	// Required at least one of fields:
 	// - Secret.Data["secret"] - secret
-	SecretTypeSecretText v1.SecretType = DevOpsCredentialPrefix + "secret-text"
+	SecretTypeSecretText v1.SecretType = DevOpsCredentialPrefix + SecretTextString
 	// SecretTextSecretKey is the key of the secret for SecretTypeSecretText secrets
 	SecretTextSecretKey = "secret"
 
+	KubeConfigString = "kubeconfig"
 	// SecretTypeKubeConfig contains data.
 	//
 	// Required at least one of fields:
 	// - Secret.Data["secret"] - secret
-	SecretTypeKubeConfig v1.SecretType = DevOpsCredentialPrefix + "kubeconfig"
+	SecretTypeKubeConfig v1.SecretType = DevOpsCredentialPrefix + KubeConfigString
 	// KubeConfigSecretKey is the key of the secret for SecretTypeKubeConfig secrets
 	KubeConfigSecretKey = "content"
 	//	CredentialAutoSyncAnnoKey is used to indicate whether the secret is automatically synchronized to devops.

--- a/pkg/client/devops/credential.go
+++ b/pkg/client/devops/credential.go
@@ -68,4 +68,6 @@ type CredentialOperator interface {
 	GetCredentialInProject(projectId, id string) (*Credential, error)
 
 	DeleteCredentialInProject(projectId, id string) (string, error)
+
+	GetKubeConfigCredentialStoreType() string
 }

--- a/pkg/client/devops/jclient/credential.go
+++ b/pkg/client/devops/jclient/credential.go
@@ -28,7 +28,7 @@ func (j *JenkinsClient) CreateCredentialInProject(projectID string, credential *
 	client := j.getClient()
 
 	var cre interface{}
-	if cre, err = util.ConvertSecretToCredential(credential); err != nil {
+	if cre, err = util.ConvertSecretToCredential(credential, j.SaveKubeConfigAs); err != nil {
 		return "", err
 	}
 	return "", client.CreateInFolder(projectID, cre)
@@ -39,7 +39,7 @@ func (j *JenkinsClient) UpdateCredentialInProject(projectID string, credential *
 	client := j.getClient()
 
 	var cre interface{}
-	if cre, err = util.ConvertSecretToCredential(credential); err != nil {
+	if cre, err = util.ConvertSecretToCredential(credential, j.SaveKubeConfigAs); err != nil {
 		return "", err
 	}
 
@@ -56,6 +56,10 @@ func (j *JenkinsClient) GetCredentialInProject(projectID, id string) (*devops.Cr
 func (j *JenkinsClient) DeleteCredentialInProject(projectID, id string) (string, error) {
 	client := j.getClient()
 	return id, client.DeleteInFolder(projectID, id)
+}
+
+func (j *JenkinsClient) GetKubeConfigCredentialStoreType() string {
+	return j.SaveKubeConfigAs
 }
 
 func (j *JenkinsClient) getClient() *jcredential.CredentialsManager {

--- a/pkg/client/devops/jclient/credential_test.go
+++ b/pkg/client/devops/jclient/credential_test.go
@@ -70,7 +70,7 @@ func TestUpdateCredentialInProject(t *testing.T) {
 	secret.SetName("id")
 	secret.Type = devopsv1alpha3.SecretTypeBasicAuth
 
-	data, err := devopsutil.ConvertSecretToCredential(secret.DeepCopy())
+	data, err := devopsutil.ConvertSecretToCredential(secret.DeepCopy(), devopsv1alpha3.KubeConfigString)
 	assert.Nil(t, err)
 
 	formData := url.Values{}
@@ -108,7 +108,7 @@ func TestCreateCredentialInProject(t *testing.T) {
 	unknownSecret := secret.DeepCopy()
 	unknownSecret.Type = "fake"
 
-	data, err := devopsutil.ConvertSecretToCredential(secret.DeepCopy())
+	data, err := devopsutil.ConvertSecretToCredential(secret.DeepCopy(), devopsv1alpha3.KubeConfigString)
 	assert.Nil(t, err)
 
 	formData := url.Values{}

--- a/pkg/client/devops/jclient/jenkins.go
+++ b/pkg/client/devops/jclient/jenkins.go
@@ -25,8 +25,9 @@ import (
 
 // JenkinsClient represents a client of Jenkins
 type JenkinsClient struct {
-	Core    core.JenkinsCore
-	jenkins *jenkins.Jenkins // For refactor purpose only
+	Core             core.JenkinsCore
+	SaveKubeConfigAs string
+	jenkins          *jenkins.Jenkins // For refactor purpose only
 }
 
 var _ devops.Interface = &JenkinsClient{}
@@ -41,7 +42,8 @@ func NewJenkinsClient(options *jenkins.Options) (*JenkinsClient, error) {
 
 	devopsClient, _ := jenkins.NewDevopsClient(options) // For refactor purpose only
 	return &JenkinsClient{
-		Core:    jenkinsCore,
-		jenkins: devopsClient, // For refactor purpose only
+		Core:             jenkinsCore,
+		jenkins:          devopsClient, // For refactor purpose only
+		SaveKubeConfigAs: options.SaveKubeConfigAs,
 	}, nil
 }

--- a/pkg/client/devops/jenkins/options.go
+++ b/pkg/client/devops/jenkins/options.go
@@ -18,22 +18,24 @@ package jenkins
 
 import (
 	"fmt"
-	"github.com/kubesphere/ks-devops/pkg/utils/reflectutils"
 	"time"
+
+	"github.com/kubesphere/ks-devops/pkg/utils/reflectutils"
 
 	"github.com/spf13/pflag"
 )
 
 type Options struct {
-	Host            string        `json:",omitempty" yaml:"host" description:"Jenkins service host address"`
-	Username        string        `json:",omitempty" yaml:"username" description:"Jenkins admin username"`
-	Password        string        `json:",omitempty" yaml:"password" description:"Jenkins admin password"`
-	ApiToken        string        `json:"apiToken,omitempty" yaml:"apiToken" description:"Jenkins admin apiToken"`
-	MaxConnections  int           `json:"maxConnections,omitempty" yaml:"maxConnections" description:"Maximum connections allowed to connect to Jenkins"`
-	Namespace       string        `json:"namespace,omitempty" yaml:"namespace"`
-	WorkerNamespace string        `json:"workerNamespace,omitempty" yaml:"workerNamespace"`
-	ReloadCasCDelay time.Duration `json:"reloadCasCDelay,omitempty" yaml:"reloadCasCDelay"`
-	SkipVerify      bool
+	Host             string        `json:",omitempty" yaml:"host" description:"Jenkins service host address"`
+	Username         string        `json:",omitempty" yaml:"username" description:"Jenkins admin username"`
+	Password         string        `json:",omitempty" yaml:"password" description:"Jenkins admin password"`
+	ApiToken         string        `json:"apiToken,omitempty" yaml:"apiToken" description:"Jenkins admin apiToken"`
+	MaxConnections   int           `json:"maxConnections,omitempty" yaml:"maxConnections" description:"Maximum connections allowed to connect to Jenkins"`
+	Namespace        string        `json:"namespace,omitempty" yaml:"namespace"`
+	WorkerNamespace  string        `json:"workerNamespace,omitempty" yaml:"workerNamespace"`
+	ReloadCasCDelay  time.Duration `json:"reloadCasCDelay,omitempty" yaml:"reloadCasCDelay"`
+	SkipVerify       bool
+	SaveKubeConfigAs string `json:"saveKubeConfigAs,omitempty" yaml:"saveKubeConfigAs"` // values: [secret-text, kubeconfig]. default is kubeconfig
 }
 
 // NewJenkinsOptions returns a `zero` instance

--- a/pkg/client/devops/util/credential.go
+++ b/pkg/client/devops/util/credential.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ConvertSecretToCredential converts a secret to Jenkins credential type
-func ConvertSecretToCredential(secret *v1.Secret) (interface{}, error) {
+func ConvertSecretToCredential(secret *v1.Secret, saveKubeConfigAs string) (interface{}, error) {
 	name := secret.GetName()
 
 	switch secret.Type {
@@ -45,6 +45,10 @@ func ConvertSecretToCredential(secret *v1.Secret) (interface{}, error) {
 		return jcredential.NewSecretTextCredential(name, secretContent), nil
 	case devopsv1alpha3.SecretTypeKubeConfig:
 		secretContent := string(secret.Data[devopsv1alpha3.KubeConfigSecretKey])
+		// for backward compatibility, empty value means kubeconfig
+		if saveKubeConfigAs == devopsv1alpha3.SecretTextString {
+			return jcredential.NewSecretTextCredential(name, secretContent), nil
+		}
 		return jcredential.NewKubeConfigCredential(name, secretContent), nil
 	default:
 		err := fmt.Errorf("error unsupport credential type")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

the kubeconfigContent credential is deprecated because the provider https://github.com/jenkinsci/kubernetes-cd-plugin has been suspended, should use secret-text to store kubeconfig in the future.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes https://github.com/kubesphere/project/issues/6185

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
support multiple kubeconfig saving types
```
