### PR TITLE
change log level for error

### DIFF
--- a/controllers/jenkins/devopscredential/devopscredential_controller.go
+++ b/controllers/jenkins/devopscredential/devopscredential_controller.go
@@ -266,14 +266,14 @@ func (c *Controller) syncHandler(key string) error {
 			if _, ok := copySecret.Annotations[devopsv1alpha3.CredentialAutoSyncAnnoKey]; ok {
 				_, err := c.devopsClient.UpdateCredentialInProject(nsName, copySecret)
 				if err != nil {
-					klog.V(8).Info(err, fmt.Sprintf("failed to update secret %s ", key))
+					klog.ErrorS(err, fmt.Sprintf("failed to update secret %s ", key))
 					return err
 				}
 			}
 		} else {
 			_, err = c.devopsClient.CreateCredentialInProject(nsName, copySecret)
 			if err != nil {
-				klog.V(8).Info(err, fmt.Sprintf("failed to create secret %s ", key))
+				klog.ErrorS(err, fmt.Sprintf("failed to create secret %s ", key))
 				return err
 			}
 		}
@@ -293,7 +293,7 @@ func (c *Controller) syncHandler(key string) error {
 					klog.Error(fmt.Sprintf("unexpected error type: %v, should be *restful.ServiceError", err))
 				}
 
-				klog.V(8).Info(err, fmt.Sprintf("failed to delete secret %s in devops", key))
+				klog.ErrorS(err, fmt.Sprintf("failed to delete secret %s in devops", key))
 			} else {
 				delSuccess = true
 			}
@@ -313,7 +313,7 @@ func (c *Controller) syncHandler(key string) error {
 	if !reflect.DeepEqual(secret, copySecret) {
 		_, err = c.client.CoreV1().Secrets(nsName).Update(context.Background(), copySecret, metav1.UpdateOptions{})
 		if err != nil {
-			klog.V(8).Info(err, fmt.Sprintf("failed to update secret %s ", key))
+			klog.ErrorS(err, fmt.Sprintf("failed to update secret %s ", key))
 			return err
 		}
 	}

--- a/controllers/jenkins/devopsproject/devopsproject_controller.go
+++ b/controllers/jenkins/devopsproject/devopsproject_controller.go
@@ -207,7 +207,7 @@ func (c *Controller) syncHandler(key string) error {
 			klog.Info(fmt.Sprintf("devopsproject '%s' in work queue no longer exists ", key))
 			return nil
 		}
-		klog.V(8).Info(err, fmt.Sprintf("could not get devopsproject %s ", key))
+		klog.ErrorS(err, fmt.Sprintf("could not get devopsproject %s ", key))
 		return err
 	}
 	copyProject := project.DeepCopy()
@@ -227,14 +227,14 @@ func (c *Controller) syncHandler(key string) error {
 		if project.Status.AdminNamespace != "" {
 			ns, err := c.namespaceLister.Get(project.Status.AdminNamespace)
 			if err != nil && !errors.IsNotFound(err) {
-				klog.V(8).Info(err, "failed to get namespace")
+				klog.ErrorS(err, "failed to get namespace")
 				return err
 			} else if errors.IsNotFound(err) {
 				// if admin ns is not found, clean project status, rerun reconcile
 				copyProject.Status.AdminNamespace = ""
 				_, err := c.kubesphereClient.DevopsV1alpha3().DevOpsProjects().Update(context.Background(), copyProject, metav1.UpdateOptions{})
 				if err != nil {
-					klog.V(8).Info(err, fmt.Sprintf("failed to update project %s ", key))
+					klog.ErrorS(err, fmt.Sprintf("failed to update project %s ", key))
 					return err
 				}
 				c.enqueueDevOpsProject(key)
@@ -250,7 +250,7 @@ func (c *Controller) syncHandler(key string) error {
 				copyNs.Labels[constants.DevOpsProjectLabelKey] = project.Name
 				_, err = c.client.CoreV1().Namespaces().Update(context.Background(), copyNs, metav1.UpdateOptions{})
 				if err != nil {
-					klog.V(8).Info(err, fmt.Sprintf("failed to update ns %s ", key))
+					klog.ErrorS(err, fmt.Sprintf("failed to update ns %s ", key))
 					return err
 				}
 			}
@@ -260,7 +260,7 @@ func (c *Controller) syncHandler(key string) error {
 			namespaces, err := c.namespaceLister.List(
 				labels.SelectorFromSet(labels.Set{constants.DevOpsProjectLabelKey: project.Name}))
 			if err != nil {
-				klog.V(8).Info(err, fmt.Sprintf("failed to list ns %s ", key))
+				klog.ErrorS(err, fmt.Sprintf("failed to list ns %s ", key))
 				return err
 			}
 			// if there is no ns, generate new one
@@ -274,7 +274,7 @@ func (c *Controller) syncHandler(key string) error {
 						c.eventRecorder.Event(project, v1.EventTypeWarning, "CreateAdminNamespaceFailed", err.Error())
 						return err
 					}
-					klog.V(8).Info(err, fmt.Sprintf("failed to create ns %s ", key))
+					klog.ErrorS(err, fmt.Sprintf("failed to create ns %s ", key))
 					return err
 				}
 				copyProject.Status.AdminNamespace = ns.Name
@@ -285,7 +285,7 @@ func (c *Controller) syncHandler(key string) error {
 					copyNs.Labels[constants.DevOpsProjectLabelKey] = project.Name
 					_, err = c.client.CoreV1().Namespaces().Update(context.Background(), copyNs, metav1.UpdateOptions{})
 					if err != nil {
-						klog.V(8).Info(err, fmt.Sprintf("failed to update ns %s ", key))
+						klog.ErrorS(err, fmt.Sprintf("failed to update ns %s ", key))
 						return err
 					}
 				}
@@ -304,7 +304,7 @@ func (c *Controller) syncHandler(key string) error {
 		if err != nil {
 			_, err := c.devopsClient.CreateDevOpsProject(copyProject.Status.AdminNamespace)
 			if err != nil {
-				klog.V(8).Info(err, fmt.Sprintf("failed to get project %s ", key))
+				klog.ErrorS(err, fmt.Sprintf("failed to get project %s ", key))
 				return err
 			}
 		}
@@ -317,7 +317,7 @@ func (c *Controller) syncHandler(key string) error {
 		if !reflect.DeepEqual(copyProject, project) {
 			_, err = c.kubesphereClient.DevopsV1alpha3().DevOpsProjects().Update(context.Background(), copyProject, metav1.UpdateOptions{})
 			if err != nil {
-				klog.V(8).Info(err, fmt.Sprintf("failed to update ns %s ", key))
+				klog.ErrorS(err, fmt.Sprintf("failed to update ns %s ", key))
 				return err
 			}
 		}
@@ -336,7 +336,7 @@ func (c *Controller) syncHandler(key string) error {
 					klog.Error(fmt.Sprintf("unexpected error type: %v, should be *restful.ServiceError", err))
 				}
 
-				klog.V(8).Info(err, fmt.Sprintf("failed to delete resource %s in devops", key))
+				klog.ErrorS(err, fmt.Sprintf("failed to delete resource %s in devops", key))
 			} else {
 				delSuccess = true
 			}
@@ -353,7 +353,7 @@ func (c *Controller) syncHandler(key string) error {
 
 			_, err = c.kubesphereClient.DevopsV1alpha3().DevOpsProjects().Update(context.Background(), project, metav1.UpdateOptions{})
 			if err != nil {
-				klog.V(8).Info(err, fmt.Sprintf("failed to update project %s ", key))
+				klog.ErrorS(err, fmt.Sprintf("failed to update project %s ", key))
 				return err
 			}
 		}

--- a/controllers/jenkins/pipeline/pipeline_controller.go
+++ b/controllers/jenkins/pipeline/pipeline_controller.go
@@ -214,7 +214,7 @@ func (c *Controller) syncHandler(key string) error {
 	//		klog.Info(fmt.Sprintf("namespace '%s' in work queue no longer exists ", key))
 	//		return nil
 	//	}
-	//	klog.V(8).Info(err, fmt.Sprintf("could not get namespace %s ", key))
+	//	klog.ErrorS(err, fmt.Sprintf("could not get namespace %s ", key))
 	//	return err
 	//}
 	// TODO this is the KubeSphere core part instead of the DevOps part
@@ -265,7 +265,7 @@ func (c *Controller) syncHandler(key string) error {
 			if !reflect.DeepEqual(jenkinsPipeline.Spec, copyPipeline.Spec) {
 				_, err := c.devopsClient.UpdateProjectPipeline(nsName, copyPipeline)
 				if err != nil {
-					klog.V(8).Info(err, fmt.Sprintf("failed to update pipeline config %s ", key))
+					klog.ErrorS(err, fmt.Sprintf("failed to update pipeline config %s ", key))
 					return err
 				}
 			} else {
@@ -274,7 +274,7 @@ func (c *Controller) syncHandler(key string) error {
 		} else {
 			_, err = c.devopsClient.CreateProjectPipeline(nsName, copyPipeline)
 			if err != nil {
-				klog.V(8).Info(err, fmt.Sprintf("failed to create copyPipeline %s ", key))
+				klog.ErrorS(err, fmt.Sprintf("failed to create copyPipeline %s ", key))
 				return err
 			}
 		}
@@ -295,7 +295,7 @@ func (c *Controller) syncHandler(key string) error {
 					klog.Error(fmt.Sprintf("unexpected error type: %v, should be *restful.ServiceError", err))
 				}
 
-				klog.V(8).Info(err, fmt.Sprintf("failed to delete pipeline %s in devops", key))
+				klog.ErrorS(err, fmt.Sprintf("failed to delete pipeline %s in devops", key))
 			} else {
 				delSuccess = true
 			}

--- a/pkg/client/devops/jenkins/pure_request.go
+++ b/pkg/client/devops/jenkins/pure_request.go
@@ -40,7 +40,7 @@ func (j *Jenkins) SendPureRequest(path string, httpParameters *devops.HttpParame
 func (j *Jenkins) SendPureRequestWithHeaderResp(path string, httpParameters *devops.HttpParameters) ([]byte, http.Header, error) {
 	apiURL, err := url.Parse(j.Server + path)
 	if err != nil {
-		klog.V(8).Info(err)
+		klog.ErrorS(err, "failed to parse url")
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

Most errors are unexpected, and should be logged by default level, not a level 8, which makes unnecessary troubles when debugging problems.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note
none
```
