### PR TITLE
fix : remove the meaningless method GetKubeConfigCredentialStoreType …

### DIFF
--- a/pkg/client/devops/credential.go
+++ b/pkg/client/devops/credential.go
@@ -68,6 +68,4 @@ type CredentialOperator interface {
 	GetCredentialInProject(projectId, id string) (*Credential, error)
 
 	DeleteCredentialInProject(projectId, id string) (string, error)
-
-	GetKubeConfigCredentialStoreType() string
 }


### PR DESCRIPTION
The Jenkins struct needs to implement the CredentialOperator interface, but it does not implement GetKubeConfigCredentialStoreType. Moreover, this method is not observed to be used in the normal workflow. Our modification here is to delete the definition of this method. 