### PR TITLE
feat: add hub.kubesphere.com.cn registry to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,7 @@ jobs:
         with:
           images: |
             kubesphere/devops-controller
+            hub.kubesphere.com.cn/kubesphere/devops-controller
           tags: ${{ steps.prepare.outputs.version }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -55,6 +56,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
+      - name: Login to hub.kubesphere.com.cn
+        uses: docker/login-action@v3
+        with:
+          registry: hub.kubesphere.com.cn
+          username: ${{ secrets.HUB_KUBESPHERE_USERNAME }}
+          password: ${{ secrets.HUB_KUBESPHERE_PASSWORD }}
       - name: Build env
         id: build_env
         run: |
@@ -97,6 +104,7 @@ jobs:
         with:
           images: |
             kubesphere/devops-apiserver
+            hub.kubesphere.com.cn/kubesphere/devops-apiserver
           tags: ${{ steps.prepare.outputs.version }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -107,6 +115,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
+      - name: Login to hub.kubesphere.com.cn
+        uses: docker/login-action@v3
+        with:
+          registry: hub.kubesphere.com.cn
+          username: ${{ secrets.HUB_KUBESPHERE_USERNAME }}
+          password: ${{ secrets.HUB_KUBESPHERE_PASSWORD }}
       - name: Build env
         id: build_env
         run: |
@@ -149,6 +163,7 @@ jobs:
         with:
           images: |
             kubesphere/devops-tools
+            hub.kubesphere.com.cn/kubesphere/devops-tools
           tags: ${{ steps.prepare.outputs.version }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -159,6 +174,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_SECRETS }}
+      - name: Login to hub.kubesphere.com.cn
+        uses: docker/login-action@v3
+        with:
+          registry: hub.kubesphere.com.cn
+          username: ${{ secrets.HUB_KUBESPHERE_USERNAME }}
+          password: ${{ secrets.HUB_KUBESPHERE_PASSWORD }}
       - name: Build env
         id: build_env
         run: |


### PR DESCRIPTION
## Summary

Add `hub.kubesphere.com.cn` as an additional container registry to the build workflow. Each job now:

- Pushes images to both DockerHub and `hub.kubesphere.com.cn`
- Authenticates using `HUB_KUBESPHERE_USERNAME` and `HUB_KUBESPHERE_PASSWORD` secrets

### Changes

- **BuildController**: Added `hub.kubesphere.com.cn/kubesphere/devops-controller` image target and registry login
- **BuildAPIServer**: Added `hub.kubesphere.com.cn/kubesphere/devops-apiserver` image target and registry login
- **BuildTools**: Added `hub.kubesphere.com.cn/kubesphere/devops-tools` image target and registry login