### PR TITLE
support self-signed certificates & skip tls authentication

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -17,14 +17,17 @@ limitations under the License.
 package constants
 
 const (
-	CreatorAnnotationKey         = "kubesphere.io/creator"
-	WorkspaceLabelKey            = "kubesphere.io/workspace"
-	DisplayNameAnnotationKey     = "kubesphere.io/alias-name"
-	InsecureSkipTLSAnnotationKey = "devops.kubesphere.io/insecure-skip-tls"
-	GitAuthorNameAnnotationKey   = "devops.kubesphere.io/git-author-name"
-	GitAuthorEmailAnnotationKey  = "devops.kubesphere.io/git-author-email"
-	DevOpsProjectLabelKey        = "kubesphere.io/devopsproject"
+	CreatorAnnotationKey           = "kubesphere.io/creator"
+	WorkspaceLabelKey              = "kubesphere.io/workspace"
+	DisplayNameAnnotationKey       = "kubesphere.io/alias-name"
+	InsecureSkipTLSAnnotationKey   = "devops.kubesphere.io/insecure-skip-tls"
+	TLSCertsNameAnnotationKey      = "devops.kubesphere.io/tls-certs"
+	TLSCertsNameSpaceAnnotationKey = "devops.kubesphere.io/tls-certs-namespace"
+	GitAuthorNameAnnotationKey     = "devops.kubesphere.io/git-author-name"
+	GitAuthorEmailAnnotationKey    = "devops.kubesphere.io/git-author-email"
+	DevOpsProjectLabelKey          = "kubesphere.io/devopsproject"
 
+	TLSCertKey               = "ca.crt"
 	AuthenticationTag        = "Authentication"
 	DevOpsCredentialTag      = "DevOps Credential"
 	DevOpsPipelineTag        = "DevOps Pipeline"
@@ -38,7 +41,9 @@ const (
 	DevOpsClusterTemplateTag = "DevOps ClusterTemplate"
 	GitOpsTag                = "GitOps"
 
-	DevOpsManagedKey = "devops.kubesphere.io/managed"
+	DevOpsManagedKey      = "devops.kubesphere.io/managed"
+	DevOpsSystemNamespace = "kubesphere-devops-system"
+	DevOpsWorkerNamespace = "kubesphere-devops-worker"
 )
 
 var (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes # https://github.com/kubesphere/project/issues/6609

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
support self-signed certificates & skip tls authentication
```
